### PR TITLE
Ignore Nix-related file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+/result
+/.envrc
+/.direnv


### PR DESCRIPTION
Now that there is a Nix flake (cf #55), I think it makes sense to also ignore the two following file names:

- `/result` for Nix's result directory
- `/.envrc` and `/.direnv` for `direnv` integration -- another possibility would be to commit a `.envrc` containing `use flake`, but maybe some other people just want another kind of `direnv` integration?