### PR TITLE
Allow line break after 'in' and "while"

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -668,7 +668,7 @@
     .
   )
   .
-  "in"
+  "in" @append_spaced_softline
 )
 ; There are special cases however. We do not want to break lines after "=" when writing
 ;
@@ -691,29 +691,6 @@
 
 (value_definition
   (and_operator) @prepend_spaced_softline
-)
-
-; The following are many constructs that need a softline.
-(
-  [
-    "in"
-    "with"
-    "="
-  ] @append_spaced_softline
-  .
-  [
-    (application_expression)
-    (class_body_type)
-    (if_expression)
-    (let_expression)
-    (object_expression)
-    (product_expression)
-    (record_expression)
-    (sequence_expression)
-    (set_expression)
-    (typed_expression)
-    (value_path)
-  ]
 )
 
 ; In module signature, each symbol declaration is separated by a softline.

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -695,6 +695,25 @@
   (and_operator) @prepend_spaced_softline
 )
 
+; There a large class of terms which should be separated from "=" by a soft lineb break.
+(
+  "=" @append_spaced_softline
+  .
+  [
+    (application_expression)
+    (class_body_type)
+    (if_expression)
+    (let_expression)
+    (object_expression)
+    (product_expression)
+    (record_expression)
+    (sequence_expression)
+    (set_expression)
+    (typed_expression)
+    (value_path)
+  ]
+)
+
 ; In module signature, each symbol declaration is separated by a softline.
 ;
 ; module type Name = sig

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -591,9 +591,11 @@
     "begin"
     "do"
     "else"
+    "in"
     "of"
     "struct"
     "then"
+    "with"
     "->"
     "{"
     ":"
@@ -668,7 +670,7 @@
     .
   )
   .
-  "in" @append_spaced_softline
+  "in"
 )
 ; There are special cases however. We do not want to break lines after "=" when writing
 ;

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -446,10 +446,11 @@ let topological_sort deps =
             else
               raise
               @@ Files_legacy.Files_error (ObjectFileNotFound (mk_mident node))
-          | _ -> assert false
-      in node::List.fold_left (explore (node::path))
+      in
+      node::List.fold_left (explore (node::path))
         visited (List.map Files_legacy.get_file edges)
-  in List.rev @@ List.fold_left (fun visited (n, _) -> explore [] visited n) [] graph
+  in
+  List.rev @@ List.fold_left (fun visited (n, _) -> explore [] visited n) [] graph
 
 (* The even and odd functions assume that their argument is non-negative. *)
 let rec odd = function
@@ -495,6 +496,14 @@ let add_multiline x =
   res
 
 let add_one_line x = let res = x + x in res
+
+let add_two_lines x =
+  let res = x + x in
+  res
+
+let add_three_lines x =
+  let res = x + x in
+  res
 
 let add_as_fun_multiline = fun x ->
   x

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -446,6 +446,7 @@ let topological_sort deps =
             else
               raise
               @@ Files_legacy.Files_error (ObjectFileNotFound (mk_mident node))
+          | _ -> assert false
       in
       node::List.fold_left (explore (node::path))
         visited (List.map Files_legacy.get_file edges)
@@ -511,10 +512,12 @@ let add_as_fun_multiline = fun x ->
 let add_as_fun_one_line = fun x -> x
 
 let sum_of_int n =
-  let res = ref 0 in for i = 1 to n do res := !res + i; done
+  let res = ref 0 in
+  for i = 1 to n do res := !res + i; done
 
 let sum_of_int_reversed n =
-  let res = ref 0 in for i = n downto 1 do res := !res + i; done
+  let res = ref 0 in
+  for i = n downto 1 do res := !res + i; done
 
 let verbose_id = function
   | -1 -> -1

--- a/tests/samples/expected/ocaml.mli
+++ b/tests/samples/expected/ocaml.mli
@@ -390,7 +390,8 @@ sig
   *)
 
   module Arith:
