### PR TITLE
Handle module inclusion

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -48,6 +48,7 @@
   [
     (exception_definition)
     (external)
+    (include_module)
     (module_definition)
     (module_type_definition)
     (open_module)
@@ -85,6 +86,7 @@
   "external"
   "if"
   "in"
+  "include"
   (infix_operator)
   "let"
   "match"
@@ -156,6 +158,11 @@
   "("* @do_nothing
   .
   "external" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "include" @prepend_space
 )
 (
   "("* @do_nothing

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -455,3 +455,8 @@ let rec odd = function
   | y -> even (y - 1)
 
 and even y = if y = 0 then true else odd (y - 1)
+
+module ListSetExtended = struct
+  include ListSet
+  let of_list lst = List.fold_right add lst empty
+end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -452,3 +452,9 @@ let rec odd = function
 | y -> even (y - 1)
 
   and even y = if y = 0 then true else odd (y - 1)
+
+
+module ListSetExtended = struct
+  include ListSet
+  let of_list lst = List.fold_right add lst empty
+end


### PR DESCRIPTION
Adds the "include" keyword where it was missing and add line breaks after module inclusions.