### PR TITLE
Bash support (POC)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -278,6 +278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -364,11 +373,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -477,18 +486,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -534,9 +543,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -555,18 +564,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -575,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -592,9 +601,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -650,22 +659,12 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "test-log",
- "tree-sitter 0.20.9",
+ "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-json",
  "tree-sitter-ocaml",
  "tree-sitter-rust",
  "tree-sitter-toml",
-]
-
-[[package]]
-name = "tree-sitter"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad726ec26496bf4c083fff0f43d4eb3a2ad1bba305323af5ff91383c0b6ecac0"
-dependencies = [
- "cc",
- "regex",
 ]
 
 [[package]]
@@ -681,11 +680,10 @@ dependencies = [
 [[package]]
 name = "tree-sitter-bash"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c629e2d29ebb85b34cd195a1c511a161ed775451456cde110470e7af693424db"
+source = "git+https://github.com/tree-sitter/tree-sitter-bash#4488aa41406547e478636a4fcfd24f5bbc3f2f74"
 dependencies = [
  "cc",
- "tree-sitter 0.19.5",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -695,7 +693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b04c4e1a92139535eb9fca4ec8fa9666cc96b618005d3ae35f3c957fa92f92"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -704,17 +702,17 @@ version = "0.20.1"
 source = "git+https://github.com/tree-sitter/tree-sitter-ocaml#de07323343946c32759933cb3b7c78e821098cad"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter",
 ]
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13470fafb7327a3acf96f5bc1013b5539a899a182f01c59b5af53f6b93195717"
+checksum = "797842733e252dc11ae5d403a18060bf337b822fc2ae5ddfaa6ff4d9cc20bda6"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -724,7 +722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter",
 ]
 
 [[package]]
@@ -735,9 +733,9 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.3"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797842733e252dc11ae5d403a18060bf337b822fc2ae5ddfaa6ff4d9cc20bda6"
+checksum = "9cd01f349407afa65b764fd78d59821aaa6257a207550f6270fc60d9c3d8607f"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,11 +650,22 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "test-log",
- "tree-sitter",
+ "tree-sitter 0.20.9",
+ "tree-sitter-bash",
  "tree-sitter-json",
  "tree-sitter-ocaml",
  "tree-sitter-rust",
  "tree-sitter-toml",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad726ec26496bf4c083fff0f43d4eb3a2ad1bba305323af5ff91383c0b6ecac0"
+dependencies = [
+ "cc",
+ "regex",
 ]
 
 [[package]]
@@ -668,13 +679,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-bash"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c629e2d29ebb85b34cd195a1c511a161ed775451456cde110470e7af693424db"
+dependencies = [
+ "cc",
+ "tree-sitter 0.19.5",
+]
+
+[[package]]
 name = "tree-sitter-json"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b04c4e1a92139535eb9fca4ec8fa9666cc96b618005d3ae35f3c957fa92f92"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter 0.20.9",
 ]
 
 [[package]]
@@ -683,7 +704,7 @@ version = "0.20.1"
 source = "git+https://github.com/tree-sitter/tree-sitter-ocaml#de07323343946c32759933cb3b7c78e821098cad"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter 0.20.9",
 ]
 
 [[package]]
@@ -693,7 +714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13470fafb7327a3acf96f5bc1013b5539a899a182f01c59b5af53f6b93195717"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter 0.20.9",
 ]
 
 [[package]]
@@ -703,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter 0.20.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ regex = "1.6.0"
 test-log = "0.2"
 tree-sitter = "0.20"
 tree-sitter-json = "0.19"
-tree-sitter-rust = "0.20"
+tree-sitter-rust = "0.20.2"
 tree-sitter-toml = "0.20.0"
 
 # Needs a version > 0.19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# For now we just load the tree-sitter language parsers statically. 
+# For now we just load the tree-sitter language parsers statically.
 # Eventually we will want to dynamically load them, like Helix does.
 clap = { version = "3.2", features = ["derive"]}
 env_logger = "0.9"
@@ -19,6 +19,7 @@ tree-sitter = "0.20"
 tree-sitter-json = "0.19"
 tree-sitter-rust = "0.20"
 tree-sitter-toml = "0.20.0"
+tree-sitter-bash = "0.19.0"
 
 # Needs a version > 0.19
 tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ tree-sitter = "0.20"
 tree-sitter-json = "0.19"
 tree-sitter-rust = "0.20"
 tree-sitter-toml = "0.20.0"
-tree-sitter-bash = "0.19.0"
 
 # Needs a version > 0.19
 tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml" }
+tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash" }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -1,0 +1,2 @@
+; Configuration
+(#language! bash)

--- a/src/language.rs
+++ b/src/language.rs
@@ -10,6 +10,7 @@ pub enum Language {
     Ocaml,
     Rust,
     Toml,
+    Bash,
 }
 
 // NOTE This list of extension mappings is influenced by Wilfred Hughes' Difftastic
@@ -37,6 +38,7 @@ const EXTENSIONS: &[(&str, &[&str])] = &[
     ("ocaml", &["ml"]),
     ("rust", &["rs"]),
     ("toml", &["toml"]),
+    ("bash", &["sh", "bash"]),
 ];
 
 impl Language {
@@ -46,6 +48,8 @@ impl Language {
             "ocaml" => Ok(Language::Ocaml),
             "rust" => Ok(Language::Rust),
             "toml" => Ok(Language::Toml),
+            "bash" => Ok(Language::Bash),
+
             _ => Err(FormatterError::Query(
                 format!("Unsupported language specified: '{s}'"),
                 None,

--- a/src/language.rs
+++ b/src/language.rs
@@ -6,16 +6,17 @@ use crate::{FormatterError, FormatterResult};
 /// The languages that we support with query files.
 #[derive(Clone, Copy, Debug)]
 pub enum Language {
+    Bash,
     Json,
     Ocaml,
     Rust,
     Toml,
-    Bash,
 }
 
 // NOTE This list of extension mappings is influenced by Wilfred Hughes' Difftastic
 // https://github.com/Wilfred/difftastic/blob/master/src/parse/guess_language.rs
 const EXTENSIONS: &[(&str, &[&str])] = &[
+    ("bash", &["sh", "bash"]),
     (
         "json",
         &[
@@ -38,17 +39,16 @@ const EXTENSIONS: &[(&str, &[&str])] = &[
     ("ocaml", &["ml"]),
     ("rust", &["rs"]),
     ("toml", &["toml"]),
-    ("bash", &["sh", "bash"]),
 ];
 
 impl Language {
     pub fn new(s: &str) -> FormatterResult<Self> {
         match s.to_lowercase().as_str() {
+            "bash" => Ok(Language::Bash),
             "json" => Ok(Language::Json),
             "ocaml" => Ok(Language::Ocaml),
             "rust" => Ok(Language::Rust),
             "toml" => Ok(Language::Toml),
-            "bash" => Ok(Language::Bash),
 
             _ => Err(FormatterError::Query(
                 format!("Unsupported language specified: '{s}'"),

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -83,11 +83,11 @@ fn capture_name<'a, 'b>(query: &'a Query, capture: &'b QueryCapture) -> &'a str 
 
 fn grammar(language: Language) -> tree_sitter::Language {
     match language {
+        Language::Bash => tree_sitter_bash::language(),
         Language::Json => tree_sitter_json::language(),
         Language::Ocaml => tree_sitter_ocaml::language_ocaml(),
         Language::Rust => tree_sitter_rust::language(),
         Language::Toml => tree_sitter_toml::language(),
-        Language::Bash => tree_sitter_bash::language(),
     }
 }
 

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -87,6 +87,7 @@ fn grammar(language: Language) -> tree_sitter::Language {
         Language::Ocaml => tree_sitter_ocaml::language_ocaml(),
         Language::Rust => tree_sitter_rust::language(),
         Language::Toml => tree_sitter_toml::language(),
+        Language::Bash => tree_sitter_bash::language(),
     }
 }
 

--- a/tests/sample-tester.rs
+++ b/tests/sample-tester.rs
@@ -12,22 +12,17 @@ fn input_output_tester() {
 
     for file in input_dir {
         let file = file.unwrap();
+
         let input_path = file.path();
+        let language =
+            Language::detect(input_path.to_str().unwrap()).unwrap_or_else(|err| panic!("{err}"));
+
         let expected_path = expected_dir.join(file.file_name());
-        let extension = input_path.extension().unwrap().to_str().unwrap();
-
-        let language = match extension {
-            "json" => Language::Json,
-            "ml" => Language::Ocaml,
-            "rs" => Language::Rust,
-            "toml" => Language::Toml,
-            _ => panic!("File extension {} not supported.", extension),
-        };
-
         let expected = fs::read_to_string(expected_path).unwrap();
-        let mut input = BufReader::new(fs::File::open(input_path).unwrap());
+
+        let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
         let mut output = Vec::new();
-        let query_path = str::to_lowercase(format!("languages/{language:?}.scm").as_str());
+        let query_path = str::to_lowercase(format!("languages/{language}.scm").as_str());
         let query = fs::read_to_string(query_path).unwrap();
         let mut query = query.as_bytes();
 

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash


### PR DESCRIPTION
This PR adds vacuous Bash support. That is, it brings in all the dependencies and contains the necessary changes to the codebase to support Bash, but the query file for Bash contains no formatting directives and the sample files (input and expected) just have their shebang lines; these will be expanded in subsequent PRs.

(I also took the opportunity to update the input vs. expected test runner to use the language detection code.)