### PR TITLE
Dynamic loading of language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,9 @@ name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -232,6 +235,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +271,41 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "git2"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -293,6 +351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +414,46 @@ name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.14.0+1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -394,6 +511,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +543,18 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plotters"
@@ -525,6 +673,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +805,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,24 +835,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "toml"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "topiary"
 version = "0.1.0"
 dependencies = [
+ "cc",
  "clap",
  "criterion",
+ "directories",
  "env_logger",
+ "git2",
  "itertools",
+ "lazy_static",
  "log",
  "pretty",
  "pretty_assertions",
  "regex",
+ "serde",
+ "serde_derive",
  "test-log",
+ "toml",
  "tree-sitter",
- "tree-sitter-bash",
- "tree-sitter-json",
- "tree-sitter-ocaml",
- "tree-sitter-rust",
- "tree-sitter-toml",
 ]
 
 [[package]]
@@ -678,58 +892,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-bash"
-version = "0.19.0"
-source = "git+https://github.com/tree-sitter/tree-sitter-bash#4488aa41406547e478636a4fcfd24f5bbc3f2f74"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
-name = "tree-sitter-json"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b04c4e1a92139535eb9fca4ec8fa9666cc96b618005d3ae35f3c957fa92f92"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
-name = "tree-sitter-ocaml"
-version = "0.20.1"
-source = "git+https://github.com/tree-sitter/tree-sitter-ocaml#de07323343946c32759933cb3b7c78e821098cad"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
-name = "tree-sitter-rust"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797842733e252dc11ae5d403a18060bf337b822fc2ae5ddfaa6ff4d9cc20bda6"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
-name = "tree-sitter-toml"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8"
-dependencies = [
- "cc",
- "tree-sitter",
-]
-
-[[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
@@ -738,10 +910,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -759,6 +957,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +880,7 @@ dependencies = [
  "git2",
  "itertools",
  "lazy_static",
+ "libloading",
  "log",
  "pretty",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,22 +7,22 @@ edition = "2021"
 [dependencies]
 # For now we just load the tree-sitter language parsers statically.
 # Eventually we will want to dynamically load them, like Helix does.
+cc = "1.0"
 clap = { version = "3.2", features = ["derive"]}
+directories = "4.0"
 env_logger = "0.9"
+git2 = "0.15"
 itertools = "0.10"
 log = "0.4"
 pretty = "0.11"
 pretty_assertions = "1.3"
-regex = "1.6.0"
+regex = "1.6"
+serde = "1.0"
+serde_derive = "1.0"
 test-log = "0.2"
+toml = "0.5"
 tree-sitter = "0.20"
-tree-sitter-json = "0.19"
-tree-sitter-rust = "0.20.3"
-tree-sitter-toml = "0.20.0"
-
-# Needs a version > 0.19
-tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml" }
-tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash" }
+lazy_static = "1.4"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# For now we just load the tree-sitter language parsers statically.
-# Eventually we will want to dynamically load them, like Helix does.
 cc = "1.0"
 clap = { version = "3.2", features = ["derive"]}
 directories = "4.0"
 env_logger = "0.9"
 git2 = "0.15"
 itertools = "0.10"
+lazy_static = "1.4"
+libloading = "0.7"
 log = "0.4"
 pretty = "0.11"
 pretty_assertions = "1.3"
@@ -22,7 +22,6 @@ serde_derive = "1.0"
 test-log = "0.2"
 toml = "0.5"
 tree-sitter = "0.20"
-lazy_static = "1.4"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -7,15 +7,16 @@ fn criterion_benchmark(c: &mut Criterion) {
     let input = fs::read_to_string("tests/samples/input/ocaml.ml").unwrap();
     let query = fs::read_to_string("languages/ocaml.scm").unwrap();
 
-    c.bench_function("format ocaml", |b| {
-        b.iter(|| {
-            let mut input = input.as_bytes();
-            let mut query = query.as_bytes();
-            let mut output = io::BufWriter::new(Vec::new());
+    // TODO!
+    // c.bench_function("format ocaml", |b| {
+    //     b.iter(|| {
+    //         let mut input = input.as_bytes();
+    //         let mut query = query.as_bytes();
+    //         let mut output = io::BufWriter::new(Vec::new());
 
-            formatter(&mut input, &mut output, &mut query, false)
-        })
-    });
+    //         formatter(&mut input, &mut output, &mut query, false)
+    //     })
+    // });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=BUILD_TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,8 @@ let
       ];
     };
 
-    nativeBuildInputs = [ pkgs.libiconv ];
+    nativeBuildInputs = with pkgs; [ libiconv ];
+    buildInputs = with pkgs; [ pkg-config openssl];
   };
 
   cargoArtifacts = craneLib.buildDepsOnly (commonArgs);

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,15 @@
         checks = with code; {
           inherit app clippy fmt audit benchmark;
         };
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ code.app ];
+          packages = with pkgs; [
+            cargo
+            rust-analyzer
+            rustc
+            rustfmt
+          ];
+        };
       }
     );
 }

