### PR TITLE
Ocaml support for bound operators

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -28,6 +28,9 @@
 (value_definition
   "and" @allow_blank_line_before
 )
+(value_definition
+  (and_operator) @allow_blank_line_before
+)
 
 ; Input softlines before and after all comments. This means that the input
 ; decides if a comment should have line breaks before or after. But don't put a
@@ -137,6 +140,20 @@
     "<-"
     "+="
 ] @prepend_space
+
+; let-like and and-like operators are only followed by a closing parenthesis
+; during their definition, in which case no space must be appended.
+; space must be appended otherwise
+(
+  (and_operator) @append_space
+  .
+  ")"* @do_nothing
+)
+(
+  (let_operator) @append_space
+  .
+  ")"* @do_nothing
+)
 
 ; For those queries, we should not have multiple queries,
 ; however, due to a known bug in tree-sitter queries
@@ -443,6 +460,10 @@
 
 (value_definition
   "and" @prepend_spaced_softline
+)
+
+(value_definition
+  (and_operator) @prepend_spaced_softline
 )
 
 ; The following are many constructs that need a softline.

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -509,3 +509,17 @@ let is_prime n =
     if n mod !i = 0 then no_divisor := false;
   done;
   !no_divisor
+
+(* Showcase the usage of operator bindings *)
+let greetings =
+  let (let*) = Option.bind
+  and (and*) a_opt b_opt =
+    match (a_opt, b_opt) with
+    | (Some a, Some b) -> Some (a, b)
+    | _ -> None
+  in
+  let* msg1 =
+    Option.map String.capitalize_ascii (Some "hello ")
+  and* msg2 = Some "world"
+  in
+  Some (msg1 ^ msg2)

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -509,3 +509,17 @@ let is_prime n =
     then no_divisor := false;
   done;
   !no_divisor
+
+(* Showcase the usage of operator bindings *)
+let greetings =
+  let (let*) = Option.bind
+  and (and*) a_opt b_opt =
+    match (a_opt, b_opt) with
+    | (Some a, Some b) -> Some (a, b)
+    | _ -> None
+  in
+  let* msg1 =
+    Option.map String.capitalize_ascii (Some "hello ")
+  and* msg2 = Some "world"
+  in
+  Some (msg1 ^ msg2)


### PR DESCRIPTION
Adds spacing and line breaks for `let`-like and `and`-like operators.
This allows the following to be correctly formatted:
```
let greetings =
  let (let*) = Option.bind
  and (and*) a_opt b_opt =
    match (a_opt, b_opt) with
    | (Some a, Some b) -> Some (a, b)
    | _ -> None
  in
  let* msg1 = Some "hello "
  and* msg2 = Some "world"
  in
  Some (msg1 ^ msg2)
```