### PR TITLE
[Bash] Functions and variables

### DIFF
--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -1,8 +1,12 @@
 ; Configuration
 (#language! bash)
 
-; Don't modify string literals
-(string) @leaf
+; Don't modify string literals or variable expansions
+[
+  (expansion)
+  (simple_expansion)
+  (string)
+] @leaf
 
 ; Allow blank line before
 ; FIXME Blank line spacing around major syntactic blocks is not correct.
@@ -13,12 +17,14 @@
   (command)
   (comment)
   (compound_statement)
+  (declaration_command)
   (for_statement)
   (function_definition)
   (if_statement)
   (list)
   (pipeline)
   (subshell)
+  (variable_assignment)
   (while_statement)
   ; TODO: etc.
 ] @allow_blank_line_before
@@ -26,17 +32,22 @@
 ; Surround with spaces
 [
   "case"
+  "declare"
   "do"
   "done"
   "elif"
   "else"
   "esac"
+  "export"
   "fi"
   "for"
   "if"
   "in"
+  "local"
+  "readonly"
   "select"
   "then"
+  "typeset"
   "until"
   "while"
   (string)
@@ -49,7 +60,7 @@
 ; way. In a multi-line context, their opening parenthesis triggers a new
 ; line and the start of an indent block; the closing parenthesis
 ; finishes that block. In a single-line context, spacing is used instead
-; of newlines (NOTE that this is a syntactic requirement of compound
+; of new lines (NOTE that this is a syntactic requirement of compound
 ; statements, but not of subshells).
 ;
 ; NOTE Despite being isomorphic, the queries for compound statements and
@@ -349,3 +360,25 @@
   .
   "function" @delete
 )
+
+;; Variable Declaration, Assignment and Expansion
+
+; Declaration and assignment on a new line.
+(declaration_command) @prepend_hardline
+(variable_assignment) @prepend_empty_softline
+
+; Multiple variables can be exported (and assigned) at once
+(declaration_command
+  .
+  "export"
+  [(variable_name) (variable_assignment)] @prepend_space
+)
+
+; NOTE The (simple_expansion), for `$foo`, and (expansion), for `${foo}`
+; and friends, node types exist. We consider them as leaves (see above).
+; However, it would be _really_ nice if we could write a query that
+; converts all (simple_expansions) into (expansions). It can almost be
+; done with delimiters, but it doesn't quite work :( For example:
+;
+; (simple_expansion (variable_name) @prepend_delimiter (#delimiter! "{"))
+; (simple_expansion (variable_name) @append_delimiter (#delimiter! "}"))

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -14,6 +14,7 @@
   (comment)
   (compound_statement)
   (for_statement)
+  (function_definition)
   (if_statement)
   (list)
   (pipeline)
@@ -327,4 +328,24 @@
   (do_group) @prepend_delimiter
 
   (#delimiter! ";")
+)
+
+;; Function Definitions
+
+; NOTE Much of the formatting work for function definitions is done by
+; whatever already-defined queries apply to the function body (e.g.,
+; (compound_statement), etc.). All we do here is ensure functions get
+; their own line and put a space between its name and the body.
+(function_definition) @prepend_hardline
+
+(function_definition
+  body: _ @prepend_space
+)
+
+; NOTE The "function" keyword in function definitions is optional and
+; thus usually considered redundant. Therefore we delete it, if it's
+; present in the input.
+(function_definition
+  .
+  "function" @delete
 )

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -70,3 +70,8 @@ fi
   }
   other
 )
+foo() {
+  bar
+  quux || xyzzy
+}
+quux() { xyzzy; }

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -75,3 +75,8 @@ foo() {
   quux || xyzzy
 }
 quux() { xyzzy; }
+export a b=1 c
+declare x=$foo
+x=123
+echo "${x:-something}"
+echo "${x/foo/bar}"

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -96,3 +96,9 @@ function foo  () {
 }
 
 quux() { xyzzy; }
+
+export a b=1 c
+declare x=$foo
+x=123
+echo "${x:-something}"
+echo "${x/foo/bar}"

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -89,3 +89,10 @@ fi
     the
   }
   other )
+
+function foo  () {
+  bar
+  quux || xyzzy
+}
+
+quux() { xyzzy; }


### PR DESCRIPTION
This PR introduces formatting queries for function definitions, variable declaration and variable assignment, in aid of #138.

Note: It would be _really_ nice to be able to write a query that can convert "simple expansions" (e.g., `$foo`) into full, unambiguous expansions (i.e., `${foo}`) as a stylistic choice; similar to how I'm forcibly removing the redundant `function` keyword. I played around with inserting delimiters, but couldn't make anything work :cry: