### PR TITLE
Bump action versions to resolve deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3.1.0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v16
+        uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
       - name: Set up Nix cache
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v12
         with:
           name: tweag-tree-sitter-formatter
           authToken: "${{ secrets.CACHIX_TWEAG_TREE_SITTER_FORMATTER_AUTH_TOKEN }}"


### PR DESCRIPTION
* Node.js 12 support deprecated\
  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

* `save-state` command deprecated\
  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The macOS 12 warning is still a thing, but it's a preparatory warning, rather than a deprecation.