### PR TITLE
[OCaml] fix spacing issues with local imports

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -317,11 +317,6 @@
 (
   "("* @do_nothing
   .
-  "{" @prepend_space
-)
-(
-  "("* @do_nothing
-  .
   "}" @prepend_space
 )
 
@@ -379,6 +374,7 @@
     (constructor_path)
     (extended_module_path)
     (field_get_expression)
+    (local_open_pattern)
     (labeled_argument)
     (module_path)
     (number)
@@ -394,6 +390,7 @@
     (value_path)
     (value_pattern)
     "("
+    "{"
   ]
 )
 

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -462,8 +462,9 @@ module ListSetExtended = struct
   let of_list lst = List.fold_right add lst empty
 end
 
-module M = struct
+module My_types = struct
   type nonrec t = t
+  type my_rec = { my_bool: bool; }
 end
 
 module type Printer = sig
@@ -512,6 +513,10 @@ let is_prime n =
     if n mod !i = 0 then no_divisor := false;
   done;
   !no_divisor
+
+let unbox_rec = function
+  | Some My_types.{ my_bool } -> my_bool
+  | _ -> false
 
 (* Showcase the usage of operator bindings *)
 let greetings =

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -459,8 +459,9 @@ module ListSetExtended = struct
   let of_list lst = List.fold_right add lst empty
 end
 
-module M = struct
+module My_types = struct
 type nonrec t=t
+type my_rec={my_bool: bool;}
 end
 
 
@@ -513,6 +514,10 @@ let is_prime n =
     then no_divisor := false;
   done;
   !no_divisor
+
+let unbox_rec = function
+  | Some My_types.{ my_bool } -> my_bool
+  | _ -> false
 
 (* Showcase the usage of operator bindings *)
 let greetings =


### PR DESCRIPTION
Allows correct formatting of the following:
```
let unbox_rec = function
  | Some My_types.{ my_bool } -> my_bool
  | _ -> false
```