### PR TITLE
Deal with unknown capture names when resolving query

### DIFF
--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -116,9 +116,13 @@ impl AtomCollection {
             "prepend_spaced_softline" => self.prepend(Atom::Softline { spaced: true }, node),
             // Skip over leafs
             "leaf" => {}
-            // Panic if we encounter any unknown capture name
+
+            // Return a query parsing error on unknown capture names
             unknown => {
-                panic!("Unknown capture name encountered in query: @{unknown}")
+                return Err(FormatterError::Query(
+                    format!("@{unknown} is not a valid capture name").into(),
+                    None,
+                ))
             }
         }
 

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -120,7 +120,7 @@ impl AtomCollection {
             // Return a query parsing error on unknown capture names
             unknown => {
                 return Err(FormatterError::Query(
-                    format!("@{unknown} is not a valid capture name").into(),
+                    format!("@{unknown} is not a valid capture name"),
                     None,
                 ))
             }

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -115,7 +115,11 @@ impl AtomCollection {
             "prepend_space" => self.prepend(Atom::Space, node),
             "prepend_spaced_softline" => self.prepend(Atom::Softline { spaced: true }, node),
             // Skip over leafs
-            _ => {}
+            "leaf" => {}
+            // Panic if we encounter any unknown capture name
+            unknown => {
+                panic!("Unknown capture name encountered in query: @{unknown}")
+            }
         }
 
         Ok(())


### PR DESCRIPTION
This is a first step wrt solving #90. Panicking is a little extreme, but it's better than nothing; the ultimate goal (in PRs to come) is to make encountering unknown capture groups a parse error and bail-out gracefully.