### PR TITLE
[Bash] More command formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,3 +559,24 @@ In order to work productively on query files, the following is one suggested way
 ```
 
 12. Run `cargo test` again, see if the output is better now, and then go back to step 6.
+
+### Terminal-Based Playground
+
+Nix users may also find the `playground.sh` script to be helpful in
+aiding the interactive development of query files. When run in a
+terminal, it will format the given source input with the requested query
+file, updating the output on any inotify event against those files.
+
+```
+Usage: playground.sh (LANGUAGE | QUERY_FILE) [INPUT_SOURCE]
+
+LANGUAGE can be one of the supported languages (e.g., "ocaml", "rust",
+etc.); alternatively, give the path to the query file itself, as
+QUERY_FILE.
+
+The INPUT_SOURCE is optional. If not specified, it defaults to trying
+to find the bundled integration test input file for the given language.
+```
+
+For example, the playground can be run in a tmux pane, with your editor
+of choice open in another.

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -35,10 +35,14 @@
 ;
 ; FIXME Can this be generalised, or does *every* context need to be
 ; individually enumerated?...
-(program (command) @prepend_spaced_softline @append_hardline)
+(program (command) @prepend_spaced_softline)
 (if_statement _ "then" (command) @prepend_spaced_softline)
 (elif_clause _ "then" (command) @prepend_spaced_softline)
 (else_clause (command) @prepend_spaced_softline)
+
+[(list) (pipeline)] @prepend_empty_softline
+(list ["&&" "||"] @append_space @prepend_space)
+(pipeline ["|" "|&"] @append_space @prepend_space)
 
 ; Space between command line arguments
 (command

--- a/playground.sh
+++ b/playground.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash --packages inotify-tools
+#shellcheck shell=bash
+
+# "Quick-and-Dirty" Topiary Playground
+
+set -euo pipefail
+
+readonly PROGNAME="$(basename "$0")"
+
+fail() {
+  local error="$*"
+
+  cat >&2 <<-EOF
+	Error: ${error}
+
+	Usage: ${PROGNAME} (LANGUAGE | QUERY_FILE) [INPUT_SOURCE]
+
+	LANGUAGE can be one of the supported languages (e.g., "ocaml", "rust",
+	etc.); alternatively, give the path to the query file itself, as
+	QUERY_FILE.
+
+	The INPUT_SOURCE is optional. If not specified, it defaults to trying
+	to find the bundled integration test input file for the given language.
+	EOF
+
+  exit 1
+}
+
+get_sample_input() {
+  local language="$1"
+
+  # Only return the first result, presuming there is one
+  find tests/samples/input -name "${language}.*" \
+  | head -1
+}
+
+main() {
+  local query="${1-}"
+  if ! [[ -e "${query}" ]]; then
+    query="languages/${query}.scm"
+    [[ -e "${query}" ]] || fail "Couldn't find language query file '${query}'"
+  fi
+
+  local language="$(basename --suffix=.scm "${query}")"
+  local input="${2-$(get_sample_input "${language}")}"
+  [[ -e "${input}" ]] || fail "Couldn't find input source file '${input}'"
+
+  while true; do
+    clear
+
+    cat <<-EOF
+		Query File    ${query}
+		Input Source  ${input}
+		$(printf "%${COLUMNS}s" "" | tr " " "-")
+		EOF
+
+    cargo run --quiet -- \
+      --skip-idempotence \
+      --query "${query}" \
+      --input-file "${input}"
+
+    # NOTE We don't wait for specific inotify events because different
+    # editors have different strategies for modifying files
+    inotifywait --quiet "${query}" "${input}"
+  done
+}
+
+main "$@"

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -2,18 +2,19 @@
 
 # Here is a comment
 do_a_thing
-
+produce | consume
 if some_command; then
   do_something
   another_thing --foo --bar
 fi
 
-if [[ -e "/some/file" ]]; then
+if [[ -e "/some/file" ]] || true; then
   foo
 elif ! ((1==0)); then
   bar
-else
   baz
-  quux
+else
+  baz && quux || xyzzy &
 fi
 
+multi | line |& pipeline

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -3,6 +3,7 @@
 # Here is a comment
 
 do_a_thing
+produce | consume
 
 if some_command
 then
@@ -17,6 +18,9 @@ elif !((1==0))
 then
   bar
 else
-    baz
-  quux
+    baz \
+  && quux && xyzzy
 fi
+
+multi \
+| line |& pipeline

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # Here is a comment
-
 do_a_thing
 produce | consume
 
@@ -12,14 +11,15 @@ another_thing --foo    --bar
 fi
 
 
-if [[ -e "/some/file" ]]; then
+if [[ -e "/some/file" ]]|| true; then
   foo
 elif !((1==0))
 then
   bar
+  baz
 else
     baz \
-  && quux && xyzzy
+  && quux || xyzzy&
 fi
 
 multi \


### PR DESCRIPTION
This PR introduces queries that improve support for command, command lists and command pipelines, in aid of #138. It is outputting valid code, but suffers from some (non-blocking, imo) shortfalls:

* The line-spacing is not perfect;
* Multi-line "commands" are collapsed into a single line (see #172)

I have also cleaned-up and checked-in the script -- with documentation -- I created to support interactive query development in the terminal (as a quick-and-dirty alternative to #171); it seems generally useful.