--- a/languages.toml
+++ b/languages.toml
@@ -1,0 +1,4 @@
+[[language]]
+name = "json"
+grammar = { git = "https://github.com/tree-sitter/tree-sitter-json.git", rev = "73076754005a460947cafe8e03a8cf5fa4fa2938" }
+extensions =  [ "json", "avsc", "geojson", "gltf", "har", "ice", "JSON-tmLanguage", "jsonl", "mcmeta", "tfstate", "tfstate.backup", "topojson", "webapp", "webmanifest" ]

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use tree_sitter::Node;
 
-use crate::{Atom, FormatterError, FormatterResult};
+use crate::{Atom, TopiaryError, TopiaryResult};
 
 #[derive(Debug)]
 pub struct AtomCollection {
@@ -22,7 +22,7 @@ impl AtomCollection {
         root: Node,
         source: &[u8],
         specified_leaf_nodes: BTreeSet<usize>,
-    ) -> FormatterResult<AtomCollection> {
+    ) -> TopiaryResult<AtomCollection> {
         // Detect user specified line breaks
         let multi_line_nodes = detect_multi_line_nodes(root);
         let blank_lines_before = detect_blank_lines_before(root);
@@ -50,7 +50,7 @@ impl AtomCollection {
         name: &str,
         node: Node,
         delimiter: Option<&str>,
-    ) -> FormatterResult<()> {
+    ) -> TopiaryResult<()> {
         log::debug!("Resolving {name}");
 
         match name {
@@ -63,7 +63,7 @@ impl AtomCollection {
                 Atom::Literal(
                     delimiter
                         .ok_or_else(|| {
-                            FormatterError::Query(
+                            TopiaryError::Query(
                                 "@append_delimiter requires a #delimiter! predicate".into(),
                                 None,
                             )
@@ -91,7 +91,7 @@ impl AtomCollection {
                 Atom::Literal(
                     delimiter
                         .ok_or_else(|| {
-                            FormatterError::Query(
+                            TopiaryError::Query(
                                 "@prepend_delimiter requires a #delimiter! predicate".into(),
                                 None,
                             )
@@ -119,7 +119,7 @@ impl AtomCollection {
 
             // Return a query parsing error on unknown capture names
             unknown => {
-                return Err(FormatterError::Query(
+                return Err(TopiaryError::Query(
                     format!("@{unknown} is not a valid capture name"),
                     None,
                 ))
@@ -163,7 +163,7 @@ impl AtomCollection {
         source: &[u8],
         parent_ids: &[usize],
         level: usize,
-    ) -> FormatterResult<()> {
+    ) -> TopiaryResult<()> {
         let id = node.id();
         let parent_ids = [parent_ids, &[id]].concat();
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,6 +1,6 @@
 //! This file deals with reading and parsing the configuration file. It is also
 //! responsible for combining the builtin one with the one provided by the user.
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::{language::Language, project_dirs::TOPIARY_DIRS, FormatterError, FormatterResult};
 
@@ -24,8 +24,14 @@ impl Configuration {
         Ok(config)
     }
 
-    pub fn find_language_by_extension(&self, extension: &str) -> &Language {
-        todo!()
+    pub fn find_language_by_extension(&self, file_path: &Path) -> &Language {
+        // TODO: Error
+        let extension_buf = PathBuf::from(file_path);
+        let extension = extension_buf.extension().unwrap();
+        self.language
+            .iter()
+            .find(|&l| l.check_extension(&extension.to_str().unwrap()))
+            .unwrap()
     }
 
     pub fn find_language_by_name(&self, name: &str) -> &Language {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -2,7 +2,7 @@
 //! responsible for combining the builtin one with the one provided by the user.
 use std::path::{Path, PathBuf};
 
-use crate::{language::Language, project_dirs::TOPIARY_DIRS, FormatterError, FormatterResult};
+use crate::{language::Language, project_dirs::TOPIARY_DIRS, TopiaryError, TopiaryResult};
 
 use serde_derive::{Deserialize, Serialize};
 
@@ -12,7 +12,7 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    pub fn parse() -> FormatterResult<Self> {
+    pub fn parse() -> TopiaryResult<Self> {
         let config_path: PathBuf = TOPIARY_DIRS.config_dir().join("languages.toml");
         println!("config_path = {:#?}", config_path);
         // TODO: error

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,78 +1,34 @@
-use crate::{language::Language, FormatterError, FormatterResult};
-use regex::Regex;
+//! This file deals with reading and parsing the configuration file. It is also
+//! responsible for combining the builtin one with the one provided by the user.
+use std::path::PathBuf;
 
+use crate::{language::Language, project_dirs::TOPIARY_DIRS, FormatterError, FormatterResult};
+
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Configuration {
-    pub language: Language,
-    pub indent_level: isize,
+    pub language: Vec<Language>,
 }
 
 impl Configuration {
-    pub fn parse(query: &str) -> FormatterResult<Self> {
-        let mut language: Option<Language> = None;
-        let mut indent_level: isize = 2;
-
-        // Match lines beginning with a predicate like this:
-        // (#language! rust)
-        // (#indent-level! 4)
-        // (#foo! 1 2 bar)
-        let regex =
-            Regex::new(r"(?m)^\(#(?P<predicate>.*?)!\s+(?P<arguments>.*?)\)").expect("valid regex");
-
-        for capture in regex.captures_iter(query) {
-            let predicate = capture
-                .name("predicate")
-                .expect("predicate capture group")
-                .as_str();
-            let mut arguments = capture
-                .name("arguments")
-                .expect("arguments capture group")
-                .as_str()
-                .split(' ');
-            log::info!("Predicate: {predicate} -  Arguments: {arguments:?}");
-
-            match predicate {
-                "language" => {
-                    if let Some(arg) = arguments.next() {
-                        language = Some(Language::new(arg)?);
-                    } else {
-                        Err(FormatterError::Query(
-                            "The #language! configuration predicate must have a parameter".into(),
-                            None,
-                        ))?
-                    }
-                }
-                "indent-level" => {
-                    if let Some(arg) = arguments.next() {
-                        indent_level = arg.parse::<isize>().map_err(|_| {
-                            FormatterError::Query(
-                                format!(
-                                    "The #indent-level! parameter must be numeric, but got '{arg}'"
-                                ),
-                                None,
-                            )
-                        })?;
-                    } else {
-                        Err(FormatterError::Query(
-                            "The #indent-level! configuration predicate must have a parameter"
-                                .into(),
-                            None,
-                        ))?
-                    }
-                }
-                _ => Err(FormatterError::Query(
-                    format!("Unknown configuration predicate '{predicate}'"),
-                    None,
-                ))?,
-            };
+    pub fn parse() -> FormatterResult<Self> {
+        let config_path: PathBuf = TOPIARY_DIRS.config_dir().join("languages.toml");
+        println!("config_path = {:#?}", config_path);
+        // TODO: error
+        let config_str: String = std::fs::read_to_string(config_path).unwrap();
+        let config: Self = toml::from_str(&config_str).unwrap();
+        for lang in &config.language {
+            println!("LANGUAGE: {}", lang.name);
         }
+        Ok(config)
+    }
 
-        if let Some(language) = language {
-            Ok(Configuration {
-                language,
-                indent_level,
-            })
-        } else {
-            Err(FormatterError::Query("The query file must configure a language using the #language! configuration predicate".into(), None))
-        }
+    pub fn find_language_by_extension(&self, extension: &str) -> &Language {
+        todo!()
+    }
+
+    pub fn find_language_by_name(&self, name: &str) -> &Language {
+        self.language.iter().find(|&l| l.name == name).unwrap()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,9 @@ pub enum FormatterError {
 
     /// Could not write the formatted output.
     Writing(WritingError),
+
+    /// Any issue that occured related to Git.
+    Git(git2::Error),
 }
 
 /// A subtype of `FormatterError::Reading`.
@@ -106,6 +109,12 @@ impl fmt::Display for FormatterError {
                     "The formatter errored when trying to format the code twice (idempotence check).\nThis probably means that the formatter produced invalid code.\n{please_log_message}"
                 )
             }
+            Self::Git(err) => {
+                write!(
+                    f,
+                    "The formatter errored when trying to fetch a grammar from git. See the following message: {}", err
+                )
+            }
         }
     }
 }
@@ -125,6 +134,7 @@ impl Error for FormatterError {
             Self::Writing(WritingError::IntoInner(source)) => Some(source),
             Self::Writing(WritingError::Io(source)) => Some(source),
             Self::Formatting(err) => Some(err),
+            Self::Git(err) => Some(err),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,9 @@ pub enum FormatterError {
 
     /// Any issue that occured related to Git.
     Git(git2::Error),
+
+    /// There was an error loading tree-sitter error
+    ParserLoading(libloading::Error),
 }
 
 /// A subtype of `FormatterError::Reading`.
@@ -115,6 +118,13 @@ impl fmt::Display for FormatterError {
                     "The formatter errored when trying to fetch a grammar from git. See the following message: {}", err
                 )
             }
+            Self::ParserLoading(err) => {
+                write!(
+                    f,
+                    "The formatter errored when trying load the parser dynamic library: {}",
+                    err
+                )
+            }
         }
     }
 }
@@ -135,6 +145,7 @@ impl Error for FormatterError {
             Self::Writing(WritingError::Io(source)) => Some(source),
             Self::Formatting(err) => Some(err),
             Self::Git(err) => Some(err),
+            Self::ParserLoading(err) => Some(err),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,11 @@ use std::{error::Error, ffi, fmt, io, process, str, string};
 
 /// The various errors the formatter may return.
 #[derive(Debug)]
-pub enum FormatterError {
+pub enum TopiaryError {
     /// The input produced output that cannot be formatted, i.e. trying to format the
     /// output again produced an error. If this happened using our provided
     /// query files, it is a bug. Please log an issue.
-    Formatting(Box<FormatterError>),
+    Formatting(Box<TopiaryError>),
 
     /// The input produced output that isn't idempotent, i.e. formatting the
     /// output again made further changes. If this happened using our provided
@@ -47,14 +47,14 @@ pub enum FormatterError {
     ParserCompilation(ParserCompilationError),
 }
 
-/// A subtype of `FormatterError::Reading`.
+/// A subtype of `TopiaryError::Reading`.
 #[derive(Debug)]
 pub enum ReadingError {
     Io(String, io::Error),
     Utf8(str::Utf8Error),
 }
 
-/// A subtype of `FormatterError::Writing`.
+/// A subtype of `TopiaryError::Writing`.
 #[derive(Debug)]
 pub enum WritingError {
     Fmt(fmt::Error),
@@ -63,14 +63,14 @@ pub enum WritingError {
     FromUtf8(string::FromUtf8Error),
 }
 
-/// A subtype of `FormatterError::ParserCompilation`.
+/// A subtype of `TopiaryError::ParserCompilation`.
 #[derive(Debug)]
 pub enum ParserCompilationError {
     Io(io::Error),
     Cc(String, String),
 }
 
-impl fmt::Display for FormatterError {
+impl fmt::Display for TopiaryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let please_log_message = "It would be helpful if you logged this error at https://github.com/tweag/topiary/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md";
         match self {
@@ -149,7 +149,7 @@ impl fmt::Display for FormatterError {
     }
 }
 
-impl Error for FormatterError {
+impl Error for TopiaryError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::Idempotence => None,
@@ -172,32 +172,32 @@ impl Error for FormatterError {
     }
 }
 
-impl From<str::Utf8Error> for FormatterError {
+impl From<str::Utf8Error> for TopiaryError {
     fn from(e: str::Utf8Error) -> Self {
-        FormatterError::Reading(ReadingError::Utf8(e))
+        TopiaryError::Reading(ReadingError::Utf8(e))
     }
 }
 
-impl From<io::Error> for FormatterError {
+impl From<io::Error> for TopiaryError {
     fn from(e: io::Error) -> Self {
-        FormatterError::Writing(WritingError::Io(e))
+        TopiaryError::Writing(WritingError::Io(e))
     }
 }
 
-impl From<string::FromUtf8Error> for FormatterError {
+impl From<string::FromUtf8Error> for TopiaryError {
     fn from(e: string::FromUtf8Error) -> Self {
-        FormatterError::Writing(WritingError::FromUtf8(e))
+        TopiaryError::Writing(WritingError::FromUtf8(e))
     }
 }
 
-impl From<io::IntoInnerError<io::BufWriter<Vec<u8>>>> for FormatterError {
+impl From<io::IntoInnerError<io::BufWriter<Vec<u8>>>> for TopiaryError {
     fn from(e: io::IntoInnerError<io::BufWriter<Vec<u8>>>) -> Self {
-        FormatterError::Writing(WritingError::IntoInner(e))
+        TopiaryError::Writing(WritingError::IntoInner(e))
     }
 }
 
-impl From<fmt::Error> for FormatterError {
+impl From<fmt::Error> for TopiaryError {
     fn from(e: fmt::Error) -> Self {
-        FormatterError::Writing(WritingError::Fmt(e))
+        TopiaryError::Writing(WritingError::Fmt(e))
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -1,0 +1,135 @@
+//! This module deals with the tree-sitter grammars.
+//! It is responsible for fetching and building them.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use git2::{Oid, Repository};
+use serde_derive::{Deserialize, Serialize};
+
+use crate::{project_dirs::TOPIARY_DIRS, FormatterResult};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase", untagged)]
+pub enum GrammarSource {
+    Local {
+        path: String,
+    },
+    Git {
+        #[serde(rename = "git")]
+        remote: String,
+        #[serde(rename = "rev")]
+        revision: String,
+    },
+}
+
+impl GrammarSource {
+    /// Ensures the grammar is updated and available. This includes fetching,
+    /// compiling and placing it in the required place.
+    pub fn ensure_available(&self, name: &str) -> FormatterResult<()> {
+        match self {
+            GrammarSource::Local { path } => {
+                let path = Path::new(path);
+                if !path.exists() {
+                    // Return error
+                    todo!()
+                } else {
+                    compile_grammar(path, name);
+                }
+                Ok(())
+            }
+            GrammarSource::Git { remote, revision } => {
+                // We could construct the path ourselves
+                let grammar_path = fetch_grammar(remote, revision);
+                compile_grammar(&grammar_path, name);
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Fetches the grammar from the remote, returns doing nothing if already present.
+fn fetch_grammar(remote: &str, revision: &str) -> PathBuf {
+    let mut path = TOPIARY_DIRS.cache_dir().to_path_buf();
+    path.push("grammars/");
+    path.push(format!("{}/", revision));
+
+    // Try to open, if fails, create new.
+    let repo = match Repository::open(&path) {
+        // If it can succesfully open the repository, we can safely return
+        Ok(repo) => return path,
+        Err(e) => match Repository::clone_recurse(remote, &path) {
+            Ok(repo) => repo,
+            Err(e) => panic!("failed to init: {}", e),
+        },
+    };
+
+    // Set detached head to the required revision
+    // TODO: error
+    repo.set_head_detached(Oid::from_str(revision).unwrap())
+        .unwrap();
+    return path;
+}
+
+// Since we do not know if a grammar is already built or not, we always build
+// it. We could possible avoid this by tagging the binary with some kind of
+// revision.
+fn compile_grammar(src_path: &Path, name: &str) {
+    let header_path = src_path;
+    let parser_path = src_path.join("parser.c");
+    let mut scanner_path = src_path.join("scanner.c");
+
+    let scanner_path = if scanner_path.exists() {
+        Some(scanner_path)
+    } else {
+        scanner_path.set_extension("cc");
+        if scanner_path.exists() {
+            Some(scanner_path)
+        } else {
+            None
+        }
+    };
+
+    let mut library_path = TOPIARY_DIRS
+        .cache_dir()
+        .join(format!("parsers/{}/parser", name));
+    // TODO: Not assume Linux
+    library_path.set_extension(".so");
+
+    let mut config = cc::Build::new();
+    config.cpp(true).opt_level(3).cargo_metadata(false);
+    let compiler = config.get_compiler();
+    let mut command = Command::new(compiler.path());
+    command.current_dir(src_path);
+    for (key, value) in compiler.env() {
+        command.env(key, value);
+    }
+    command.args(compiler.args());
+
+    command
+        .arg("-shared")
+        .arg("-fPIC")
+        .arg("-fno-exceptions")
+        .arg("-g")
+        .arg("-I")
+        .arg(header_path)
+        .arg("-o")
+        .arg(&library_path)
+        .arg("-O3");
+    if let Some(scanner_path) = scanner_path.as_ref() {
+        if scanner_path.extension() == Some("c".as_ref()) {
+            command.arg("-xc").arg("-std=c99").arg(scanner_path);
+        } else {
+            command.arg(scanner_path);
+        }
+    }
+    command.arg("-xc").arg(parser_path);
+    command.arg("-Wl,-z,relro,-z,now");
+
+    let output = command.output().unwrap();
+    if !output.status.success() {
+        todo!("error")
+    }
+}

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -78,8 +78,9 @@ fn fetch_grammar(remote: &str, revision: &str) -> PathBuf {
 // Since we do not know if a grammar is already built or not, we always build
 // it. We could possible avoid this by tagging the binary with some kind of
 // revision.
-fn compile_grammar(src_path: &Path, name: &str) {
-    let header_path = src_path;
+fn compile_grammar(source_path: &Path, name: &str) {
+    let src_path = source_path.join("src");
+    let header_path = src_path.clone();
     let parser_path = src_path.join("parser.c");
     let mut scanner_path = src_path.join("scanner.c");
 
@@ -98,7 +99,8 @@ fn compile_grammar(src_path: &Path, name: &str) {
         .cache_dir()
         .join(format!("parsers/{}/parser", name));
     // TODO: Not assume Linux
-    library_path.set_extension(".so");
+    // TODO: Ensure path exists
+    library_path.set_extension("so");
 
     let mut config = cc::Build::new();
     config
@@ -137,6 +139,11 @@ fn compile_grammar(src_path: &Path, name: &str) {
 
     let output = command.output().unwrap();
     if !output.status.success() {
+        println!(
+            "Parser compilation failed.\nStdout: {}\nStderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
         todo!("error")
     }
 }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -11,6 +11,8 @@ use serde_derive::{Deserialize, Serialize};
 
 use crate::{project_dirs::TOPIARY_DIRS, FormatterResult};
 
+const BUILD_TARGET: &str = env!("BUILD_TARGET");
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase", untagged)]
 pub enum GrammarSource {
@@ -99,7 +101,12 @@ fn compile_grammar(src_path: &Path, name: &str) {
     library_path.set_extension(".so");
 
     let mut config = cc::Build::new();
-    config.cpp(true).opt_level(3).cargo_metadata(false);
+    config
+        .cpp(true)
+        .opt_level(3)
+        .cargo_metadata(false)
+        .host(BUILD_TARGET)
+        .target(BUILD_TARGET);
     let compiler = config.get_compiler();
     let mut command = Command::new(compiler.path());
     command.current_dir(src_path);

--- a/src/language.rs
+++ b/src/language.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use directories::ProjectDirs;
 use serde_derive::{Deserialize, Serialize};
 
-use crate::grammar::GrammarSource;
+use crate::grammar::{GrammarSource, DYLIB_EXTENSION};
 use crate::project_dirs::TOPIARY_DIRS;
 use crate::{FormatterError, FormatterResult};
 
@@ -62,7 +62,7 @@ impl Language {
     pub fn parser_path(&self) -> FormatterResult<PathBuf> {
         let mut path = TOPIARY_DIRS.cache_dir().to_path_buf();
         path.push("parsers/");
-        path.push(format!("{}/parser.so", self.name));
+        path.push(format!("{}/parser.{}", self.name, DYLIB_EXTENSION));
         Ok(path)
     }
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -72,4 +72,14 @@ impl Language {
                 .join(format!("{}.scm", self.name)),
         )
     }
+
+    #[cfg(test)]
+    pub fn dummy_json_lanuage() -> Self {
+        Self {
+            name: "json",
+            grammar: todo!(),
+            extensions: vec![".json"],
+            indent_level: Some(2),
+        }
+    }
 }

--- a/src/language.rs
+++ b/src/language.rs
@@ -73,12 +73,16 @@ impl Language {
         )
     }
 
+    pub fn ensure_available(&self) -> Result<(), FormatterError> {
+        self.grammar.ensure_available(&self.name)
+    }
+
     #[cfg(test)]
     pub fn dummy_json_lanuage() -> Self {
         Self {
-            name: "json",
+            name: String::from("json"),
             grammar: todo!(),
-            extensions: vec![".json"],
+            extensions: vec![String::from(".json")],
             indent_level: Some(2),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{
     io::{stdin, stdout, BufReader, BufWriter},
     path::{Path, PathBuf},
 };
-use topiary::{configuration::Configuration, formatter, FormatterResult, Language};
+use topiary::{configuration::Configuration, formatter, Language, TopiaryResult};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -42,7 +42,7 @@ fn main() {
     }
 }
 
-fn run() -> FormatterResult<()> {
+fn run() -> TopiaryResult<()> {
     env_logger::init();
     let args = Args::parse();
     let config = Configuration::parse()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,36 +3,18 @@ use std::{
     error::Error,
     fs::File,
     io::{stdin, stdout, BufReader, BufWriter},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 use topiary::{configuration::Configuration, formatter, FormatterResult, Language};
-
-#[derive(ArgEnum, Clone, Copy, Debug)]
-enum SupportedLanguage {
-    Json,
-    Toml,
-    // Any other entries in crate::Language are experimental and won't be
-    // exposed in the CLI. They can be accessed using --query language/foo.scm
-    // instead.
-}
-
-impl From<SupportedLanguage> for &str {
-    fn from(language: SupportedLanguage) -> Self {
-        match language {
-            SupportedLanguage::Json => "json",
-            SupportedLanguage::Toml => "toml",
-        }
-    }
-}
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 // Require at least one of --language, --query or --input-file (n.b., query > language > input)
-#[clap(group(ArgGroup::new("rule").multiple(true).required(true).args(&["language", "query", "input-file"]),))]
+#[clap(group(ArgGroup::new("rule").multiple(true).required(true).args(&["language", "input-file"]),))]
 struct Args {
     /// Which language to parse and format
-    #[clap(short, long, arg_enum)]
-    language: Option<SupportedLanguage>,
+    #[clap(short, long)]
+    language: Option<String>,
 
     /// Which query file to use
     #[clap(short, long)]
@@ -63,33 +45,43 @@ fn main() {
 fn run() -> FormatterResult<()> {
     env_logger::init();
     let args = Args::parse();
-    let config = Configuration::parse();
+    let config = Configuration::parse()?;
     // The as_deref() gives us an Option<&str>, which we can match against
     // string literals
-    //    let mut input: Box<dyn std::io::Read> = match args.input_file.as_deref() {
-    //        Some("-") | None => Box::new(stdin()),
-    //        Some(file) => Box::new(BufReader::new(File::open(file)?)),
-    //    };
-    //
-    //    let mut output: Box<dyn std::io::Write> = match args.output_file.as_deref() {
-    //        Some("-") | None => Box::new(stdout()),
-    //        Some(file) => Box::new(BufWriter::new(File::open(file)?)),
-    //    };
-    //
-    //    let query_path = if let Some(query) = args.query {
-    //        query
-    //    } else if let Some(language) = args.language {
-    //        Language::query_path(language.into())?
-    //    } else if let Some(file) = args.input_file.as_deref() {
-    //        Language::query_path(Language::detect(file)?)?
-    //    } else {
-    //        // Clap ensures we won't get here
-    //        unreachable!();
-    //    };
-    //
-    //    let mut query = BufReader::new(File::open(query_path)?);
-    //
-    //    formatter(&mut input, &mut output, &mut query, args.skip_idempotence)?;
+    let mut input: Box<dyn std::io::Read> = match args.input_file.as_deref() {
+        Some("-") | None => Box::new(stdin()),
+        Some(file) => Box::new(BufReader::new(File::open(file)?)),
+    };
+
+    let mut output: Box<dyn std::io::Write> = match args.output_file.as_deref() {
+        Some("-") | None => Box::new(stdout()),
+        Some(file) => Box::new(BufWriter::new(File::open(file)?)),
+    };
+
+    let language = if let Some(language_name) = args.language {
+        config.find_language_by_name(&language_name)
+    } else if let Some(file) = args.input_file {
+        config.find_language_by_extension(&PathBuf::from(file))
+    } else {
+        // Clap ensures we won't get here
+        unreachable!();
+    };
+
+    let query_path = if let Some(query) = args.query {
+        query
+    } else {
+        Language::query_path(&language)?
+    };
+
+    let mut query = BufReader::new(File::open(query_path)?);
+
+    formatter(
+        &mut input,
+        &mut output,
+        &mut query,
+        args.skip_idempotence,
+        &language,
+    )?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{
     io::{stdin, stdout, BufReader, BufWriter},
     path::PathBuf,
 };
-use topiary::{formatter, FormatterResult, Language};
+use topiary::{configuration::Configuration, formatter, FormatterResult, Language};
 
 #[derive(ArgEnum, Clone, Copy, Debug)]
 enum SupportedLanguage {
@@ -63,33 +63,33 @@ fn main() {
 fn run() -> FormatterResult<()> {
     env_logger::init();
     let args = Args::parse();
-
+    let config = Configuration::parse();
     // The as_deref() gives us an Option<&str>, which we can match against
     // string literals
-    let mut input: Box<dyn std::io::Read> = match args.input_file.as_deref() {
-        Some("-") | None => Box::new(stdin()),
-        Some(file) => Box::new(BufReader::new(File::open(file)?)),
-    };
-
-    let mut output: Box<dyn std::io::Write> = match args.output_file.as_deref() {
-        Some("-") | None => Box::new(stdout()),
-        Some(file) => Box::new(BufWriter::new(File::open(file)?)),
-    };
-
-    let query_path = if let Some(query) = args.query {
-        query
-    } else if let Some(language) = args.language {
-        Language::query_path(language.into())?
-    } else if let Some(file) = args.input_file.as_deref() {
-        Language::query_path(Language::detect(file)?)?
-    } else {
-        // Clap ensures we won't get here
-        unreachable!();
-    };
-
-    let mut query = BufReader::new(File::open(query_path)?);
-
-    formatter(&mut input, &mut output, &mut query, args.skip_idempotence)?;
+    //    let mut input: Box<dyn std::io::Read> = match args.input_file.as_deref() {
+    //        Some("-") | None => Box::new(stdin()),
+    //        Some(file) => Box::new(BufReader::new(File::open(file)?)),
+    //    };
+    //
+    //    let mut output: Box<dyn std::io::Write> = match args.output_file.as_deref() {
+    //        Some("-") | None => Box::new(stdout()),
+    //        Some(file) => Box::new(BufWriter::new(File::open(file)?)),
+    //    };
+    //
+    //    let query_path = if let Some(query) = args.query {
+    //        query
+    //    } else if let Some(language) = args.language {
+    //        Language::query_path(language.into())?
+    //    } else if let Some(file) = args.input_file.as_deref() {
+    //        Language::query_path(Language::detect(file)?)?
+    //    } else {
+    //        // Clap ensures we won't get here
+    //        unreachable!();
+    //    };
+    //
+    //    let mut query = BufReader::new(File::open(query_path)?);
+    //
+    //    formatter(&mut input, &mut output, &mut query, args.skip_idempotence)?;
 
     Ok(())
 }

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -1,7 +1,7 @@
-use crate::{Atom, FormatterResult};
+use crate::{Atom, TopiaryResult};
 use pretty::RcDoc;
 
-pub fn render(atoms: &[Atom], indent_level: isize) -> FormatterResult<String> {
+pub fn render(atoms: &[Atom], indent_level: isize) -> TopiaryResult<String> {
     let doc = atoms_to_doc(&mut 0, atoms, indent_level);
     let mut rendered = String::new();
     doc.render_fmt(usize::max_value(), &mut rendered)?;

--- a/src/project_dirs.rs
+++ b/src/project_dirs.rs
@@ -1,0 +1,8 @@
+use directories::ProjectDirs;
+
+// TODO: unwrap?
+
+lazy_static! {
+    pub static ref TOPIARY_DIRS: ProjectDirs =
+        ProjectDirs::from("com", "Tweag", "Topiary").unwrap();
+}

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -84,6 +84,8 @@ fn capture_name<'a, 'b>(query: &'a Query, capture: &'b QueryCapture) -> &'a str 
 }
 
 fn grammar(language: &Language) -> tree_sitter::Language {
+    let _grammar_path = language.grammar_path();
+    language.ensure_available();
     todo!()
 }
 

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -14,7 +14,7 @@ pub fn apply_query(
     query_content: &str,
     language: &Language,
 ) -> FormatterResult<AtomCollection> {
-    let grammar = grammar(language);
+    let grammar = language.get_tree_sitter_language()?;
     let tree = parse(input_content, grammar)?;
     let root = tree.root_node();
     let source = input_content.as_bytes();
@@ -81,12 +81,6 @@ pub fn apply_query(
 
 fn capture_name<'a, 'b>(query: &'a Query, capture: &'b QueryCapture) -> &'a str {
     query.capture_names()[capture.index as usize].as_str()
-}
-
-fn grammar(language: &Language) -> tree_sitter::Language {
-    let _grammar_path = language.grammar_path();
-    language.ensure_available();
-    todo!()
 }
 
 fn parse(content: &str, grammar: tree_sitter::Language) -> FormatterResult<Tree> {

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -1,3 +1,5 @@
+//! Tree-sitter API related functions.
+//! Notably, this module is not responsible for managing the actual grammars.
 use crate::atom_collection::AtomCollection;
 use crate::error::FormatterError;
 use crate::language::Language;
@@ -10,7 +12,7 @@ use tree_sitter::{
 pub fn apply_query(
     input_content: &str,
     query_content: &str,
-    language: Language,
+    language: &Language,
 ) -> FormatterResult<AtomCollection> {
     let grammar = grammar(language);
     let tree = parse(input_content, grammar)?;
@@ -81,14 +83,8 @@ fn capture_name<'a, 'b>(query: &'a Query, capture: &'b QueryCapture) -> &'a str 
     query.capture_names()[capture.index as usize].as_str()
 }
 
-fn grammar(language: Language) -> tree_sitter::Language {
-    match language {
-        Language::Bash => tree_sitter_bash::language(),
-        Language::Json => tree_sitter_json::language(),
-        Language::Ocaml => tree_sitter_ocaml::language_ocaml(),
-        Language::Rust => tree_sitter_rust::language(),
-        Language::Toml => tree_sitter_toml::language(),
-    }
+fn grammar(language: &Language) -> tree_sitter::Language {
+    todo!()
 }
 
 fn parse(content: &str, grammar: tree_sitter::Language) -> FormatterResult<Tree> {

--- a/tests/sample-tester.rs
+++ b/tests/sample-tester.rs
@@ -14,22 +14,23 @@ fn input_output_tester() {
         let file = file.unwrap();
 
         let input_path = file.path();
-        let language =
-            Language::detect(input_path.to_str().unwrap()).unwrap_or_else(|err| panic!("{err}"));
+        todo!();
+        //let language =
+        //Language::detect(input_path.to_str().unwrap()).unwrap_or_else(|err| panic!("{err}"));
 
-        let expected_path = expected_dir.join(file.file_name());
-        let expected = fs::read_to_string(expected_path).unwrap();
+        //let expected_path = expected_dir.join(file.file_name());
+        //let expected = fs::read_to_string(expected_path).unwrap();
 
-        let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
-        let mut output = Vec::new();
-        let query_path = str::to_lowercase(format!("languages/{language}.scm").as_str());
-        let query = fs::read_to_string(query_path).unwrap();
-        let mut query = query.as_bytes();
+        //let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
+        //let mut output = Vec::new();
+        //let query_path = str::to_lowercase(format!("languages/{language}.scm").as_str());
+        //let query = fs::read_to_string(query_path).unwrap();
+        //let mut query = query.as_bytes();
 
-        formatter(&mut input, &mut output, &mut query, true).unwrap();
-        let formatted = String::from_utf8(output).unwrap();
-        log::debug!("{}", formatted);
+        //formatter(&mut input, &mut output, &mut query, true).unwrap();
+        //let formatted = String::from_utf8(output).unwrap();
+        //log::debug!("{}", formatted);
 
-        assert_eq!(expected, formatted);
+        //assert_eq!(expected, formatted);
     }
 }


### PR DESCRIPTION
This PR is very early stage. Below are two lists; one for things that are required for a merge, one for optional improvements.

Required:
- [ ] Integrate the entire thing with FormatterResult/Error
- [ ] Resolve all of the TODO's introduced.
- [ ] Documentation
- [ ] Consolidate Configuration and LanguageDetection errors
- [ ] Have a builtin default configuration file, this is also what Helix does
- [ ] Pass CI ;)

Optional:
- [ ] Don't use `Repository::open` to test for availability.
- [ ] Allow some way for parsers to be present without their source-code. This would pave the way to providing the parsers via Nix.