### PR TITLE
Basic Rust formatting. Just the necessary line breaks and spaces.

### DIFF
--- a/languages/queries/rust.scm
+++ b/languages/queries/rust.scm
@@ -1,0 +1,126 @@
+; Sometimes we want to indicate that certain parts of our source text should
+; not be formated, but taken as is. We use the leaf capture name to inform the
+; tool of this.
+(string_literal) @leaf
+
+; Append line breaks
+[
+  (attribute_item)
+  (enum_item)
+  (function_item)
+  (line_comment)
+  (struct_item)
+  (use_declaration)
+] @append_hardline
+
+; Append spaces
+[
+  (visibility_modifier)
+] @append_space
+
+; Prepend spaces
+[
+  (scoped_use_list)
+] @prepend_space
+
+; dyn
+(dynamic_type
+  (scoped_type_identifier) @prepend_space
+)
+
+; enum
+(enum_item
+  (type_identifier) @prepend_space
+)
+
+(enum_item
+  (type_identifier) @append_space
+)
+
+; fn
+(function_item
+  (identifier) @prepend_space
+)
+
+(function_item
+  (identifier) @append_space
+)
+
+; for
+(for_expression
+  (identifier) @prepend_space
+)
+
+(for_expression
+  (identifier) @append_space
+)
+
+(for_expression
+  (call_expression) @prepend_space
+)
+
+(for_expression
+  (field_expression) @prepend_space
+)
+
+; if
+(if_expression
+  (binary_expression) @prepend_space
+)
+
+; if let
+(if_let_expression
+  "let" @prepend_space
+)
+
+(if_let_expression
+  (identifier) @prepend_space
+)
+
+; let
+(let_declaration
+  (identifier) @prepend_space
+)
+
+(let_declaration
+  (mutable_specifier) @prepend_space
+)
+
+; match
+(match_expression
+  (call_expression) @prepend_space
+)
+
+(match_expression
+  (field_expression) @prepend_space
+)
+
+(match_expression
+  (identifier) @prepend_space
+)
+
+; mut
+(
+  (mutable_specifier) @append_space
+  .
+  (dynamic_type)
+)
+
+; return
+(return_expression
+  (identifier) @prepend_space
+)
+
+; struct
+(struct_item
+  (type_identifier) @prepend_space
+)
+
+(struct_item
+  (type_identifier) @append_space
+)
+
+; use
+(use_declaration
+  (scoped_identifier) @prepend_space
+)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,7 @@ fn resolve_capture(name: String, atoms: &mut Vec<Atom>, node: Node) {
     match name.as_ref() {
         "append_hardline" => atoms_append(Atom::Hardline, node, atoms),
         "append_space" => atoms_append(Atom::Space, node, atoms),
+        "prepend_space" => atoms_prepend(Atom::Space, node, atoms),
         "append_indent_start" => atoms_append(Atom::IndentStart, node, atoms),
         "prepend_indent_end" => atoms_prepend(Atom::IndentEnd, node, atoms),
         "prepend_indent_start" => atoms_prepend(Atom::IndentStart, node, atoms),


### PR DESCRIPTION
Fixes #2.
