### PR TITLE
[OCaml] Add spacing for booleans

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -347,6 +347,7 @@
 ; Certain elements must be separated by spaces.
 (
   [
+    (boolean)
     (character)
     (class_path)
     (class_type_path)
@@ -382,6 +383,7 @@
   ]* @do_nothing
   .
   [
+    (boolean)
     (character)
     (class_name)
     (class_path)

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -519,6 +519,10 @@ let unbox_rec = function
   | Some My_types.{ my_bool } -> my_bool
   | _ -> false
 
+let unbox_bool = function
+  | Some true -> true
+  | _ -> false
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -519,6 +519,10 @@ let unbox_rec = function
   | Some My_types.{ my_bool } -> my_bool
   | _ -> false
 
+let unbox_bool = function
+  | Some true -> true
+  | _ -> false
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind


### PR DESCRIPTION
Allows the following to be formatted correctly:
```
let unbox_bool = function
  | Some true -> true
  | _ -> false
```