### PR TITLE
[OCaml] indentation and softlines in multiline function definitions

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -847,17 +847,6 @@
   ; well as the final non-named node, causing double indentation.
 )
 
-; Make an indented block after ":" in let bindings
-;
-; let type_open :
-;   (?used_slot:bool ref -> override_flag -> Env.t -> Location.t ->
-;
-(let_binding
-  ":" @append_indent_start
-  (_) @append_indent_end
-  .
-)
-
 ; Make an indented block after "=" in
 ; * let bindings
 ; * class[_type] bindings
@@ -961,7 +950,7 @@
 
 ; Indent and add softlines in multiline application expressions, such as
 ; let _ =
-;   large function
+;   long_function
 ;     long_argument_1
 ;     long_argument_2
 ;     long_argument_3
@@ -976,6 +965,24 @@
   (_) @append_spaced_softline
   .
   (_)
+)
+
+; Indent and allow softlines in multiline function definitions, such as
+; let long_function
+;   (long_argument_1: int)
+;   (long_argument_2: int)
+;   (long_argument_3: int)
+;   (long_argument_4: int) =
+;   ()
+(let_binding
+  .
+  (_) @append_indent_start
+  (_) @append_indent_end
+  .
+  "="
+)
+(let_binding
+  (parameter) @prepend_input_softline
 )
 
 ; Try block formatting

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -557,6 +557,13 @@ let my_id ~value = value
 
 let into_list ~value = my_id ~value :: []
 
+let long_function
+  (long_argument_1 : int)
+  (long_argument_2 : int)
+  (long_argument_3 : int)
+  (long_argument_4 : int) =
+  ()
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -553,6 +553,13 @@ let my_id ~value = value
 
 let into_list ~value = my_id ~value :: []
 
+let long_function
+  (long_argument_1 : int)
+  (long_argument_2 : int)
+  (long_argument_3 : int)
+  (long_argument_4 : int) =
+  ()
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind


### PR DESCRIPTION
Allows correct formatting of 
```
let long_function
  (long_argument_1: int)
  (long_argument_2: int)
  (long_argument_3: int)
  (long_argument_4: int) =
  ()
```
Also, remove redundant OCaml queries