### PR TITLE
[OCaml] spacing in object signatures

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -473,6 +473,18 @@
   (_)
 )
 
+; Keep spacing between pointy brackets when used in object types.
+;
+; This is syntactically correct:
+;   let obj_id (obj : < .. >) = obj
+; This is not:
+;   let obj_id (obj : <..>) = obj
+(object_type
+  "<" @append_space
+  (_)*
+  ">" @prepend_space
+)
+
 ; Softlines. These become either a space or a newline, depending on whether we
 ; format their node as single-line or multi-line. If there is a comment
 ; following, we don't add anything, because they will have their own line break

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -623,6 +623,12 @@ let (Some 2) =
   my_stack#push 2;
   my_stack#pop
 
+let obj_id (obj : < .. >) = obj
+
+let obj_with_unit_id (obj : < nothing: unit; .. >) = obj
+
+let obj_with_only_unit_id (obj : < nothing: unit >) = obj
+
 (* Some modules and functors *)
 module type T1 = sig
   type t = private int64

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -623,6 +623,12 @@ let (Some 2) =
   my_stack#push 2;
   my_stack#pop
 
+let obj_id (obj : < .. >) = obj
+
+let obj_with_unit_id (obj : < nothing: unit; .. >) = obj
+
+let obj_with_only_unit_id (obj : < nothing: unit >) = obj
+
 (* Some modules and functors *)
 module type T1 = sig
   type t = private int64


### PR DESCRIPTION
Allows correct formatting of the following:
```
let obj_id (obj : < .. >) = obj
let obj_with_unit_id (obj : < nothing: unit; .. >) = obj
let obj_with_only_unit_id (obj : < nothing: unit >) = obj
```