### PR TITLE
Document generation of code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /result
 /.envrc
 /.direnv
+*.profraw

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,5 +51,6 @@ grcov --branch \
 :warning: `grcov` relies on the `llvm-tools-preview` component for
 `rustup`. For Nix users, `rustup` can interfere with the Rust toolchain
 that is provided by Nix, if you have both installed. For convenience,
-the `generate-coverage.sh` script can be run to avoid contaminating your
-environment.
+the `generate-coverage.sh` script can be run from the root of this
+repository to avoid contaminating your environment, but note it will
+download a full toolchain on each run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+Issues and pull requests are welcome! If you have Nix installed, you can start a
+development shell with Rust like this:
+
+```bash
+nix develop
+```
+
+## Performance
+
+You can check performance before or after changes by running `cargo bench`.
+
+If you do `cargo install flamegraph`, you can generate a performance flamegraph
+like this:
+
+```bash
+CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph -- -l ocaml < tests/samples/input/ocaml.ml > formatted.ml
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,3 +17,39 @@ like this:
 ```bash
 CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph -- -l ocaml < tests/samples/input/ocaml.ml > formatted.ml
 ```
+
+## Code Coverage
+
+Code coverage metrics can be generated via LLVM profiling data generated
+by the build. These can be created by setting appropriate environment
+variables to `cargo test`:
+
+```bash
+CARGO_INCREMENTAL=0 \
+RUSTFLAGS='-Cinstrument-coverage' \
+LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' \
+cargo test
+```
+
+This will build and run the test suite and output
+`cargo-test-*-*.profraw` files in the working directory. (Outside of the
+Nix development shell, you may need `binutils` installed.)
+
+These files can be used by [`grcov`](https://github.com/mozilla/grcov)
+to render a variety of output reports. For example, the following
+renders HTML output in `target/coverage/html`:
+
+```bash
+grcov --branch \
+      --output-type html \
+      --source-dir src \
+      --binary-path target/debug/deps \
+      --output-path target/coverage/html \
+      .
+```
+
+:warning: `grcov` relies on the `llvm-tools-preview` component for
+`rustup`. For Nix users, `rustup` can interfere with the Rust toolchain
+that is provided by Nix, if you have both installed. For convenience,
+the `generate-coverage.sh` script can be run to avoid contaminating your
+environment.

--- a/README.md
+++ b/README.md
@@ -396,23 +396,3 @@ In order to work productively on query files, the following is one suggested way
 ```
 
 12. Run `cargo test` again, see if the output is better now, and then go back to step 6.
-
-## Contributing
-
-Issues and pull requests are welcome! If you have Nix installed, you can start a
-development shell with Rust like this:
-
-```bash
-nix develop
-```
-
-### Performance
-
-You can check performance before or after changes by running `cargo bench`.
-
-If you do `cargo install flamegraph`, you can generate a performance flamegraph
-like this:
-
-```bash
-CARGO_PROFILE_RELEASE_DEBUG=true cargo flamegraph -- -l ocaml < tests/samples/input/ocaml.ml > formatted.ml
-```

--- a/generate-coverage.sh
+++ b/generate-coverage.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash --pure --packages cacert grcov rustup
+#shellcheck shell=bash
+
+set -eu
+
+# Create temporary working directory
+readonly WORKING_DIR="$(mktemp --directory)"
+trap 'rm -rf "${WORKING_DIR}"' EXIT
+
+# Setup subdirectories for rustup and the profile data
+export RUSTUP_HOME="${WORKING_DIR}/rustup"
+readonly PROFRAW_DIR="${WORKING_DIR}/profraw"
+mkdir --parents "${RUSTUP_HOME}" "${PROFRAW_DIR}"
+
+# Install Rust toolchain and necessary components
+rustup default stable
+rustup component add llvm-tools-preview
+
+# Build and output profiling data
+CARGO_INCREMENTAL=0 \
+RUSTFLAGS='-Cinstrument-coverage' \
+LLVM_PROFILE_FILE="${PROFRAW_DIR}/cargo-test-%p-%m.profraw" \
+cargo test
+
+# Render HTML coverage report
+readonly REPORT_DIR="target/coverage/html"
+mkdir --parents "${REPORT_DIR}"
+grcov --branch \
+      --output-type html \
+      --source-dir src \
+      --binary-path target/debug/deps \
+      --output-path "${REPORT_DIR}" \
+      "${PROFRAW_DIR}"


### PR DESCRIPTION
This PR documents how one can generate an HTML code coverage report using LLVM profiling data. It also provides a script, for Nix users, to do this automatically without (hopefully) polluting their environment.

This goes towards #80, but has not been added to the CI as it flaunts the usual Nix Flake-based distribution. (See that issue for discussion.)