### PR TITLE
draft:[OCaml] support of ppx syntax

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -89,64 +89,69 @@
 )
 
 ; Surround spaces
-; A space is put after, and before (except just after an open parenthesis).
-[
-  "and"
-  "as"
-  "assert"
-  (attribute)
-  (attribute_id)
-  "class"
-  "downto"
-  "else"
-  "exception"
-  (extension)
-  "external"
-  (floating_attribute)
-  "for"
-  "if"
-  "in"
-  "include"
-  (infix_operator)
-  "inherit"
-  (item_attribute)
-  "let"
-  "match"
-  "method"
-  "module"
-  (module_parameter)
-  "mutable"
-  "new"
-  "nonrec"
-  "object"
-  "of"
-  "open"
-  (parameter)
-  "private"
-  "rec"
-  "sig"
-  "then"
-  "to"
-  "try"
-  "type"
-  "val"
-  "virtual"
-  "when"
-  "while"
-  "with"
-  "*"
-  "="
-  "|"
-  "||"
-  "->"
-  "<-"
-  "{"
-  "}"
-  ":"
-  ";"
-  "+="
-  ":="
-] @append_space
+; A space is put after (except just before a '%', which indicates ppx syntax),
+; and before (except just after an open parenthesis).
+(
+  [
+    "and"
+    "as"
+    "assert"
+    (attribute)
+    (attribute_id)
+    "class"
+    "downto"
+    "else"
+    "exception"
+    (extension)
+    "external"
+    (floating_attribute)
+    "for"
+    "if"
+    "in"
+    "include"
+    (infix_operator)
+    "inherit"
+    (item_attribute)
+    "let"
+    "match"
+    "method"
+    "module"
+    (module_parameter)
+    "mutable"
+    "new"
+    "nonrec"
+    "object"
+    "of"
+    "open"
+    (parameter)
+    "private"
+    "rec"
+    "sig"
+    "then"
+    "to"
+    "try"
+    "type"
+    "val"
+    "virtual"
+    "when"
+    "while"
+    "with"
+    "*"
+    "="
+    "|"
+    "||"
+    "->"
+    "<-"
+    "{"
+    "}"
+    ":"
+    ";"
+    "+="
+    ":="
+  ] @append_space
+  .
+  "%"* @do_nothing
+)
 
 ; Those keywords are not expected to come right after an open parenthesis.
 [

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -20,6 +20,7 @@
   (comment)
   (exception_definition)
   (external)
+  (floating_attribute)
   (include_module)
   (include_module_type)
   (inheritance_definition)
@@ -93,17 +94,22 @@
   "and"
   "as"
   "assert"
+  (attribute)
+  (attribute_id)
   "class"
   "downto"
   "else"
   "exception"
+  (extension)
   "external"
+  (floating_attribute)
   "for"
   "if"
   "in"
   "include"
   (infix_operator)
   "inherit"
+  (item_attribute)
   "let"
   "match"
   "method"
@@ -192,6 +198,11 @@
 (
   "("* @do_nothing
   .
+  (attribute) @prepend_space
+)
+(
+  "("* @do_nothing
+  .
   "begin" @prepend_space
 )
 (
@@ -207,7 +218,17 @@
 (
   "("* @do_nothing
   .
+  (extension) @prepend_space
+)
+(
+  "("* @do_nothing
+  .
   "external" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  (floating_attribute) @prepend_space
 )
 (
   "("* @do_nothing
@@ -228,6 +249,11 @@
   "("* @do_nothing
   .
   "inherit" @prepend_space
+)
+(
+  "("* @do_nothing
+  .
+  (item_attribute) @prepend_space
 )
 (
   "("* @do_nothing

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -649,3 +649,14 @@ module F (X: T1) (Y: T1 with type t := X.t) = struct
 
   include M
 end
+
+(* Showcase of ppx syntax *)
+let _ = [%ext fun () -> ()]
+
+let _ = 12 [@attr pl]
+
+let _ = "some string" [@@attr pl]
+
+[@@@attr pl]
+
+let%ext _ = ()

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -649,3 +649,14 @@ module F (X: T1) (Y: T1 with type t := X.t) = struct
 
   include M
 end
+
+(* Showcase of ppx syntax *)
+let _ = [%ext fun () -> ()]
+
+let _ = 12 [@attr pl]
+
+let _ = "some string" [@@attr pl]
+
+[@@@attr pl]
+
+let%ext _ = ()


### PR DESCRIPTION
Allows correct formatting of the following:
```
let _ = [%ext fun () -> ()]

let _ = 12 [@attr pl]

let _ = "some string" [@@attr pl]

[@@@attr pl]

let%ext _ = ()
```
