### PR TITLE
Types of curried functions in OCaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,66 @@ single-line nodes.
 )
 ```
 
+### @append_spaced_soft_ancestor_line / @prepend_spaced_soft_ancestor_line
+
+The matched nodes will have a spaced softline appended or prepended to them.
+This will be expanded to a newline if the earliest ancestor of the same type is a multi-line
+node and to a space if it is a single-line node.
+
+#### Use case
+
+For instance, if one has a tree of the form
+```
+(op
+  (num 1)
+  (symbol +)
+  (op
+    (num 2)
+    (symbol +)
+    (num 3)
+  )
+)
+```
+one could like to see it as an addition with 3 terms
+rather than an addition nested under another one.
+
+#### Example
+
+When functions are curried, their types are of the shape `a -> b -> c -> d`
+implicitely parenthesized as `a -> (b -> (c -> d))`,
+which can lead to a tree of the shape
+```
+(fun_type
+  a
+  "->"
+  (fun_type
+    b
+    "->"
+    (fun_type
+      c
+      "->"
+      d
+    )
+  )
+)
+```
+
+We generally prefer to have line break after all or none of the arrows,
+this is achieved with:
+
+```scheme
+; Append spaced softlines, unless there is a comment following.
+(
+  [
+    "->"
+  ] @append_spaced_soft_ancestor_line
+  .
+  (comment)* @do_nothing
+)
+```
+
+
+
 ### @do_nothing
 
 If any of the captures in a query match are `@do_nothing`, then the match will

--- a/README.md
+++ b/README.md
@@ -355,9 +355,9 @@ rather than an addition nested under another one.
 
 #### Example
 
-When functions are curried, their types are of the shape `a -> b -> c -> d`
-implicitely parenthesized as `a -> (b -> (c -> d))`,
-which can lead to a tree of the shape
+Consider an Ocaml type of shape `a -> b -> c -> d`
+implicitely parenthesized as `a -> (b -> (c -> d))`.
+It is parsed to a tree of the shape
 ```
 (fun_type
   a
@@ -374,7 +374,7 @@ which can lead to a tree of the shape
 )
 ```
 
-We generally prefer to have line break after all or none of the arrows,
+The Ocaml formatter inserts line break after either all or none of the arrows,
 this is achieved with:
 
 ```scheme

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -317,9 +317,17 @@
 )
 
 (
-  "->" @append_spaced_soft_ancestor_line
+  "->" @append_spaced_softline
   .
   [ (comment) ]* @do_nothing
+)
+
+(function_type
+  "->"
+  .
+  (function_type
+    "->" @append_spaced_soft_ancestor_line
+  )
 )
 
 ; Always put softlines before these:

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -306,7 +306,6 @@
     "of"
     "struct"
     "then"
-    "->"
     "{"
     ":"
     ";"
@@ -315,6 +314,12 @@
   [
     (comment)
   ]* @do_nothing
+)
+
+(
+  "->" @append_spaced_soft_ancestor_line
+  .
+  [ (comment) ]* @do_nothing
 )
 
 ; Always put softlines before these:

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -330,10 +330,19 @@
 ;
 
 ; This query guarantees that a break occurs after the first arrow of a multiline type.
-(
-  "->" @append_spaced_softline
-  .
-  [ (comment) ]* @do_nothing
+(function_type
+  (
+    "->" @append_spaced_softline
+    .
+    (comment)* @do_nothing
+  )
+)
+(function_type
+  (
+    "->"
+    .
+    (comment)+ @append_spaced_softline
+  )
 )
 
 ; But the first query alone is not sufficient, because Ocaml arrows are binary operators,
@@ -367,11 +376,38 @@
 (function_type
   "->"
   .
+  (comment)*
+  .
   (function_type
     "->" @append_spaced_soft_ancestor_line
     .
-    [ (comment) ]* @do_nothing
+    (comment)* @do_nothing
   )
+)
+
+(function_type
+  "->"
+  (comment)*
+  .
+  (function_type
+    "->"
+    .
+    (comment)+ @append_spaced_soft_ancestor_line
+  )
+)
+
+; In matches, if a line break is required, we want it to happen after the last comment following the arrow.
+
+(match_case
+  "->"  @append_spaced_softline
+  .
+  (comment)* @do_nothing
+)
+
+(match_case
+  "->"
+  .
+  (comment)+ @append_spaced_softline
 )
 
 ; Always put softlines before these:

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -369,6 +369,8 @@
   .
   (function_type
     "->" @append_spaced_soft_ancestor_line
+    .
+    [ (comment) ]* @do_nothing
   )
 )
 

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -316,12 +316,54 @@
   ]* @do_nothing
 )
 
