### PR TITLE
Handle mutually recursive functions

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -23,6 +23,12 @@
   (value_definition)
 ] @allow_blank_line_before
 
+; In a definition including several mutually recursive functions,
+; one can skip a line before each of them.
+(value_definition
+  "and" @allow_blank_line_before
+)
+
 ; Input softlines before and after all comments. This means that the input
 ; decides if a comment should have line breaks before or after. But don't put a
 ; softline directly in front of commas or semicolons.
@@ -69,6 +75,7 @@
 ; Surround spaces
 ; A space is put after, and before (except just after an open parenthesis).
 [
+  "and"
   "as"
   "assert"
   "begin"
@@ -365,6 +372,9 @@
   )
   .
   "in"
+)
+(value_definition
+  "and" @prepend_spaced_softline
 )
 
 ; The following are many constructs that need a softline.

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -448,3 +448,10 @@ let topological_sort deps =
       in node::List.fold_left (explore (node::path))
         visited (List.map Files_legacy.get_file edges)
   in List.rev @@ List.fold_left (fun visited (n, _) -> explore [] visited n) [] graph
+
+(* The even and odd functions assume that their argument is non-negative. *)
+let rec odd = function
+  | 0 -> false
+  | y -> even (y - 1)
+
+and even y = if y = 0 then true else odd (y - 1)

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -445,3 +445,10 @@ let topological_sort deps =
         (List.map Files_legacy.get_file edges)
   in
   List.rev @@ List.fold_left (fun visited (n, _) -> explore [] visited n) [] graph
+
+(* The even and odd functions assume that their argument is non-negative. *)
+let rec odd = function
+| 0 -> false
+| y -> even (y - 1)
+
+  and even y = if y = 0 then true else odd (y - 1)


### PR DESCRIPTION
Adds the "and" keyword where it was missing and allows blank lines between several mutually recursive definitions.