### PR TITLE
@prepend_hardline and further documentation of different newline types

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,23 +362,23 @@ newline in the input. Otherwise, they are rendered as spaces.
 
 #### Example
 
-Consider the following JSON:
+Consider the following JSON, which has been hand-formatted to exhibit
+every context under which the different newline capture names operate:
 
 ```json
 {
   "single-line": [1, 2, 3],
   "multi-line": [
-    1,
-    2,
+    1, 2,
     3
   ]
 }
 ```
 
 We'll apply a simplified set of JSON format queries that:
-* Opens (and closes) an indented block for objects;
-* Each key-value pair gets its own line, with the value split onto a second;
-* Applies the different newline capture name on array delimiters.
+1. Opens (and closes) an indented block for objects;
+2. Each key-value pair gets its own line, with the value split onto a second;
+3. Applies the different newline capture name on array delimiters.
 
 That is, iterating over each `@NEWLINE` type, we apply the following:
 
@@ -392,6 +392,9 @@ That is, iterating over each `@NEWLINE` type, we apply the following:
 
 (array "," @NEWLINE)
 ```
+
+The first two formatting rules are just for clarity's sake. The last
+rule is what's important and demonstrated below:
 
 ##### `@append_hardline`
 
@@ -482,8 +485,7 @@ That is, iterating over each `@NEWLINE` type, we apply the following:
   "single-line":
   [1, 2, 3],
   "multi-line":
-  [1,
-  2,
+  [1, 2,
   3]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -362,103 +362,141 @@ newline in the input. Otherwise, they are rendered as spaces.
 
 #### Example
 
-Consider the following pseudocode:
+Consider the following JSON:
 
-```bash
-# This is a comment
-
-# Here's another comment
-some_syntax # Yet another comment
+```json
+{
+  "single-line": [1, 2, 3],
+  "multi-line": [
+    1,
+    2,
+    3
+  ]
+}
 ```
 
-We shall apply the different newline captures to syntactic items and
-comments, respectively, to observe their effect. That is, for each
-`@CAPTURE` name, we apply the following query:
+We'll apply a simplified set of JSON format queries that:
+* Opens (and closes) an indented block for objects;
+* Each key-value pair gets its own line, with the value split onto a second;
+* Applies the different newline capture name on array delimiters.
+
+That is, iterating over each `@NEWLINE` type, we apply the following:
 
 ```scheme
-(_ [(syntax_node) (comment)] @CAPTURE)
+(#language! json)
+
+(object . "{" @append_hardline @append_indent_start)
+(object "}" @prepend_hardline @prepend_indent_end .)
+(object (pair) @prepend_hardline)
+(pair . _ ":" @append_hardline)
+
+(array "," @NEWLINE)
 ```
-
-**Notes**
-
-1. The query is embedded with respect to an arbitrary parent node to
-   "escape" any multi-line context that may be inherited from that
-   parent.
-
-2. Trailing newlines, in the output, have been replaced with `␊` so they
-   are not stripped out by GitHub's markdown rendering.
 
 ##### `@append_hardline`
 
-```bash
-# This is a comment
-# Here's another comment
-some_syntax
-# Yet another comment
-␊
+```json
+{
+  "single-line":
+  [1,
+  2,
+  3],
+  "multi-line":
+  [1,
+  2,
+  3]
+}
 ```
 
 ##### `@prepend_hardline`
 
-```bash
-# This is a comment
-# Here's another comment
-some_syntax
-# Yet another comment
+```json
+{
+  "single-line":
+  [1
+  ,2
+  ,3],
+  "multi-line":
+  [1
+  ,2
+  ,3]
+}
 ```
 
 ##### `@append_empty_softline`
 
-```bash
-# This is a comment
-# Here's another comment
-some_syntax
-# Yet another comment
-␊
+```json
+{
+  "single-line":
+  [1,2,3],
+  "multi-line":
+  [1,
+  2,
+  3]
+}
 ```
 
 ##### `@prepend_empty_softline`
 
-```bash
-# This is a comment
-# Here's another comment
-some_syntax
-# Yet another comment
+```json
+{
+  "single-line":
+  [1,2,3],
+  "multi-line":
+  [1
+  ,2
+  ,3]
+}
 ```
 
 ##### `@append_spaced_softline`
 
-```bash
-# This is a comment
-# Here's another comment
-some_syntax
-# Yet another comment
-␊
+```json
+{
+  "single-line":
+  [1, 2, 3],
+  "multi-line":
+  [1,
+  2,
+  3]
+}
 ```
 
 ##### `@prepend_spaced_softline`
 
-```bash
-# This is a comment
-# Here's another comment
-some_syntax
-# Yet another comment
+```json
+{
+  "single-line":
+  [1 ,2 ,3],
+  "multi-line":
+  [1
+  ,2
+  ,3]
+}
 ```
 
 ##### `@append_input_softline`
 
