### PR TITLE
[Bash] Loops

### DIFF
--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -90,6 +90,9 @@
 )
 
 ; Surround command list and pipeline delimiters with spaces
+; TODO These rules can be subsumed into the list of symbols that are
+; surrounded by spaces, above; the context is irrelevant.
+; (See https://github.com/tweag/topiary/pull/173#discussion_r1071123588)
 (list
   [
     "&&"

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -1,8 +1,11 @@
 ; Configuration
 (#language! bash)
 
-; Don't modify string literals
-(string) @leaf
+; Don't modify commands and string literals
+[
+ (command)
+ (string)
+] @leaf
 
 ; Allow blank line before
 ; FIXME Blank line spacing around major syntactic blocks is not correct.

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -15,6 +15,7 @@
   (if_statement)
   (list)
   (pipeline)
+  (while_statement)
   ; TODO: etc.
 ] @allow_blank_line_before
 
@@ -30,6 +31,8 @@
   "in"
   "select"
   "then"
+  "until"
+  "while"
   (string)
   ; TODO: etc.
 ] @append_space @prepend_space
@@ -133,9 +136,9 @@
 
 ; Start loops on a new line
 [
-  (for_statement)
   (c_style_for_statement)
-  ; <TODO: etc.>
+  (for_statement)
+  (while_statement)
 ] @prepend_hardline
 
 ; Indentation block between the "do" and the "done"

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -62,10 +62,6 @@
 ; delimiter -- but I've never seen this form in the wild
 (_ [(command) (list) (pipeline)] . "&" @prepend_space)
 
-[(list) (pipeline)] @prepend_empty_softline
-(list ["&&" "||"] @append_space @prepend_space)
-(pipeline ["|" "|&"] @append_space @prepend_space)
-
 ; Space between command line arguments
 (command
   argument: _ @append_space @prepend_space

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -1,11 +1,8 @@
 ; Configuration
 (#language! bash)
 
-; Don't modify commands and string literals
-[
- (command)
- (string)
-] @leaf
+; Don't modify string literals
+(string) @leaf
 
 ; Allow blank line before
 ; FIXME Blank line spacing around major syntactic blocks is not correct.
@@ -120,6 +117,10 @@
 )
 
 ; Space between command line arguments
+; NOTE If we treat (command) as a leaf node, then commands are formatted
+; as is and the below will be ignored. On balance, I think keeping this
+; rule, rather than deferring to the input, is the better choice
+; (although it's not without its problems; e.g., see Issue #172).
 (command
   argument: _* @append_space @prepend_space
 )

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -15,6 +15,7 @@
   (list)
   (pipeline)
   (for_statement)
+  (c_style_for_statement)
   ; TODO: etc.
 ] @allow_blank_line_before
 
@@ -100,9 +101,9 @@
 ; Keep the "if"/"elif" and the "then" on the same line,
 ; inserting a delimiter when necessary
 (_
-  (_) @prepend_space @append_delimiter
   ";"* @do_nothing
-  "then"
+  .
+  "then" @prepend_delimiter
 
   (#delimiter! ";")
 )
@@ -121,12 +122,11 @@
 (test_command . (unary_expression) @prepend_space @append_space)
 
 ; FIXME The binary_expression node is not being returned by Tree-Sitter
+; in the context of a (test_command); it does work in other contexts
 ; See https://github.com/tweag/topiary/pull/155#issuecomment-1364143677
-(test_command
-  (binary_expression
-     left: _ @prepend_space @append_space
-     right: _ @prepend_space @append_space
-  )
+(binary_expression
+   left: _ @append_space
+   right: _ @prepend_space
 )
 
 ;; Loops
@@ -134,6 +134,7 @@
 ; Start loops on a new line
 [
   (for_statement)
+  (c_style_for_statement)
   ; <TODO: etc.>
 ] @prepend_hardline
 
@@ -141,16 +142,22 @@
 (do_group . "do" @append_hardline @append_indent_start)
 (do_group "done" @prepend_indent_end @prepend_hardline .)
 
-; Ensure the word list is delimited by spaces
+; Ensure the word list is delimited by spaces in classic for loops
 (for_statement value: _* @prepend_space)
+
+; Ensure the loop condition is pleasantly spaced in C-style for loops
+(c_style_for_statement
+  initializer: _ @prepend_space
+  condition: _ @prepend_space
+  update: _ @prepend_space @append_space
+)
 
 ; Keep the loop construct and the "do" on the same line,
 ; inserting a delimiter when necessary
 (_
-  (_) @append_delimiter
   ";"* @do_nothing
   .
-  (do_group)
+  (do_group) @prepend_delimiter
 
   (#delimiter! ";")
 )

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -27,6 +27,7 @@
   "else"
   "fi"
   "for"
+  "select"
   "in"
   "do"
   "done"

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -1,6 +1,9 @@
 ; Configuration
 (#language! bash)
 
+; FIXME Blank line spacing around major syntactic blocks is not correct.
+; Some blank lines are getting consumed unexpectedly in the output.
+
 ; Don't modify string literals
 (string) @leaf
 

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -62,6 +62,10 @@
 ; delimiter -- but I've never seen this form in the wild
 (_ [(command) (list) (pipeline)] . "&" @prepend_space)
 
+[(list) (pipeline)] @prepend_empty_softline
+(list ["&&" "||"] @append_space @prepend_space)
+(pipeline ["|" "|&"] @append_space @prepend_space)
+
 ; Space between command line arguments
 (command
   argument: _ @append_space @prepend_space

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -59,29 +59,73 @@
 ;
 ; NOTE Because "command" is such a pervasive and general concept, each
 ; context needs to be individually enumerated to account for exceptions.
-(program [(command) (list) (pipeline)] @prepend_hardline)
-(if_statement . _ "then" [(command) (list) (pipeline)] @prepend_hardline)
-(elif_clause . _ "then" [(command) (list) (pipeline)] @prepend_hardline)
-(else_clause . "else" [(command) (list) (pipeline)] @prepend_hardline)
-(do_group . "do" [(command) (list) (pipeline)] @prepend_hardline)
+(program
+  [(command) (list) (pipeline)] @prepend_hardline
+)
+
+(if_statement
+  .
+  _
+  "then"
+  [(command) (list) (pipeline)] @prepend_hardline
+)
+
+(elif_clause
+  .
+  _
+  "then"
+  [(command) (list) (pipeline)] @prepend_hardline
+)
+
+(else_clause
+  .
+  "else"
+  [(command) (list) (pipeline)] @prepend_hardline
+)
+
+(do_group
+  .
+  "do"
+  [(command) (list) (pipeline)] @prepend_hardline
+)
 
 ; Surround command list and pipeline delimiters with spaces
-(list ["&&" "||"] @append_space @prepend_space)
-(pipeline ["|" "|&"] @append_space @prepend_space)
+(list
+  [
+    "&&"
+    "||"
+  ] @append_space @prepend_space
+)
+
+(pipeline
+  [
+    "|"
+    "|&"
+  ] @append_space @prepend_space
+)
 
 ; Prepend the asynchronous operator with a space
 ; NOTE If I'm not mistaken, this can interpose two "commands" -- like a
 ; delimiter -- but I've never seen this form in the wild
-(_ [(command) (list) (pipeline)] . "&" @prepend_space)
+(_
+  [(command) (list) (pipeline)]
+  .
+  "&" @prepend_space
+)
 
 ; Space between command line arguments
-(command argument: _* @append_space @prepend_space)
+(command
+  argument: _* @append_space @prepend_space
+)
 
 ;; Operators
 
 ; Ensure the negation operator is surrounded by spaces
 ; NOTE This is a syntactic requirement
-(negated_command . "!" @prepend_space @append_space)
+(negated_command
+  .
+  "!" @prepend_space @append_space
+)
 
 ;; Conditionals
 
@@ -99,7 +143,10 @@
 ] "then" @append_hardline @append_indent_start
 
 ; New line after "else" and start indent block
-(else_clause . "else" @append_hardline @append_indent_start)
+(else_clause
+  .
+  "else" @append_hardline @append_indent_start
+)
 
 ; Keep the "if"/"elif" and the "then" on the same line,
 ; inserting a delimiter when necessary
@@ -122,7 +169,10 @@
 
 ;; Test Commands
 
-(test_command . (unary_expression) @prepend_space @append_space)
+(test_command
+  .
+  (unary_expression) @prepend_space @append_space
+)
 
 ; FIXME The binary_expression node is not being returned by Tree-Sitter
 ; in the context of a (test_command); it does work in other contexts
@@ -142,11 +192,20 @@
 ] @prepend_hardline
 
 ; Indentation block between the "do" and the "done"
-(do_group . "do" @append_hardline @append_indent_start)
-(do_group "done" @prepend_indent_end @prepend_hardline .)
+(do_group
+  .
+  "do" @append_hardline @append_indent_start
+)
+
+(do_group
+  "done" @prepend_indent_end @prepend_hardline
+  .
+)
 
 ; Ensure the word list is delimited by spaces in classic for loops
-(for_statement value: _* @prepend_space)
+(for_statement
+  value: _* @prepend_space
+)
 
 ; Ensure the loop condition is pleasantly spaced in C-style for loops
 (c_style_for_statement

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -1,36 +1,35 @@
 ; Configuration
 (#language! bash)
 
-; FIXME Blank line spacing around major syntactic blocks is not correct.
-; Some blank lines are getting consumed unexpectedly in the output.
-
 ; Don't modify string literals
 (string) @leaf
 
 ; Allow blank line before
+; FIXME Blank line spacing around major syntactic blocks is not correct.
+; Some blank lines are getting consumed unexpectedly in the output.
 [
-  (comment)
-  (if_statement)
+  (c_style_for_statement)
   (command)
+  (comment)
+  (for_statement)
+  (if_statement)
   (list)
   (pipeline)
-  (for_statement)
-  (c_style_for_statement)
   ; TODO: etc.
 ] @allow_blank_line_before
 
 ; Surround with spaces
 [
-  "if"
-  "then"
+  "do"
+  "done"
   "elif"
   "else"
   "fi"
   "for"
-  "select"
+  "if"
   "in"
-  "do"
-  "done"
+  "select"
+  "then"
   (string)
   ; TODO: etc.
 ] @append_space @prepend_space

--- a/playground.sh
+++ b/playground.sh
@@ -46,24 +46,33 @@ main() {
   local input="${2-$(get_sample_input "${language}")}"
   [[ -e "${input}" ]] || fail "Couldn't find input source file '${input}'"
 
+  # Horizontal rule (this is a function because executing it in a TTY-
+  # -less subshell, to assign it to a variable, sets COLUMNS to 0)
+  hr() { printf "%${COLUMNS}s" "" | tr " " "-"; }
+
   while true; do
     clear
 
+    hr
     cat <<-EOF
 		Query File    ${query}
 		Input Source  ${input}
-		$(printf "%${COLUMNS}s" "" | tr " " "-")
 		EOF
+    hr
 
     cargo run --quiet -- \
       --skip-idempotence \
       --query "${query}" \
-      --input-file "${input}"
+      --input-file "${input}" \
+    || true
+
+    hr
 
     # NOTE We don't wait for specific inotify events because different
     # editors have different strategies for modifying files
     inotifywait --quiet "${query}" "${input}"
   done
+
 }
 
 main "$@"

--- a/playground.sh
+++ b/playground.sh
@@ -48,7 +48,7 @@ main() {
 
   # Horizontal rule (this is a function because executing it in a TTY-
   # -less subshell, to assign it to a variable, sets COLUMNS to 0)
-  hr() { printf "%${COLUMNS}s" "" | tr " " "-"; }
+  hr() { printf "%${COLUMNS}s\n" "" | tr " " "-"; }
 
   while true; do
     clear

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -18,3 +18,20 @@ else
 fi
 
 multi | line |& pipeline
+for thing in foo bar quux; do
+  echo $thing
+  rm -rf /
+done
+select thing in foo bar quux; do
+  echo $thing
+  break
+done
+for (( i=0; i < 10; i++ )); do
+  echo $i
+done
+while true; do
+  echo "Hello world!"
+done
+until true; do
+  echo "Hello world!"
+done

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -24,3 +24,28 @@ fi
 
 multi \
 | line |& pipeline
+
+for thing in foo bar quux
+do
+  echo $thing
+  rm -rf /
+done
+
+select thing in foo bar quux; do
+  echo $thing
+  break
+done
+
+for (( i=0; i<10; i++ )); do
+  echo $i
+done
+
+while true
+do
+  echo "Hello world!"
+done
+
+until true
+do
+  echo "Hello world!"
+done


### PR DESCRIPTION
This PR introduces support for the various forms of Bash loops, in aid of #138:

1. Classic `for` loops
2. C-style `for` loops
3. `select` loops
4. `while` loops
5. `until` loops

:bulb: This PR builds upon the following; do not merge until its ancestors have landed.
* [x] #173