### PR TITLE
[OCaml]: Support for quoted strings

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -7,6 +7,7 @@
 (
   [
     (character)
+    (quoted_string)
     (string)
   ]
 ) @leaf
@@ -296,6 +297,7 @@
     (number)
     (parenthesized_expression)
     (parenthesized_pattern)
+    (quoted_string)
     (string)
     (type_constructor_path)
     (typed_expression)
@@ -323,6 +325,7 @@
     (parenthesized_expression)
     (parenthesized_pattern)
     (prefix_expression)
+    (quoted_string)
     (string)
     (type_constructor_path)
     (typed_expression)
@@ -519,15 +522,27 @@
   "sig"
   "struct"
   "then"
-  "{"
 ] @append_indent_start
+
+; "{" can be used to start quoted strings. Don't indent in that case
+(
+  "{" @append_indent_start
+  .
+  (quoted_string_content)* @do_nothing
+)
 
 ; End the indented block before these
 [
   "done"
   "end"
-  "}"
 ] @prepend_indent_end
+
+; "}" can be used to end quoted strings. Don't indent in that case
+(
+  (quoted_string_content)* @do_nothing
+  .
+  "}" @prepend_indent_end
+)
 
 ; End the indented block after these
 [

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -536,3 +536,17 @@ let [1, snd] = [1, 2]
 
 type a = int
 and b = float
+
+(* Messing around with quoted strings and curly brackets *)
+type string_record = { my_string: string; }
+let quoted_string =
+  {|Hello|}
+and quoted_string_multiline_with_id =
+  {external|
+World
+{|!|}
+|external}
+let _ =
+  {
+    my_string = quoted_string ^ quoted_string_multiline_with_id
+  }

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -537,3 +537,17 @@ let [1, snd] = [1, 2]
 
 type a = int and
 b = float
+
+(* Messing around with quoted strings and curly brackets *)
+type string_record = { my_string: string; }
+let quoted_string =
+  {|Hello|}
+and quoted_string_multiline_with_id =
+  {external|
+World
+{|!|}
+|external}
+let _ =
+  {
+    my_string = quoted_string ^ quoted_string_multiline_with_id
+  }


### PR DESCRIPTION
Allows the following to be formatted correctly:
```
let quoted_string =
  {|Hello|}
print_endline quoted_string
```