### PR TITLE
[OCaml] Indentation and softlines in multiline function calls

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -959,6 +959,25 @@
   )
 )
 
+; Indent and add softlines in multiline application expressions, such as
+; let _ =
+;   large function
+;     long_argument_1
+;     long_argument_2
+;     long_argument_3
+;     long_argument_4
+(application_expression
+  .
+  (_) @append_indent_start
+  (_) @append_indent_end
+  .
+)
+(application_expression
+  (_) @append_spaced_softline
+  .
+  (_)
+)
+
 ; Try block formatting
 ; A soft linebreak after the "try" (potentially "try%ppx") and one after the "with".
 (try_expression
@@ -976,17 +995,6 @@
 (try_expression
   "with" @prepend_indent_end @prepend_spaced_softline @append_indent_start
   (_) @append_indent_end
-  .
-)
-
-; Softlines and indenting between parenthesized expressions
-;
-; mkexp (Texp_construct(mknoloc lid, csome, [texp]))
-;   (type_option texp.exp_type) texp.exp_loc texp.exp_env
-;
-(
-  (parenthesized_expression) @append_spaced_softline @append_indent_start
-  (parenthesized_expression) @append_indent_end
   .
 )
 

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -448,8 +448,10 @@ let topological_sort deps =
               @@ Files_legacy.Files_error (ObjectFileNotFound (mk_mident node))
           | _ -> assert false
       in
-      node::List.fold_left (explore (node::path))
-        visited (List.map Files_legacy.get_file edges)
+      node::List.fold_left
+        (explore (node::path))
+        visited
+        (List.map Files_legacy.get_file edges)
   in
   List.rev @@ List.fold_left (fun visited (n, _) -> explore [] visited n) [] graph
 
@@ -685,8 +687,9 @@ module F (X: T1) (Y: T1 with type t := X.t) = struct
 end
 
 (* Showcase ppx usage *)
-let lid =
-  [%sedlex.regexp? R] in body
+let _ =
+  let lid = [%sedlex.regexp? R] in
+  body
 
 let _ = [%sedlex.regexp R]
 

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -682,8 +682,9 @@ module F (X: T1) (Y: T1 with type t := X.t) = struct
 end
 
 (* Showcase ppx usage *)
-let lid = [%sedlex.regexp? R] in
-body
+let _ =
+  let lid = [%sedlex.regexp? R] in
+  body
 
 let _ = [%sedlex.regexp R]
 


### PR DESCRIPTION
Allows proper formatting of
```
List.fold_left
  (explore (node::path))
  visited
  (List.map Files_legacy.get_file edges)
```
Also, remove redundant rules and fix nonsensical example in OCaml input.