### PR TITLE
[OCaml] spacing before `::` when preceded by labeled argument

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -529,6 +529,24 @@
   ">" @prepend_space
 )
 
+; Keep spacing around the list constructor if it is preceded by
+; a labeled argument, avoiding syntax errors.
+;
+; This is syntactically correct:
+;   foo ~arg :: []
+; This is not:
+;   foo ~arg::[]
+;
+; While both are correct if the argument is not labeled
+(
+  (application_expression
+    (labeled_argument)
+    .
+  )
+  .
+  "::" @prepend_space @append_space
+)
+
 ; Softlines. These become either a space or a newline, depending on whether we
 ; format their node as single-line or multi-line. If there is a comment
 ; following, we don't add anything, because they will have their own line break

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -531,6 +531,10 @@ let unbox_bool = function
 let my_const :
   type a b. a: a -> b: b -> a = fun ~a ~b -> a
 
+let my_id ~value = value
+
+let into_list ~value = my_id ~value :: []
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -532,6 +532,10 @@ let my_const :
   type a b. a: a -> b: b -> a =
   fun ~a ~b -> a
 
+let my_id ~value = value
+
+let into_list ~value = my_id ~value :: []
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind


### PR DESCRIPTION
Allows correct formatting of the following:
```
let into_list ~value = my_id ~value :: []
```