### PR TITLE
Add line break after equal for multiline definition

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -395,7 +395,7 @@
   (match_case) @prepend_spaced_softline
 )
 
-; Multi-line definitions must have a linebreak before "in":
+; Multi-line definitions must have a linebreak after "=" and before "in":
 ;
 ; let a =
 ;   expression
@@ -410,6 +410,25 @@
   .
   "in"
 )
+; There are special cases however. We do not want to break lines after "=" when writing
+;
+; let f = function
+;   | Constructor -> expression
+;
+; or
+;
+; let f = fun x ->
+;   expression
+;
+(let_binding
+  "=" @append_spaced_softline
+  .
+  [
+    (function_expression)
+    (fun_expression)
+  ]* @do_nothing
+)
+
 (value_definition
   "and" @prepend_spaced_softline
 )

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -437,7 +437,8 @@ let topological_sort deps =
       raise @@ Dep_error (CircularDependencies (node, path));
     if List.mem node visited then visited
     else
-      let edges = try
+      let edges =
+        try
           List.assoc node graph
         with
           Not_found ->
@@ -483,3 +484,16 @@ type _ variant +=
 
 (* Two times. *)
 type _ variant += WithBuff : t variant
+
+let add_multiline x =
+  let res =
+    x + x
+  in
+  res
+
+let add_one_line x = let res = x + x in res
+
+let add_as_fun_multiline = fun x ->
+  x
+
+let add_as_fun_one_line = fun x -> x

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -483,3 +483,15 @@ type _ variant +=
 
 (* Two times. *)
 type _ variant += WithBuff : t variant
+
+let add_multiline x =
+  let res =
+    x + x in
+  res
+
+let add_one_line x = let res = x + x in res
+
+let add_as_fun_multiline = fun x ->
+  x
+
+let add_as_fun_one_line = fun x -> x


### PR DESCRIPTION
Add a line break after = in multiline definition, both to be faithful with the presented example and to have an idempotent formatter.