### PR TITLE
detect blank lines

### DIFF
--- a/languages/queries/rust.scm
+++ b/languages/queries/rust.scm
@@ -13,6 +13,18 @@
   (use_declaration)
 ] @append_hardline
 
+; Allow blank line before
+[
+  (attribute_item)
+  (enum_item)
+  (enum_variant)
+  (field_declaration)
+  (function_item)
+  (line_comment)
+  (struct_item)
+  (use_declaration)
+] @allow_blank_line_before
+
 ; Append spaces
 [
   (visibility_modifier)


### PR DESCRIPTION
Fixes #24.

- Detect blank lines.
- Output blank lines where specified by input code.
- Query lists node types that are allowed to have a blank line before.
