### PR TITLE
[OCaml] Support constructors in assignment lhs

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -324,6 +324,7 @@
     (string)
     (type_constructor_path)
     (typed_expression)
+    (value_name)
     (value_path)
     (value_pattern)
     "("

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -523,3 +523,10 @@ let greetings =
   and* msg2 = Some "world"
   in
   Some (msg1 ^ msg2)
+
+(* Some pattern-matching *)
+let hd::_ = [1, 2, 3]
+
+let Some message = Some "message"
+
+let [1, snd] = [1, 2]

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -523,3 +523,10 @@ let greetings =
   and* msg2 = Some "world"
   in
   Some (msg1 ^ msg2)
+
+(* Some pattern-matching *)
+let hd::_ = [1, 2, 3]
+
+let Some message = Some "message"
+
+let [1, snd] = [1, 2]


### PR DESCRIPTION
This allows the following to be correctly formatted:
```
let Some foo = Some bar
```
Closes #139 