+; If a type is written on several lines, then the types of all the arguments should be separated.
+;
+; let f : typeA -> typeB ->
+;   typeC -> typeD =
+;
+; is formatted as
+;
+; let f : typeA ->
+;   typeB ->
+;   typeC ->
+;   typeD
+;
+
+; This query guarantees that a break occurs after the first arrow of a multiline type.
 (
   "->" @append_spaced_softline
   .
   [ (comment) ]* @do_nothing
 )
 
+; But the first query alone is not sufficient, because Ocaml arrows are binary operators,
+; so  typeA -> typeB -> typeC -> typeD is parsed as the tree
+;
+; fun_type
+;   typeA
+;   "->"
+;   (fun_type
+;     typeB
+;     "->"
+;     (fun_type
+;       typeC
+;       "->"
+;       typeD
+;     )
+;   )
+; )
+;
+; Hence, we want to flatten the tree of arrows
+; (Well, since we do not modify the parsed tree,
+; we will rather put special glasses to look at the tree as if it was flattened).
+; But the arrow is not an assoicated operation, so for instance we do not want
+;
+; typeA ->
+; (typeB -> typeC) ->
+; typeD
+;
+; to be displayed with a line break between typeB and typeC just because the whole type is on several lines.
+; So we only merge the arrows on the right-hand side of another one with the top node.
 (function_type
   "->"
   .

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -30,7 +30,7 @@ pub struct AtomCollection {
 // )
 // One could like to see it as an addition with 3 terms
 // rather than an addition nested under another one.
-fn earliest_ancestor_of_same_type(node : Node) -> Node {
+fn earliest_ancestor_of_same_type(node: Node) -> Node {
     if let Some(parent) = node.parent() {
         if parent.kind() == node.kind() {
             earliest_ancestor_of_same_type(parent)
@@ -99,8 +99,11 @@ impl AtomCollection {
                 node,
             ),
             "append_empty_softline" => self.append(
-                Atom::Softline { spaced: false, considering_ancestor: false },
-                node
+                Atom::Softline {
+                    spaced: false,
+                    considering_ancestor: false,
+                },
+                node,
             ),
             "append_hardline" => self.append(Atom::Hardline, node),
             "append_indent_start" => self.append(Atom::IndentStart, node),
@@ -116,16 +119,25 @@ impl AtomCollection {
             }
             "append_space" => self.append(Atom::Space, node),
             "append_spaced_softline" => self.append(
-                Atom::Softline { spaced: true, considering_ancestor: false },
-                node
+                Atom::Softline {
+                    spaced: true,
+                    considering_ancestor: false,
+                },
+                node,
             ),
             "append_empty_soft_ancestor_line" => self.append(
-                Atom::Softline { spaced: false, considering_ancestor: true },
-                node
+                Atom::Softline {
+                    spaced: false,
+                    considering_ancestor: true,
+                },
+                node,
             ),
             "append_spaced_soft_ancestor_line" => self.append(
-                Atom::Softline { spaced: true, considering_ancestor: true },
-                node
+                Atom::Softline {
+                    spaced: true,
+                    considering_ancestor: true,
+                },
+                node,
             ),
             "prepend_delimiter" => self.prepend(
                 Atom::Literal(
@@ -141,8 +153,11 @@ impl AtomCollection {
                 node,
             ),
             "prepend_empty_softline" => self.prepend(
-                Atom::Softline { spaced: false, considering_ancestor: false },
-                node
+                Atom::Softline {
+                    spaced: false,
+                    considering_ancestor: false,
+                },
+                node,
             ),
             "prepend_indent_start" => self.prepend(Atom::IndentStart, node),
             "prepend_indent_end" => self.prepend(Atom::IndentEnd, node),
@@ -157,16 +172,25 @@ impl AtomCollection {
             }
             "prepend_space" => self.prepend(Atom::Space, node),
             "prepend_spaced_softline" => self.prepend(
-                Atom::Softline { spaced: true, considering_ancestor: false },
-                node
+                Atom::Softline {
+                    spaced: true,
+                    considering_ancestor: false,
+                },
+                node,
             ),
             "prepend_empty_soft_ancestor_line" => self.prepend(
-                Atom::Softline { spaced: false, considering_ancestor: true },
-                node
+                Atom::Softline {
+                    spaced: false,
+                    considering_ancestor: true,
+                },
+                node,
             ),
             "prepend_spaced_soft_ancestor_line" => self.prepend(
-                Atom::Softline { spaced: true, considering_ancestor: true },
-                node
+                Atom::Softline {
+                    spaced: true,
+                    considering_ancestor: true,
+                },
+                node,
             ),
             // Skip over leafs
             "leaf" => {}
@@ -295,12 +319,17 @@ impl AtomCollection {
     }
 
     fn expand_softline(&self, atom: Atom, node: Node) -> Option<Atom> {
-        if let Atom::Softline { spaced , considering_ancestor } = atom {
+        if let Atom::Softline {
+            spaced,
+            considering_ancestor,
+        } = atom
+        {
             if let Some(parent) = node.parent() {
-                let ancestor =
-                    if considering_ancestor {
-                        earliest_ancestor_of_same_type(parent)
-                    } else {parent};
+                let ancestor = if considering_ancestor {
+                    earliest_ancestor_of_same_type(parent)
+                } else {
+                    parent
+                };
                 let ancestor_id = ancestor.id();
 
                 if self.multi_line_nodes.contains(&ancestor_id) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,10 @@ pub enum Atom {
     Literal(String),
     /// Represents a softline. It will be turned into a hardline for multi-line
     /// constructs, and either a space or nothing for single-line constructs.
-    Softline { spaced: bool, considering_ancestor: bool },
+    Softline {
+        spaced: bool,
+        considering_ancestor: bool,
+    },
     /// Represents a space. Consecutive spaces are reduced to one before rendering.
     Space,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub enum Atom {
     Literal(String),
     /// Represents a softline. It will be turned into a hardline for multi-line
     /// constructs, and either a space or nothing for single-line constructs.
-    Softline { spaced: bool },
+    Softline { spaced: bool, considering_ancestor: bool },
     /// Represents a space. Consecutive spaces are reduced to one before rendering.
     Space,
 }

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -429,7 +429,7 @@ module Foo = (val create "Issue #106")
 
 let long_type :
   ?used_slot: bool ref ->
-  override_flag ->
+  override_flag -> (* With a comment *)
   Env.t ->
   Location.t ->
   Longident.t loc ->
@@ -440,7 +440,7 @@ let long_type :
     fun x -> x
 
 let long_higher_order_type :
-  ?used_slot: bool ref ->
+  ?used_slot: bool ref -> (* With a comment *)
   override_flag ->
   Env.t ->
   (Location.t -> Longident.t loc -> a) ->
@@ -454,7 +454,7 @@ let long_third_order_type :
   ?used_slot: bool ref ->
   override_flag ->
   Env.t ->
-  (a -> (Location.t -> Longident.t loc) -> a) ->
+  (a -> (Location.t -> Longident.t loc) -> a) -> (* With a comment *)
   Path.t * Env.t =
     (* The identity function does not have the declared type at all,
       it is just for formatting verification purpose.

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -424,3 +424,17 @@ let foo =
 module type FOO = sig val foo : string end
 let create foo : (module FOO) = (module struct let foo = foo end)
 module Foo = (val create "Issue #106")
+
+(* A long type annotation. *)
+
+let long_type :
+  ?used_slot: bool ref ->
+  override_flag ->
+  Env.t ->
+  Location.t ->
+  Longident.t loc ->
+  Path.t * Env.t =
+    (* The identity function does not have the declared type at all,
+     it is just for formatting verification purpose.
+  *)
+    fun x -> x

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -438,3 +438,25 @@ let long_type :
      it is just for formatting verification purpose.
   *)
     fun x -> x
+
+let long_higher_order_type :
+  ?used_slot: bool ref ->
+  override_flag ->
+  Env.t ->
+  (Location.t -> Longident.t loc -> a) ->
+  Path.t * Env.t =
+    (* The identity function does not have the declared type at all,
+      it is just for formatting verification purpose.
+  *)
+    fun x -> x
+
+let long_third_order_type :
+  ?used_slot: bool ref ->
+  override_flag ->
+  Env.t ->
+  (a -> (Location.t -> Longident.t loc) -> a) ->
+  Path.t * Env.t =
+    (* The identity function does not have the declared type at all,
+      it is just for formatting verification purpose.
+  *)
+    fun x -> x

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -420,3 +420,12 @@ else
 module type FOO = sig val foo : string end
 let create foo : (module FOO) = (module struct let foo = foo end)
 module Foo = (val create "Issue #106")
+
+(* A long type annotation. *)
+
+let long_type : ?used_slot: bool ref -> override_flag ->
+  Env.t -> Location.t -> Longident.t loc -> Path.t * Env.t =
+  (* The identity function does not have the declared type at all,
+     it is just for formatting verification purpose.
+  *)
+  fun x -> x

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -423,14 +423,14 @@ module Foo = (val create "Issue #106")
 
 (* A long type annotation. *)
 
-let long_type : ?used_slot: bool ref -> override_flag ->
+let long_type : ?used_slot: bool ref -> override_flag -> (* With a comment *)
   Env.t -> Location.t -> Longident.t loc -> Path.t * Env.t =
   (* The identity function does not have the declared type at all,
      it is just for formatting verification purpose.
   *)
   fun x -> x
 
-let long_higher_order_type : ?used_slot: bool ref -> override_flag ->
+let long_higher_order_type : ?used_slot: bool ref ->  (* With a comment *) override_flag ->
   Env.t -> (Location.t -> Longident.t loc ->a) -> Path.t * Env.t =
   (* The identity function does not have the declared type at all,
       it is just for formatting verification purpose.
@@ -438,7 +438,7 @@ let long_higher_order_type : ?used_slot: bool ref -> override_flag ->
   fun x -> x
 
 let long_third_order_type : ?used_slot: bool ref -> override_flag ->
-  Env.t -> (a-> (Location.t -> Longident.t loc) ->a) -> Path.t * Env.t =
+  Env.t -> (a-> (Location.t -> Longident.t loc) ->a) ->  (* With a comment *) Path.t * Env.t =
   (* The identity function does not have the declared type at all,
       it is just for formatting verification purpose.
   *)

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -429,3 +429,17 @@ let long_type : ?used_slot: bool ref -> override_flag ->
      it is just for formatting verification purpose.
   *)
   fun x -> x
+
+let long_higher_order_type : ?used_slot: bool ref -> override_flag ->
+  Env.t -> (Location.t -> Longident.t loc ->a) -> Path.t * Env.t =
+  (* The identity function does not have the declared type at all,
+      it is just for formatting verification purpose.
+  *)
+  fun x -> x
+
+let long_third_order_type : ?used_slot: bool ref -> override_flag ->
+  Env.t -> (a-> (Location.t -> Longident.t loc) ->a) -> Path.t * Env.t =
+  (* The identity function does not have the declared type at all,
+      it is just for formatting verification purpose.
+  *)
+  fun x -> x


### PR DESCRIPTION
This creates commands `append_spaced_soft_ancestor_line` and analogous, which behaves as if several nodes of the same type nested one under the other were only one node.