### PR TITLE
[OCaml] fix several spacing issues

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -438,6 +438,7 @@
     (parenthesized_pattern)
     (prefix_expression)
     (quoted_string)
+    (range_pattern)
     (string)
     (tag)
     (type_constructor_path)

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -428,6 +428,7 @@
     (class_type_path)
     (constructed_type)
     (constructor_path)
+    (constructor_pattern)
     (extended_module_path)
     (field_get_expression)
     (local_open_pattern)

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -145,6 +145,7 @@
     ";"
     "+="
     ":="
+    ":>"
   ] @append_space
   .
   "%"? @do_nothing
@@ -171,6 +172,7 @@
     "<-"
     "+="
     ":="
+    ":>"
 ] @prepend_space
 
 ; let-like and and-like operators are only followed by a closing parenthesis

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -528,6 +528,10 @@ let unbox_bool = function
   | Some true -> true
   | _ -> false
 
+let is_some_letter = function
+  | Some 'a'..'z' -> true
+  | _ -> false
+
 let my_const :
   type a b. a: a -> b: b -> a = fun ~a ~b -> a
 

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -532,6 +532,10 @@ let is_some_letter = function
   | Some 'a'..'z' -> true
   | _ -> false
 
+let is_some_some = function
+  | Some Some _ -> true
+  | _ -> false
+
 let my_const :
   type a b. a: a -> b: b -> a = fun ~a ~b -> a
 

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -578,6 +578,9 @@ type my_box = [`Foo of int | `Bar of int]
 let unbox = function
   | `Foo a | `Bar a -> a
 
+(* Type coercion *)
+let _ = (`Foo 4 :> [`Foo of int])
+
 (* function signature containing type variables *)
 let my_const : 'a 'b. 'a -> 'b -> 'a = Fun.const
 

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -528,6 +528,10 @@ let unbox_bool = function
   | Some true -> true
   | _ -> false
 
+let is_some_letter = function
+  | Some 'a'..'z' -> true
+  | _ -> false
+
 let my_const :
   type a b. a: a -> b: b -> a =
   fun ~a ~b -> a

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -532,6 +532,10 @@ let is_some_letter = function
   | Some 'a'..'z' -> true
   | _ -> false
 
+let is_some_some = function
+  | Some Some _ -> true
+  | _ -> false
+
 let my_const :
   type a b. a: a -> b: b -> a =
   fun ~a ~b -> a

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -579,6 +579,9 @@ type my_box = [`Foo of int | `Bar of int]
 let unbox = function
   | `Foo a | `Bar a -> a
 
+(* Type coercion *)
+let _ = (`Foo 4 :> [`Foo of int])
+
 (* function signature containing type variables *)
 let my_const : 'a 'b. 'a -> 'b -> 'a = Fun.const
 


### PR DESCRIPTION
This PR fixes spacing issues in OCaml with
- the type coercion operator `:>`,
- the range pattern `'a'..'z'`,
- nested constructor patterns.