### PR TITLE
Detect language from input file extension

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -1,4 +1,26 @@
-use std::path::PathBuf;
+// Portions of this code, highlighted below, are influenced by Difftastic (MIT licensed):
+//
+// Copyright (c) 2021-2022 Wilfred Hughes
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use std::path::{Path, PathBuf};
 
 use crate::{FormatterError, FormatterResult};
 
@@ -10,6 +32,32 @@ pub enum Language {
     Rust,
     Toml,
 }
+
+// NOTE Influenced by Difftastic; see above
+const EXTENSIONS: &[(&str, &[&str])] = &[
+    (
+        "json",
+        &[
+            "json",
+            "avsc",
+            "geojson",
+            "gltf",
+            "har",
+            "ice",
+            "JSON-tmLanguage",
+            "jsonl",
+            "mcmeta",
+            "tfstate",
+            "tfstate.backup",
+            "topojson",
+            "webapp",
+            "webmanifest",
+        ],
+    ),
+    ("ocaml", &["ml"]),
+    ("rust", &["rs"]),
+    ("toml", &["toml"]),
+];
 
 impl Language {
     pub fn new(s: &str) -> FormatterResult<Self> {
@@ -26,10 +74,34 @@ impl Language {
     }
 
     pub fn detect(filename: &str) -> FormatterResult<&str> {
-        todo!()
+        // NOTE Influenced by Difftastic; see above
+        if let Some(extension) = Path::new(filename).extension() {
+            let extension = extension.to_str().unwrap();
+
+            for (language, extensions) in EXTENSIONS {
+                for candidate in extensions.iter() {
+                    if *candidate == extension {
+                        return Ok(*language);
+                    }
+                }
+            }
+
+            return Err(FormatterError::Query(
+                format!("Cannot detect language from unknown extension: '{filename}'"),
+                None,
+            ));
+        }
+
+        Err(FormatterError::Query(
+            format!("Cannot detect language without extension: '{filename}'"),
+            None,
+        ))
     }
 
     pub fn query_path(language: &str) -> FormatterResult<PathBuf> {
+        // Check for support
+        Language::new(language)?;
+
         Ok(
             PathBuf::from(option_env!("TOPIARY_LANGUAGE_DIR").unwrap_or("languages"))
                 .join(format!("{language}.scm")),

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::{FormatterError, FormatterResult};
 
 /// The languages that we support with query files.
@@ -21,5 +23,16 @@ impl Language {
                 None,
             )),
         }
+    }
+
+    pub fn detect(filename: &str) -> FormatterResult<&str> {
+        todo!()
+    }
+
+    pub fn query_path(language: &str) -> FormatterResult<PathBuf> {
+        Ok(
+            PathBuf::from(option_env!("TOPIARY_LANGUAGE_DIR").unwrap_or("languages"))
+                .join(format!("{language}.scm")),
+        )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ enum SupportedLanguage {
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 // Require either --language or --query, but not both.
-#[clap(group(ArgGroup::new("rule").required(true).args(&["language", "query"]),))]
+#[clap(group(ArgGroup::new("rule").required(true).args(&["language", "query", "input-file"]),))]
 struct Args {
     /// Which language to parse and format
     #[clap(short, long, arg_enum)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ impl From<SupportedLanguage> for &str {
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
-// Require either --language or --query, but not both.
-#[clap(group(ArgGroup::new("rule").required(true).args(&["language", "query", "input-file"]),))]
+// Require at least one of --language, --query or --input-file (n.b., query > language > input)
+#[clap(group(ArgGroup::new("rule").multiple(true).required(true).args(&["language", "query", "input-file"]),))]
 struct Args {
     /// Which language to parse and format
     #[clap(short, long, arg_enum)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ enum SupportedLanguage {
 }
 
 impl From<SupportedLanguage> for &str {
-    fn from(s: SupportedLanguage) -> Self {
-        match s {
+    fn from(language: SupportedLanguage) -> Self {
+        match language {
             SupportedLanguage::Json => "json",
             SupportedLanguage::Toml => "toml",
         }


### PR DESCRIPTION
Detect the language by examining the filename extension, if there is one.

:bulb: I have changed the semantics of the command line arguments. Before you were required to supply exactly one of `--language` or `--query`; now you must provide at least one of `--language`, `--query` and `--input-file`. It is not communicated to the user that there is a precedence when it comes to determining the language (i.e., query > language > input file).

:warning: Some of the detection code is influenced by Difftastic. It's not exactly copied verbatim, but it's close enough to make me nervous. To that end, I have included Difftastic's license (MIT) in the relevant source file and highlighted the code that falls under its purview as a first approximation of compliance.

Resolves #3 