### PR TITLE
[Bash] Compound statements and subshells

### DIFF
--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -6,13 +6,14 @@
 
 ; Allow blank line before
 ; FIXME Blank line spacing around major syntactic blocks is not correct.
-; Some blank lines are getting consumed unexpectedly in the output.
+; Most blank lines are getting consumed unexpectedly in the output.
 [
   (c_style_for_statement)
   (case_item)
   (case_statement)
   (command)
   (comment)
+  (compound_statement)
   (for_statement)
   (if_statement)
   (list)
@@ -41,14 +42,36 @@
   ; TODO: etc.
 ] @append_space @prepend_space
 
+;; Compound Statements and Subshells
+
+; Compound statements and subshells are formatted in exactly the same
+; way. In a multi-line context, their opening parenthesis triggers a new
+; line and the start of an indent block; the closing parenthesis
+; finishes that block. In a single-line context, spacing is used instead
+; of newlines (NOTE that this is a syntactic requirement of compound
+; statements, but not of subshells).
+
+(compound_statement
+  .
+  "{" @append_spaced_softline @append_indent_start
+)
+
+(compound_statement
+  "}" @prepend_spaced_softline @prepend_indent_end
+  .
+)
+
 ;; Commands
 
-; NOTE "Command" is shorthand for a "unit of execution":
+; NOTE "Command" is an epithet for a "unit of execution":
 ; * Simple commands (e.g., binaries, builtins, functions, etc.)
 ; * Command lists
 ; * Command pipelines
+; * Compound statements
+; * Subshells
 ;
-; That is: [(command) (list) (pipeline)], per the grammar
+; That is, per the grammar:
+;   [(command) (list) (pipeline) (compound_statement)]
 
 ; FIXME I don't think it's possible to insert the necessary line
 ; continuations; or, at least, it's not possible to insert them only in
@@ -57,35 +80,42 @@
 
 ; One command per line in the following contexts:
 ; * Top-level
+; * Multi-line compound statements and subshells
 ; * In any branch of a conditional
 ; * In any branch of a switch statement
 ; * Within loops
 ; * <TODO: etc.>
 ;
 ; NOTE Because "command" is such a pervasive and general concept, each
-; context needs to be individually enumerated to account for exceptions.
+; context needs to be individually enumerated to account for exceptions;
+; the primary of which being the condition in if statements.
 (program
-  [(command) (list) (pipeline)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement)] @prepend_hardline
+)
+
+; NOTE Single-line compound statements are a thing; hence the softline
+(compound_statement
+  [(command) (list) (pipeline) (compound_statement)] @prepend_spaced_softline
 )
 
 (if_statement
   .
   _
   "then"
-  [(command) (list) (pipeline)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement)] @prepend_hardline
 )
 
 (elif_clause
   .
   _
   "then"
-  [(command) (list) (pipeline)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement)] @prepend_hardline
 )
 
 (else_clause
   .
   "else"
-  [(command) (list) (pipeline)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement)] @prepend_hardline
 )
 
 ; NOTE Single-line switch branches are a thing; hence the softline
@@ -93,13 +123,13 @@
   .
   _
   ")"
-  [(command) (list) (pipeline)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement)] @prepend_spaced_softline
 )
 
 (do_group
   .
   "do"
-  [(command) (list) (pipeline)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement)] @prepend_hardline
 )
 
 ; Surround command list and pipeline delimiters with spaces
@@ -124,7 +154,7 @@
 ; NOTE If I'm not mistaken, this can interpose two "commands" -- like a
 ; delimiter -- but I've never seen this form in the wild
 (_
-  [(command) (list) (pipeline)]
+  [(command) (list) (pipeline) (compound_statement)]
   .
   "&" @prepend_space
 )

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -7,7 +7,6 @@ if some_command; then
   do_something
   another_thing --foo --bar
 fi
-
 if [[ -e "/some/file" ]] || true; then
   foo
 elif ! ((1==0)); then
@@ -16,7 +15,6 @@ elif ! ((1==0)); then
 else
   baz && quux || xyzzy &
 fi
-
 multi | line |& pipeline
 for thing in foo bar quux; do
   echo $thing
@@ -47,3 +45,28 @@ case "${foo}" in
   *)
     exit 1
 esac
+{
+  here
+  is
+  { a; nested; compound; }
+}
+if { foo; }; then
+  echo
+fi
+(
+  here
+  is
+  ( a; nested; subshell )
+)
+if ( foo; bar ); then
+  echo
+fi
+{ one; ( inside; the ); other; }
+(
+  one
+  {
+    inside
+    the
+  }
+  other
+)

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -62,3 +62,30 @@ case "${foo}" in
   *)
     exit 1
 esac
+
+{
+  here
+  is
+  { a; nested; compound; }
+}
+
+if { foo; }; then
+  echo
+fi
+
+(
+  here
+  is
+  ( a; nested; subshell )
+)
+
+if ( foo; bar ); then
+  echo
+fi
+
+{ one; (inside; the); other; }
+( one
+  { inside
+    the
+  }
+  other )


### PR DESCRIPTION
This PR introduces formatting queries for compound statements (i.e., between curly-parentheses) and subshells (i.e., between parentheses), in aid of #138. It's worth pointing out the following:

1. Both compound statements and subshells are "units of execution"; i.e., they can appear anywhere a basic command can appear. Usually a unit of execution is given its own line, except in the case of the condition to an `if` statement.[^1] This is making the list of queries that express the contexts for units of execution -- and the alternation that defines them -- particularly long... I _think_ that is all of them, now :crossed_fingers:
2. Both compound statements and subshells can (and regularly do) appear in a single-line context. As such, unit spacing is done within these using spaced softlines.

(Also in this PR, I have removed the hardline after `fi`: now all syntactic blocks are uniformly juxtaposed against each other without an interceding blank line. Fixing this is a task for another day.)

[^1]: If the Tree Sitter query language supported negative anchors -- like negative lookaheads/behinds, in PCREs -- this growing list of queries could be collapsed into just a handful... Alas, no such luck.