### PR TITLE
[Rust] Fix query after tree-sitter-rust update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd01f349407afa65b764fd78d59821aaa6257a207550f6270fc60d9c3d8607f"
+checksum = "797842733e252dc11ae5d403a18060bf337b822fc2ae5ddfaa6ff4d9cc20bda6"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ regex = "1.6.0"
 test-log = "0.2"
 tree-sitter = "0.20"
 tree-sitter-json = "0.19"
-tree-sitter-rust = "0.20.2"
+tree-sitter-rust = "0.20.3"
 tree-sitter-toml = "0.20.0"
 
 # Needs a version > 0.19

--- a/languages/rust.scm
+++ b/languages/rust.scm
@@ -84,11 +84,11 @@
     (struct_item)
     (type_item)
     (use_declaration)
-  ] @append_hardline 
-  . 
+  ] @append_hardline
+  .
   [
     (block_comment)
-    (line_comment) 
+    (line_comment)
   ]* @do_nothing
 )
 
@@ -100,7 +100,7 @@
     ","
     ";"
   ] @append_spaced_softline
-  . 
+  .
   [ (block_comment) (line_comment) ]* @do_nothing
 )
 
@@ -195,20 +195,12 @@
   (binary_expression) @prepend_space
 )
 
-; if let
-(if_let_expression
-  [
-    (identifier)
-    "let"
-  ] @prepend_space
-)
-
 ; impl
 (impl_item
   (type_identifier) @prepend_space
 )
 
-(declaration_list  
+(declaration_list
   .
   "{" @prepend_space
 )


### PR DESCRIPTION
This PR updates tree-sitter-rust to v0.20.3, which removes support for `if_let_expression` directives. This has been obviated by an improved `if_expression`.

Resolves #147