-  Fixed_point_repr.Safe with type 'a t = private Saturation_repr.may_saturate Saturation_repr.t
+  Fixed_point_repr.Safe with
+  type 'a t = private Saturation_repr.may_saturate Saturation_repr.t
 
   (** For maintenance operations or for testing, gas can be
      [Unaccounted]. Otherwise, the computation is [Limited] by the
@@ -2186,7 +2187,8 @@ sig
   module Merkle_hash: S.HASH
 
   module Merkle:
-  Merkle_list.T with type elt = Tx_rollup_message_result_hash.t
+  Merkle_list.T with
+  type elt = Tx_rollup_message_result_hash.t
   and type h = Merkle_hash.t
 
   type 'a template = {
@@ -3422,7 +3424,8 @@ sig
 
     module History:
     sig
-      include Bounded_history_repr.S with type key = Hash.t
+      include Bounded_history_repr.S with
+      type key = Hash.t
       and type value = merkelized_and_payload
 
       val no_history : t
@@ -3518,7 +3521,8 @@ sig
     module Hash: S.HASH
 
     module History:
-    Bounded_history_repr.S with type key = Hash.t
+    Bounded_history_repr.S with
+    type key = Hash.t
     and type value = history_proof
 
     type serialized_proof
@@ -3765,7 +3769,8 @@ sig
       end
     end
 
-    type ('state , 'proof , 'output )implementation = (module S with type state = 'state
+    type ('state , 'proof , 'output )implementation = (module S with
+    type state = 'state
     and type proof = 'proof
     and type output_proof = 'output)
 
@@ -3822,7 +3827,8 @@ sig
 
     module Make (C: P) :
     sig
-      include PVM.S with type context = C.Tree.t
+      include PVM.S with
+      type context = C.Tree.t
       and type state = C.tree
       and type proof = C.proof
 
@@ -3844,7 +3850,8 @@ sig
     val reference_initial_state_hash : State_hash.t
 
     module Protocol_implementation:
-    PVM.S with type context = Context.t
+    PVM.S with
+    type context = Context.t
     and type state = Context.tree
     and type proof = Context.Proof.tree Context.Proof.t
   end
@@ -3889,7 +3896,8 @@ sig
 
     module Make (Wasm_backend: Make_wasm) (C: P) :
     sig
-      include PVM.S with type context = C.Tree.t
+      include PVM.S with
+      type context = C.Tree.t
       and type state = C.tree
       and type proof = C.proof
 
@@ -3909,7 +3917,8 @@ sig
     end
 
     module Protocol_implementation:
-    PVM.S with type context = Context.t
+    PVM.S with
+    type context = Context.t
     and type state = Context.tree
     and type proof = Context.Proof.tree Context.Proof.t
 
@@ -5452,7 +5461,8 @@ end
 (** This module re-exports definitions from {!Raw_context.Consensus}. *)
 module Consensus:
 sig
-  include Raw_context.CONSENSUS with type t := t
+  include Raw_context.CONSENSUS with
+  type t := t
   and type slot := Slot.t
   and type 'a slot_map := 'a Slot.Map.t
   and type slot_set := Slot.Set.t

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -493,6 +493,15 @@ let add_multiline x =
 
 let add_one_line x = let res = x + x in res
 
+let add_two_lines x =
+  let res = x + x in
+  res
+
+let add_three_lines x =
+  let res = x + x
+  in
+  res
+
 let add_as_fun_multiline = fun x ->
   x
 


### PR DESCRIPTION
This addresses #133 by adding the new line after the "in" in let definition rather than having it before some very specific constructs.
Same for "=" and "with", there are already some line breaks added depending of the context (ie ancestor node) in which these symbols occur, and it seems more principled to have it this way and made the incriminated query redundant.

@aspiwack I know that you do not like the formatting of `add_three_lines`, but as I mentioned in https://github.com/tweag/topiary/pull/127#issuecomment-1351770298 I do not see how to format it differently with the current set of command.
Of course, adding a new command would not be hard at all, but I do not see it as a priority.

Closes #133 .