-```bash
-# This is a comment
-# Here's another comment
-some_syntax # Yet another comment
+```json
+{
+  "single-line":
+  [1, 2, 3],
+  "multi-line":
+  [1,
+  2,
+  3]
+}
 ```
 
 ##### `@prepend_input_softline`
 
-```bash
-# This is a comment
-# Here's another comment
-some_syntax # Yet another comment
+```json
+{
+  "single-line":
+  [1 ,2 ,3],
+  "multi-line":
+  [1 ,2 ,3]
+}
 ```
 
 ## Suggested workflow

--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ single-line nodes.
 )
 ```
 
-### @append_hardline
+### @append_hardline / @prepend_hardline
 
-The matched nodes will have a newline appended to them.
+The matched nodes will have a newline appended or prepended to them.
 
 #### Example
 
@@ -350,12 +350,12 @@ be ignored.
 
 ### Understanding the different newline captures
 
-| Type            | Append/Prepend | Single-Line Context | Multi-Line Context |
-| :-------------- | :------------- | :------------------ | :----------------- |
-| Hardline        | Append Only    | Newline             | Newline            |
-| Empty Softline  | Both           | Nothing             | Newline            |
-| Spaced Softline | Both           | Space               | Newline            |
-| Input Softline  | Both           | Input-Dependent     | Input-Dependent    |
+| Type            | Single-Line Context | Multi-Line Context |
+| :-------------- | :------------------ | :----------------- |
+| Hardline        | Newline             | Newline            |
+| Empty Softline  | Nothing             | Newline            |
+| Spaced Softline | Space               | Newline            |
+| Input Softline  | Input-Dependent     | Input-Dependent    |
 
 "Input softlines" are rendered as newlines whenever they proceed a
 newline in the input. Otherwise, they are rendered as spaces.
@@ -391,6 +391,15 @@ stripped by GitHub's markdown rendering.)
 some_syntax
 # Yet another comment
 ␊
+```
+
+##### `@prepend_hardline`
+
+```bash
+# This is a comment
+# Here's another comment
+some_syntax
+# Yet another comment
 ```
 
 ##### `@append_empty_softline`

--- a/README.md
+++ b/README.md
@@ -373,23 +373,27 @@ some_syntax # Yet another comment
 
 We shall apply the different newline captures to syntactic items and
 comments, respectively, to observe their effect. That is, for each
-`@CAPTURE` name, we apply the following queries:
+`@CAPTURE` name, we apply the following query:
 
 ```scheme
-(syntax_node) @CAPTURE
-(comment) @CAPTURE
+(_ [(syntax_node) (comment)] @CAPTURE)
 ```
 
