### PR TITLE
[OCaml] fix disappearing negative numbers

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -8,6 +8,7 @@
   [
     (character)
     (quoted_string)
+    (signed_number)
     (string)
   ]
 ) @leaf

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -504,6 +504,10 @@ let sum_of_int n =
 let sum_of_int_reversed n =
   let res = ref 0 in for i = n downto 1 do res := !res + i; done
 
+let verbose_id = function
+  | -1 -> -1
+  | n -> n
+
 let is_prime n =
   let no_divisor = ref true in
   let i = ref 1 in

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -504,6 +504,10 @@ let sum_of_int_reversed n =
   let res = ref 0 in
   for i = n downto 1 do res := !res + i; done
 
+let verbose_id = function
+  | -1 -> -1
+  | n -> n
+
 let is_prime n =
   let no_divisor = ref true in
   let i = ref 1 in


### PR DESCRIPTION
Allows correct formatting of the following:
```
function -1 -> -1
```
Closes #153