### PR TITLE
[OCaml] miscellaneous improvements on module/functors formatting

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -579,7 +579,11 @@
 ;
 (signature
   "sig" @append_spaced_softline
-  (value_specification) @append_spaced_softline
+  [
+    (value_specification)
+    (type_definition)
+    (include_module_type)
+  ] @append_spaced_softline
 )
 
 ; In class definitions and class type definitions, each declaration is separated

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -19,6 +19,8 @@
   (comment)
   (exception_definition)
   (external)
+  (include_module)
+  (include_module_type)
   (inheritance_definition)
   (inheritance_specification)
   (instance_variable_definition)
@@ -28,6 +30,7 @@
   (open_module)
   (type_definition)
   (value_definition)
+  (value_specification)
 ] @allow_blank_line_before
 
 ; In a definition including several mutually recursive functions,

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -134,6 +134,7 @@
   ":"
   ";"
   "+="
+  ":="
 ] @append_space
 
 ; Those keywords are not expected to come right after an open parenthesis.
@@ -156,6 +157,7 @@
     "->"
     "<-"
     "+="
+    ":="
 ] @prepend_space
 
 ; let-like and and-like operators are only followed by a closing parenthesis

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -111,6 +111,7 @@
   "of"
   "open"
   (parameter)
+  "private"
   "rec"
   "sig"
   "then"
@@ -265,6 +266,11 @@
   "("* @do_nothing
   .
   (parameter) @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  "private" @prepend_space
 )
 (
   "("* @do_nothing

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -104,6 +104,7 @@
   "match"
   "method"
   "module"
+  (module_parameter)
   "mutable"
   "new"
   "nonrec"
@@ -243,6 +244,11 @@
   "("* @do_nothing
   .
   "module" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  (module_parameter) @prepend_space
 )
 (
   "("* @do_nothing

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -606,6 +606,9 @@ let (Some 2) =
   my_stack#push 2;
   my_stack#pop
 
-(* Module with a private type *)
+(* Some modules and functors *)
 module type M = sig type t = private int64
+end
+
+module F(X: M)(Y: M with type t := X.t) = struct
 end

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -605,3 +605,7 @@ let (Some 2) =
   my_stack#push 1;
   my_stack#push 2;
   my_stack#pop
+
+(* Module with a private type *)
+module type M = sig type t = private int64
+end

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -471,6 +471,7 @@ module type Printer = sig
     element printer and [sep] as separator between elements. *)
   val print_list : string -> 'a printer -> 'a list printer
   val print_name : name printer
+
   val print_ident : ident printer
 end
 
@@ -610,5 +611,24 @@ let (Some 2) =
 module type M = sig type t = private int64
 end
 
+module type T2 = sig end
+
+module M: T2 = struct end
+
 module F (X: M) (Y: M with type t := X.t) = struct
+  module type S = sig
+    type t = X.t
+
+    val zero : t
+
+    val succ : t -> t
+
+    include T2
+  end
+
+  let zero = 0
+
+  let succ n = n + 1
+
+  include M
 end

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -608,14 +608,15 @@ let (Some 2) =
   my_stack#pop
 
 (* Some modules and functors *)
-module type M = sig type t = private int64
+module type T1 = sig
+  type t = private int64
 end
 
 module type T2 = sig end
 
 module M: T2 = struct end
 
-module F (X: M) (Y: M with type t := X.t) = struct
+module F (X: T1) (Y: T1 with type t := X.t) = struct
   module type S = sig
     type t = X.t
 

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -610,5 +610,5 @@ let (Some 2) =
 module type M = sig type t = private int64
 end
 
-module F(X: M)(Y: M with type t := X.t) = struct
+module F (X: M) (Y: M with type t := X.t) = struct
 end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -606,7 +606,10 @@ let (Some 2) =
   my_stack#push 2;
   my_stack#pop
 
-(* Module with a private type *)
+(* Some modules and functors *)
 module type M = sig
   type t = private int64
+end
+
+module F (X: M) (Y: M with type t := X.t) = struct
 end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -611,5 +611,24 @@ module type M = sig
   type t = private int64
 end
 
+module type T2 = sig end
+
+module M: T2 = struct end
+
 module F (X: M) (Y: M with type t := X.t) = struct
+  module type S = sig
+    type t = X.t
+
+    val zero : t
+
+    val succ : t -> t
+
+    include T2
+  end
+
+  let zero = 0
+
+  let succ n = n + 1
+
+  include M
 end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -605,3 +605,8 @@ let (Some 2) =
   my_stack#push 1;
   my_stack#push 2;
   my_stack#pop
+
+(* Module with a private type *)
+module type M = sig
+  type t = private int64
+end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -607,7 +607,7 @@ let (Some 2) =
   my_stack#pop
 
 (* Some modules and functors *)
-module type M = sig
+module type T1 = sig
   type t = private int64
 end
 
@@ -615,7 +615,7 @@ module type T2 = sig end
 
 module M: T2 = struct end
 
-module F (X: M) (Y: M with type t := X.t) = struct
+module F (X: T1) (Y: T1 with type t := X.t) = struct
   module type S = sig
     type t = X.t
 


### PR DESCRIPTION
This will allow the following to be formatted correctly:
```
module type T1 = sig
  type t = private int64
end

module type T2 = sig end

module M: T2 = struct end

module F (X: T1) (Y: T1 with type t := X.t) = struct
  module type S = sig
    type t = X.t

    val zero : t

    val succ : t -> t

    include T2
  end

  let zero = 0

  let succ n = n + 1

  include T2
end
```