-(Note that trailing newlines have been replaced with `␊` so they are not
-stripped by GitHub's markdown rendering.)
+**Notes**
+
+1. The query is embedded with respect to an arbitrary parent node to
+   "escape" any multi-line context that may be inherited from that
+   parent.
+
+2. Trailing newlines, in the output, have been replaced with `␊` so they
+   are not stripped out by GitHub's markdown rendering.
 
 ##### `@append_hardline`
 
 ```bash
 # This is a comment
 # Here's another comment
-some_syntax
-# Yet another comment
+some_syntax# Yet another comment
 ␊
 ```
 
@@ -397,8 +401,7 @@ some_syntax
 
 ```bash
 # This is a comment
-# Here's another comment
-some_syntax
+# Here's another commentsome_syntax
 # Yet another comment
 ```
 
@@ -407,8 +410,7 @@ some_syntax
 ```bash
 # This is a comment
 # Here's another comment
-some_syntax
-# Yet another comment
+some_syntax# Yet another comment
 ␊
 ```
 
@@ -416,8 +418,7 @@ some_syntax
 
 ```bash
 # This is a comment
-# Here's another comment
-some_syntax
+# Here's another commentsome_syntax
 # Yet another comment
 ```
 
@@ -426,8 +427,7 @@ some_syntax
 ```bash
 # This is a comment
 # Here's another comment
-some_syntax
-# Yet another comment
+some_syntax# Yet another comment
 ␊
 ```
 
@@ -435,8 +435,7 @@ some_syntax
 
 ```bash
 # This is a comment
-# Here's another comment
-some_syntax
+# Here's another commentsome_syntax
 # Yet another comment
 ```
 
@@ -445,15 +444,14 @@ some_syntax
 ```bash
 # This is a comment
 # Here's another comment
-some_syntax # Yet another comment
+some_syntax# Yet another comment
 ```
 
 ##### `@prepend_input_softline`
 
 ```bash
 # This is a comment
-# Here's another comment
-some_syntax # Yet another comment
+# Here's another commentsome_syntax # Yet another comment
 ```
 
 ## Suggested workflow

--- a/README.md
+++ b/README.md
@@ -393,7 +393,8 @@ comments, respectively, to observe their effect. That is, for each
 ```bash
 # This is a comment
 # Here's another comment
-some_syntax# Yet another comment
+some_syntax
+# Yet another comment
 ␊
 ```
 
@@ -401,7 +402,8 @@ some_syntax# Yet another comment
 
 ```bash
 # This is a comment
-# Here's another commentsome_syntax
+# Here's another comment
+some_syntax
 # Yet another comment
 ```
 
@@ -410,7 +412,8 @@ some_syntax# Yet another comment
 ```bash
 # This is a comment
 # Here's another comment
-some_syntax# Yet another comment
+some_syntax
+# Yet another comment
 ␊
 ```
 
@@ -418,7 +421,8 @@ some_syntax# Yet another comment
 
 ```bash
 # This is a comment
-# Here's another commentsome_syntax
+# Here's another comment
+some_syntax
 # Yet another comment
 ```
 
@@ -427,7 +431,8 @@ some_syntax# Yet another comment
 ```bash
 # This is a comment
 # Here's another comment
-some_syntax# Yet another comment
+some_syntax
+# Yet another comment
 ␊
 ```
 
@@ -435,7 +440,8 @@ some_syntax# Yet another comment
 
 ```bash
 # This is a comment
-# Here's another commentsome_syntax
+# Here's another comment
+some_syntax
 # Yet another comment
 ```
 
@@ -444,14 +450,15 @@ some_syntax# Yet another comment
 ```bash
 # This is a comment
 # Here's another comment
-some_syntax# Yet another comment
+some_syntax # Yet another comment
 ```
 
 ##### `@prepend_input_softline`
 
 ```bash
 # This is a comment
-# Here's another commentsome_syntax # Yet another comment
+# Here's another comment
+some_syntax # Yet another comment
 ```
 
 ## Suggested workflow

--- a/README.md
+++ b/README.md
@@ -357,8 +357,8 @@ be ignored.
 | Spaced Softline | Space               | Newline            |
 | Input Softline  | Input-Dependent     | Input-Dependent    |
 
-"Input softlines" are rendered as newlines whenever they follow a
-newline in the input. Otherwise, they are rendered as spaces.
+"Input softlines" are rendered as newlines whenever the targeted node
+follows a newline in the input. Otherwise, they are rendered as spaces.
 
 #### Example
 
@@ -367,10 +367,11 @@ every context under which the different newline capture names operate:
 
 ```json
 {
-  "single-line": [1, 2, 3],
+  "single-line": [1, 2, 3, 4],
   "multi-line": [
     1, 2,
     3
+    , 4
   ]
 }
 ```
@@ -394,7 +395,7 @@ That is, iterating over each `@NEWLINE` type, we apply the following:
 ```
 
 The first two formatting rules are just for clarity's sake. The last
-rule is what's important and demonstrated below:
+rule is what's important; the results of which are demonstrated below:
 
 ##### `@append_hardline`
 
@@ -403,11 +404,13 @@ rule is what's important and demonstrated below:
   "single-line":
   [1,
   2,
-  3],
+  3,
+  4],
   "multi-line":
   [1,
   2,
-  3]
+  3,
+  4]
 }
 ```
 
@@ -418,11 +421,13 @@ rule is what's important and demonstrated below:
   "single-line":
   [1
   ,2
-  ,3],
+  ,3
+  ,4],
   "multi-line":
   [1
   ,2
-  ,3]
+  ,3
+  ,4]
 }
 ```
 
@@ -431,11 +436,12 @@ rule is what's important and demonstrated below:
 ```json
 {
   "single-line":
-  [1,2,3],
+  [1,2,3,4],
   "multi-line":
   [1,
   2,
-  3]
+  3,
+  4]
 }
 ```
 
@@ -444,11 +450,12 @@ rule is what's important and demonstrated below:
 ```json
 {
   "single-line":
-  [1,2,3],
+  [1,2,3,4],
   "multi-line":
   [1
   ,2
-  ,3]
+  ,3
+  ,4]
 }
 ```
 
@@ -457,11 +464,12 @@ rule is what's important and demonstrated below:
 ```json
 {
   "single-line":
-  [1, 2, 3],
+  [1, 2, 3, 4],
   "multi-line":
   [1,
   2,
-  3]
+  3,
+  4]
 }
 ```
 
@@ -470,11 +478,12 @@ rule is what's important and demonstrated below:
 ```json
 {
   "single-line":
-  [1 ,2 ,3],
+  [1 ,2 ,3 ,4],
   "multi-line":
   [1
   ,2
-  ,3]
+  ,3
+  ,4]
 }
 ```
 
@@ -483,10 +492,10 @@ rule is what's important and demonstrated below:
 ```json
 {
   "single-line":
-  [1, 2, 3],
+  [1, 2, 3, 4],
   "multi-line":
   [1, 2,
-  3]
+  3, 4]
 }
 ```
 
@@ -495,9 +504,10 @@ rule is what's important and demonstrated below:
 ```json
 {
   "single-line":
-  [1 ,2 ,3],
+  [1 ,2 ,3 ,4],
   "multi-line":
-  [1 ,2 ,3]
+  [1 ,2 ,3
+  ,4]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ be ignored.
 | Spaced Softline | Space               | Newline            |
 | Input Softline  | Input-Dependent     | Input-Dependent    |
 
-"Input softlines" are rendered as newlines whenever they proceed a
+"Input softlines" are rendered as newlines whenever they follow a
 newline in the input. Otherwise, they are rendered as spaces.
 
 #### Example

--- a/README.md
+++ b/README.md
@@ -348,6 +348,105 @@ be ignored.
 )
 ```
 
+### Understanding the different newline captures
+
+| Type            | Append/Prepend | Single-Line Context | Multi-Line Context |
+| :-------------- | :------------- | :------------------ | :----------------- |
+| Hardline        | Append Only    | Newline             | Newline            |
+| Empty Softline  | Both           | Nothing             | Newline            |
+| Spaced Softline | Both           | Space               | Newline            |
+| Input Softline  | Both           | Input-Dependent     | Input-Dependent    |
+
+"Input softlines" are rendered as newlines whenever they proceed a
+newline in the input. Otherwise, they are rendered as spaces.
+
+#### Example
+
+Consider the following pseudocode:
+
+```bash
+# This is a comment
+
+# Here's another comment
+some_syntax # Yet another comment
+```
+
+We shall apply the different newline captures to syntactic items and
+comments, respectively, to observe their effect. That is, for each
+`@CAPTURE` name, we apply the following queries:
+
+```scheme
+(syntax_node) @CAPTURE
+(comment) @CAPTURE
+```
+
+(Note that trailing newlines have been replaced with `␊` so they are not
+stripped by GitHub's markdown rendering.)
+
+##### `@append_hardline`
+
+```bash
+# This is a comment
+# Here's another comment
+some_syntax
+# Yet another comment
+␊
+```
+
+##### `@append_empty_softline`
+
+```bash
+# This is a comment
+# Here's another comment
+some_syntax
+# Yet another comment
+␊
+```
+
+##### `@prepend_empty_softline`
+
+```bash
+# This is a comment
+# Here's another comment
+some_syntax
+# Yet another comment
+```
+
+##### `@append_spaced_softline`
+
+```bash
+# This is a comment
+# Here's another comment
+some_syntax
+# Yet another comment
+␊
+```
+
+##### `@prepend_spaced_softline`
+
+```bash
+# This is a comment
+# Here's another comment
+some_syntax
+# Yet another comment
+```
+
+##### `@append_input_softline`
+
+```bash
+# This is a comment
+# Here's another comment
+some_syntax # Yet another comment
+```
+
+##### `@prepend_input_softline`
+
+```bash
+# This is a comment
+# Here's another comment
+some_syntax # Yet another comment
+```
+
 ## Suggested workflow
 
 In order to work productively on query files, the following is one suggested way to work:

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -101,6 +101,7 @@ impl AtomCollection {
                 node,
             ),
             "prepend_empty_softline" => self.prepend(Atom::Softline { spaced: false }, node),
+            "prepend_hardline" => self.prepend(Atom::Hardline, node),
             "prepend_indent_start" => self.prepend(Atom::IndentStart, node),
             "prepend_indent_end" => self.prepend(Atom::IndentEnd, node),
             "prepend_input_softline" => {


### PR DESCRIPTION
This PR implements the `@prepend_hardline` capture group, for completeness' sake, and provides more detailed documentation of the various newline types to aid understanding.

#### To Do
* [x] Better minimal example that more obviously showcases the differences