### PR TITLE
Support first-class module

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -14,9 +14,10 @@
 ; Allow blank line before
 [
   (comment)
-  (external)
   (exception_definition)
+  (external)
   (module_definition)
+  (module_type_definition)
   (open_module)
   (type_definition)
   (value_definition)
@@ -75,6 +76,7 @@
   "else"
   "exception"
   "external"
+  "if"
   (infix_operator)
   "let"
   "match"
@@ -100,58 +102,132 @@
   "<-"
   "{"
   "}"
-] @append_space
-
-(
-  "("* @do_nothing
-  .
-  [
-    "as"
-    "assert"
-    "begin"
-    "do"
-    "else"
-    "exception"
-    "external"
-    (infix_operator)
-    "let"
-    "match"
-    "module"
-    "mutable"
-    "of"
-    "open"
-    (parameter)
-    "rec"
-    "sig"
-    "then"
-    "try"
-    "type"
-    "val"
-    "when"
-    "while"
-    "with"
-    "*"
-    "="
-    "|"
-    "||"
-    "->"
-    "<-"
-    "{"
-    "}"
-  ] @prepend_space
-)
-
-; Prepend spaces
-[
-  "done"
-] @prepend_space
-
-; Append spaces
-[
-  "if"
   ":"
   ";"
 ] @append_space
+
+; Those keywords are not expected to come right after an open parenthesis.
+[
+    "as"
+    "do"
+    "done"
+    "else"
+    "of"
+    "rec"
+    "then"
+    "when"
+    "while"
+    "with"
+    "|"
+    "->"
+    "<-"
+] @prepend_space
+
+; For those queries, we should not have multiple queries,
+; however, due to a known bug in tree-sitter queries
+; https://github.com/tree-sitter/tree-sitter/issues/1811
+; using an alternative after the starred parenthesis does not work as intented.
+;
+(
+  "("* @do_nothing
+  .
+  "assert" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "begin" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "exception" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "external" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  (infix_operator) @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "let" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "match" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "module" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "mutable" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "open" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  (parameter) @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "sig" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "try" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "type" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "val" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "*" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "=" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "||" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "{" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "}" @prepend_space
+)
 
 ; Put a space after commas, except the last one.
 (

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -41,6 +41,8 @@
   [
     (exception_definition)
     (external)
+    (module_definition)
+    (module_type_definition)
     (open_module)
     (type_definition)
   ] @append_hardline
@@ -52,10 +54,19 @@
 (
   (value_definition) @append_hardline
   .
-  (value_definition)
+  [
+    (exception_definition)
+    (external)
+    (module_definition)
+    (module_type_definition)
+    (open_module)
+    (type_definition)
+    (value_definition)
+  ]
 )
 
 ; Surround spaces
+; A space is put after, and before (except just after an open parenthesis).
 [
   "as"
   "assert"
@@ -73,9 +84,11 @@
   "open"
   (parameter)
   "rec"
+  "sig"
   "then"
   "try"
   "type"
+  "val"
   "when"
   "while"
   "with"
@@ -87,7 +100,46 @@
   "<-"
   "{"
   "}"
-] @prepend_space @append_space
+] @append_space
+
+(
+  "("* @do_nothing
+  .
+  [
+    "as"
+    "assert"
+    "begin"
+    "do"
+    "else"
+    "exception"
+    "external"
+    (infix_operator)
+    "let"
+    "match"
+    "module"
+    "mutable"
+    "of"
+    "open"
+    (parameter)
+    "rec"
+    "sig"
+    "then"
+    "try"
+    "type"
+    "val"
+    "when"
+    "while"
+    "with"
+    "*"
+    "="
+    "|"
+    "||"
+    "->"
+    "<-"
+    "{"
+    "}"
+  ] @prepend_space
+)
 
 ; Prepend spaces
 [
@@ -264,6 +316,7 @@
 [
   "begin"
   "else"
+  "sig"
   "struct"
   "then"
   "{"

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -418,3 +418,9 @@ let foo =
   else
     let y = w1 in
     w2
+
+(* Test of a first-class module. *)
+
+module type FOO = sig val foo : string end
+let create foo : (module FOO) = (module struct let foo = foo end)
+module Foo = (val create "Issue #106")

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -46,7 +46,7 @@ let sub b ofs len =
 let blit src srcoff dst dstoff len =
   if len < 0 || srcoff < 0 || srcoff > src.position - len
              || dstoff < 0 || dstoff > (Bytes.length dst) - len
-  then 
+  then
     invalid_arg "Buffer.blit"
   else
     Bytes.unsafe_blit src.buffer srcoff dst dstoff len
@@ -414,3 +414,9 @@ if u then
 else
   let y = w1 in
   w2
+
+(* Test of a first-class module. *)
+
+module type FOO = sig val foo : string end
+let create foo : (module FOO) = (module struct let foo = foo end)
+module Foo = (val create "Issue #106")


### PR DESCRIPTION
This implements the parts missing to support the first-class module example given by Niols in #106.
It includes: 
 - dealing with the line breaks between declaration of different natures, 
 - opening the indentation for module signature which is closed by the `end` keyword 
 - removing the spaces between parentheses and keywords. This last bit is not working as expected, due to a bug in tree-sitter queries: https://github.com/tree-sitter/tree-sitter/issues/1811 . There are 3 options to deal with it: 
     1. Chose that we always want spaces around parentheses (quite unusual in the OCaml world, but the default in many languages), 
     2. Write the queries in a not elegant, but bug-avoiding way,
     3. Spend time working on the tree-sitter repository to fix the issue upstream.

The [golden rule of software quality](https://www.haskellforall.com/2020/07/the-golden-rule-of-software-quality.html) would push toward option 3, but it is the less sure and longest path.