### PR TITLE
Add a @delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,22 @@ single-line nodes.
 )
 ```
 
+### @delete
+
+Suppress the matched node.
+
+#### Example
+
+```scheme
+; Move semicolon after comments.
+(
+  ";" @delete
+  .
+  (comment)+ @append_delimiter
+  (#delimiter! ";")
+)
+```
+
 ### @do_nothing
 
 If any of the captures in a query match are `@do_nothing`, then the match will

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -66,18 +66,6 @@
   (and_operator) @allow_blank_line_before
 )
 
-; Input softlines before and after all comments. This means that the input
-; decides if a comment should have line breaks before or after. But don't put a
-; softline directly in front of commas or semicolons.
-
-(comment) @prepend_input_softline
-
-(
-  (comment) @append_input_softline
-  .
-  [ "," ";" ]* @do_nothing
-)
-
 ; Append line breaks. If there is a comment following, we don't add anything,
 ; because the input softlines and spaces above will already have sorted out the
 ; formatting.
@@ -767,6 +755,19 @@
 (
   (field_declaration) @append_delimiter
   .
+  [
+    ";"
+    (comment)
+  ] * @do_nothing
+  (#delimiter! ";")
+)
+(
+  (field_declaration)
+  .
+  ";"* @delete
+  .
+  (comment)+  @append_delimiter
+  .
   ";"* @do_nothing
   (#delimiter! ";")
 )
@@ -973,4 +974,16 @@
   (parenthesized_expression) @append_spaced_softline @append_indent_start
   (parenthesized_expression) @append_indent_end
   .
+)
+
+; Input softlines before and after all comments. This means that the input
+; decides if a comment should have line breaks before or after. But don't put a
+; softline directly in front of commas or semicolons.
+
+(comment) @prepend_input_softline
+
+(
+  (comment) @append_input_softline
+  .
+  [ "," ";" ]* @do_nothing
 )

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -774,7 +774,7 @@
   [
     ";"
     (comment)
-  ] * @do_nothing
+  ]* @do_nothing
   (#delimiter! ";")
 )
 (

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -752,6 +752,22 @@
 
 ; Put a semicolon delimiter after field declarations, unless they already have
 ; one, in which case we do nothing.
+; The semicolon always comes right after the declaration of the new field,
+; before any comment.
+; Hence, if there is a comment between the field declaration and the associated ";",
+; the semicolon is moved before the comment.
+;
+; type t =
+;   { mutable position : int (* End-of-line comment *);
+;   ...
+;
+; is turned into
+;
+; type t =
+;   {
+;     mutable position : int; (* End-of-line comment *)
+;     ...
+;
 (
   (field_declaration) @append_delimiter
   .
@@ -762,13 +778,13 @@
   (#delimiter! ";")
 )
 (
-  (field_declaration)
-  .
-  ";"* @delete
-  .
-  (comment)+  @append_delimiter
+  (field_declaration) @append_delimiter
   .
   ";"* @do_nothing
+  .
+  (comment)+ @append_input_softline
+  .
+  ";"* @delete
   (#delimiter! ";")
 )
 

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -324,14 +324,11 @@ fn post_process_internal(new_vec: &mut Vec<Atom>, prev: Atom, next: Atom) {
                 _ => new_vec.push(next),
             }
         }
-        // If the last one is a DeleteBegin
+        // If the last one is a DeleteBegin,
+        // we ignore all the atoms until a DeleteEnd is met.
         Atom::DeleteBegin => {
-            match next {
-                Atom::DeleteEnd => {
-                    new_vec.pop();
-                    ();
-                }
-                _ => ()
+            if next == Atom::DeleteEnd {
+                new_vec.pop();
             }
         }
         // Otherwise, we simply copy the atom to the new vector.

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -117,6 +117,11 @@ impl AtomCollection {
             "prepend_spaced_softline" => self.prepend(Atom::Softline { spaced: true }, node),
             // Skip over leafs
             "leaf" => {}
+            // Deletion
+            "delete" => {
+                self.prepend(Atom::DeleteBegin, node);
+                self.append(Atom::DeleteEnd, node)
+            }
 
             // Return a query parsing error on unknown capture names
             unknown => {
@@ -317,6 +322,16 @@ fn post_process_internal(new_vec: &mut Vec<Atom>, prev: Atom, next: Atom) {
                     new_vec.push(prev);
                 }
                 _ => new_vec.push(next),
+            }
+        }
+        // If the last one is a DeleteBegin
+        Atom::DeleteBegin => {
+            match next {
+                Atom::DeleteEnd => {
+                    new_vec.pop();
+                    ();
+                }
+                _ => ()
             }
         }
         // Otherwise, we simply copy the atom to the new vector.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,11 @@ pub enum Atom {
     Softline { spaced: bool },
     /// Represents a space. Consecutive spaces are reduced to one before rendering.
     Space,
+    /// Represents a segment to be deleted.
+    // It is a segment, because if one wants to delete a node,
+    // it might happen that it contains several leaves.
+    DeleteBegin,
+    DeleteEnd,
 }
 
 /// A convenience wrapper around `std::result::Result<T, FormatterError>`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,17 @@ pub enum Atom {
     IndentStart,
     /// Represents the contents of a named Tree-sitter node. We track the node id here
     /// as well.
-    Leaf { content: String, id: usize },
+    Leaf {
+        content: String,
+        id: usize,
+    },
     /// Represents a literal string, such as a semicolon.
     Literal(String),
     /// Represents a softline. It will be turned into a hardline for multi-line
     /// constructs, and either a space or nothing for single-line constructs.
-    Softline { spaced: bool },
+    Softline {
+        spaced: bool,
+    },
     /// Represents a space. Consecutive spaces are reduced to one before rendering.
     Space,
     /// Represents a segment to be deleted.

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -29,6 +29,8 @@ fn atoms_to_doc<'a>(i: &mut usize, atoms: &'a [Atom], indent_level: isize) -> Rc
                 }
                 Atom::Softline { .. } => unreachable!(),
                 Atom::Space => RcDoc::space(),
+                Atom::DeleteBegin => unreachable!(),
+                Atom::DeleteEnd => unreachable!(),
             });
         }
         *i += 1;

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -17,7 +17,7 @@
 
 type t = {
   mutable buffer: bytes;
-  mutable position: int; (* End-of-line comment *)
+  mutable position: int (* End-of-line comment *);
   mutable length: int;
   initial_buffer: bytes;
 }
@@ -698,3 +698,12 @@ let _ =
   [@@deprecated "assignment are deprecated, inline everything instead"]
 
 [@@@deprecated "writing code is deprecated, use ai-generated code instead"]
+
+type t = {
+  verbose: int
+  (** Verbosity level. *);
+  loggers: string
+  (** Loggers enabled. *);
+  bflags: bool StrMap.t
+  (** Boolean flags. *);
+}

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -17,7 +17,7 @@
 
 type t = {
   mutable buffer: bytes;
-  mutable position: int (* End-of-line comment *);
+  mutable position: int; (* End-of-line comment *)
   mutable length: int;
   initial_buffer: bytes;
 }
@@ -700,10 +700,10 @@ let _ =
 [@@@deprecated "writing code is deprecated, use ai-generated code instead"]
 
 type t = {
-  verbose: int
-  (** Verbosity level. *);
-  loggers: string
-  (** Loggers enabled. *);
-  bflags: bool StrMap.t
-  (** Boolean flags. *);
+  verbose: int;
+  (** Verbosity level. *)
+  loggers: string;
+  (** Loggers enabled. *)
+  bflags: bool StrMap.t;
+  (** Boolean flags. *)
 }

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -696,3 +696,12 @@ let _ = "some string"
   [@@deprecated "assignment are deprecated, inline everything instead"]
 
 [@@@deprecated "writing code is deprecated, use ai-generated code instead"]
+
+type t =
+  { verbose: int
+  (** Verbosity level. *)
+  ; loggers: string
+  (** Loggers enabled. *)
+  ; bflags: bool StrMap.t
+  (** Boolean flags. *)
+  }


### PR DESCRIPTION
This command simply deletes a node.
I do not think that deleting a non-trivial node will ever be useful, but this allows us to move things around.
The need for it occurred to me when dealing with Ocaml records. Currently, we are adding a semi-colon after the last field. This is precisely the kind of decision a developer does not want to take, so it seems reasonable to me that topiary adds it.
But what if there is a comment right after the field declaration. Should the semicolon come before or after it? That's also the kind of micro-decision the formatter should take care of.
To do so, we have to suppress the semicolon before comments and put it after.

PS: I realize that this pull request both implement the new comment and the use-case described. It is part of the same story in my mind, but you might want to review them separately. If so, please ask, I can open 2 PRs.