### PR TITLE
[Bash] Redirection, herestrings, heredocs, command and process substitution

### DIFF
--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -74,6 +74,7 @@
   [
     (c_style_for_statement)
     (case_statement)
+    (comment)
     (compound_statement)
     (declaration_command)
     (for_statement)
@@ -97,6 +98,7 @@
     (c_style_for_statement)
     (case_statement)
     (command)
+    (comment)
     (compound_statement)
     (compound_statement)
     (for_statement)
@@ -133,6 +135,8 @@
   "until"
   "while"
 ] @append_space @prepend_space
+
+(comment) @prepend_hardline
 
 ;; Compound Statements and Subshells
 
@@ -316,7 +320,8 @@
 ; Ensure heredocs start on a new line, after their start marker, and
 ; there is a new line after their end marker
 ; NOTE This is a syntactic requirement
-(heredoc_body) @prepend_hardline @append_input_softline
+(heredoc_start) @append_hardline
+(heredoc_body) @append_input_softline
 
 ;; Conditionals
 

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -103,9 +103,12 @@
 ; * Redirection statements (NOTE these aren't "units of execution" in
 ;   their own right, but are treated as such due to how the grammar
 ;   organises them as parent nodes of such units)
+; * Variable assignment (NOTE these aren't "units of execution" at all,
+;   but are treated as such to isolate them from their declaration
+;   context; see Variables section, below)
 ;
 ; That is, per the grammar:
-;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)]
+;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
 
 ; One command per line in the following contexts:
 ; * Top-level
@@ -119,37 +122,37 @@
 ; context needs to be individually enumerated to account for exceptions;
 ; the primary of which being the condition in if statements.
 (program
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
 )
 
 ; NOTE Single-line compound statements are a thing; hence the softline
 (compound_statement
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_spaced_softline
 )
 
 ; NOTE Single-line subshells are a thing; hence the softline
 (subshell
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_spaced_softline
 )
 
 (if_statement
   .
   _
   "then"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
 )
 
 (elif_clause
   .
   _
   "then"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
 )
 
 (else_clause
   .
   "else"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
 )
 
 ; NOTE Single-line switch branches are a thing; hence the softline
@@ -157,22 +160,22 @@
   .
   _
   ")"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_spaced_softline
 )
 
 (do_group
   .
   "do"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
 )
 
 ; NOTE Single-line command substitutions are a thing; hence the softline
 (command_substitution
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_empty_softline
 )
 
 ; Surround command list and pipeline delimiters with spaces
-; TODO These rules can be subsumed into the list of symbols that are
+; TODO These queries can be subsumed into the list of symbols that are
 ; surrounded by spaces, above; the context is irrelevant.
 ; (See https://github.com/tweag/topiary/pull/173#discussion_r1071123588)
 (list
@@ -398,9 +401,13 @@
 
 ;; Variable Declaration, Assignment and Expansion
 
-; Declaration and assignment on a new line.
+; NOTE Assignment only gets a new line when not part of a declaration;
+; that is, all the contexts in which units of execution can appear.
+; Hence the queries for this are defined above. (My kingdom for a
+; negative anchor!)
+
+; Declaration on a new line
 (declaration_command) @prepend_hardline
-(variable_assignment) @prepend_empty_softline
 
 ; Multiple variables can be exported (and assigned) at once
 (declaration_command
@@ -417,3 +424,5 @@
 ;
 ; (simple_expansion (variable_name) @prepend_delimiter (#delimiter! "{"))
 ; (simple_expansion (variable_name) @append_delimiter (#delimiter! "}"))
+;
+; See https://github.com/tweag/topiary/pull/179#discussion_r1073202151

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -1,6 +1,10 @@
 ; Configuration
 (#language! bash)
 
+; NOTE There is (currently) no support for line continuations. As such,
+; any which are encountered by Topiary will be forcibly collapsed on to
+; a single line. (See Issue #172)
+
 ; Don't modify string literals or variable expansions
 [
   (expansion)
@@ -97,11 +101,6 @@
 ;
 ; That is, per the grammar:
 ;   [(command) (list) (pipeline) (compound_statement) (subshell)]
-
-; FIXME I don't think it's possible to insert the necessary line
-; continuations; or, at least, it's not possible to insert them only in
-; a multi-line context. As such, all multi-line commands are forcibly
-; collapsed on to a single line for now... See Issue #172
 
 ; One command per line in the following contexts:
 ; * Top-level

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -416,6 +416,11 @@
   [(variable_name) (variable_assignment)] @prepend_space
 )
 
+; Environment variables assigned to commands inline need to be spaced
+(command
+  (variable_assignment) @append_space
+)
+
 ; NOTE The (simple_expansion), for `$foo`, and (expansion), for `${foo}`
 ; and friends, node types exist. We consider them as leaves (see above).
 ; However, it would be _really_ nice if we could write a query that

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -16,8 +16,9 @@
   (word)
 ] @leaf
 
+;; Spacing
+
 ; Allow blank line before
-; FIXME Blank line spacing around major syntactic blocks is not correct.
 [
   (c_style_for_statement)
   (case_item)
@@ -37,7 +38,80 @@
   (while_statement)
 ] @allow_blank_line_before
 
-; Surround with spaces
+; Insert a new line after multi-line syntactic blocks or, for where
+; single-line variants exists, after the "closing" subnodes (the
+; specificity is to avoid targeting the single-line context)
+[
+  (if_statement)
+  (case_statement)
+  (do_group)
+] @append_hardline
+
+(subshell
+  ")" @append_empty_softline
+  .
+)
+
+(compound_statement
+  "}" @append_empty_softline
+  .
+)
+
+; A run of "units of execution" (see below, sans variables which are
+; special) and function definitions should be followed by a new line,
+; before a multi-line syntactic block or variable.
+(
+  [
+    (command)
+    (compound_statement)
+    (function_definition)
+    (list)
+    (pipeline)
+    (redirected_statement)
+    (subshell)
+  ] @append_empty_softline
+  .
+  [
+    (c_style_for_statement)
+    (case_statement)
+    (compound_statement)
+    (declaration_command)
+    (for_statement)
+    (function_definition)
+    (if_statement)
+    (subshell)
+    (variable_assignment)
+    (while_statement)
+  ]
+)
+
+; A run of variable declarations and assignments should be followed by a
+; new line, before anything else
+(
+  [
+    (declaration_command)
+    (variable_assignment)
+  ] @append_hardline
+  .
+  [
+    (c_style_for_statement)
+    (case_statement)
+    (command)
+    (compound_statement)
+    (compound_statement)
+    (for_statement)
+    (function_definition)
+    (if_statement)
+    (list)
+    (pipeline)
+    (redirected_statement)
+    (subshell)
+    (subshell)
+    (while_statement)
+  ]
+)
+
+; Surround keywords with spaces
 [
   "case"
   "declare"
@@ -175,9 +249,10 @@
 )
 
 ; Surround command list and pipeline delimiters with spaces
-; TODO These queries can be subsumed into the list of symbols that are
-; surrounded by spaces, above; the context is irrelevant.
-; (See https://github.com/tweag/topiary/pull/173#discussion_r1071123588)
+; NOTE These queries could be subsumed into the list of symbols that are
+; surrounded by spaces (above), as the context is irrelevant. However,
+; they're kept here, separately, in anticipation of line continuation
+; support in multi-line contexts.
 (list
   [
     "&&"
@@ -217,7 +292,7 @@
   "!" @prepend_space @append_space
 )
 
-; Multi-line command substitutions become and indent block
+; Multi-line command substitutions become an indent block
 (command_substitution
   .
   (_) @prepend_empty_softline @prepend_indent_start

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -80,3 +80,13 @@ declare x=$foo
 x=123
 echo "${x:-something}"
 echo "${x/foo/bar}"
+cat <<-HEREDOC
+	Here is
+	a
+	  heredoc
+	HEREDOC
+some_command >output <input
+another_thing <<< herestring
+if foo 2>/dev/null; then
+  exit 1
+fi

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -3,10 +3,12 @@
 # Here is a comment
 do_a_thing
 produce | consume
+
 if some_command; then
   do_something
   another_thing --foo --bar
 fi
+
 if [[ -e "/some/file" ]] || true; then
   foo
 elif ! ((1==0)); then
@@ -15,24 +17,31 @@ elif ! ((1==0)); then
 else
   baz && quux || xyzzy &
 fi
+
 multi | line |& pipeline
+
 for thing in foo bar quux; do
   echo $thing
   rm -rf /
 done
+
 select thing in foo bar quux; do
   echo $thing
   break
 done
+
 for (( i=0; i < 10; i++ )); do
   echo $i
 done
+
 while true; do
   echo "Hello world!"
 done
+
 until true; do
   echo "Hello world!"
 done
+
 case "${foo}" in
   single) line --mode;;
   multi)
@@ -45,39 +54,56 @@ case "${foo}" in
   *)
     exit 1
 esac
+
 {
   here
   is
+
   { a; nested; compound; }
 }
+
 if { foo; }; then
   echo
 fi
+
 (
   here
   is
+
   ( a; nested; subshell )
 )
+
 if ( foo; bar ); then
   echo
 fi
+
 { one; ( inside; the ); other; }
+
 (
   one
+
   {
     inside
     the
   }
+
   other
 )
+
 foo() {
+  local x=1
+  x=2
+
   bar
   quux || xyzzy
 }
+
 quux() { xyzzy; }
+
 export a b=1 c
 declare x=$foo
 x=123
+
 echo "${x:-something}"
 echo "${x/foo/bar}"
 ENV_VAR=123 ANOTHER=456 some_command
@@ -88,17 +114,22 @@ cat <<-HEREDOC
 	HEREDOC
 some_command >output <input
 another_thing <<< herestring
+
 if foo 2>/dev/null; then
   exit 1
 fi
+
 {
   cat <<EOF
   This shouldn't be indented
 ...nor this
 EOF
 }
+
 readonly a=$(foo | bar || baz --quux 2>&1)
+
 foo <(bar || baz --something) | tee >(quux)
+
 export xyzzy=$(
   something
   another_thing --foo

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -80,6 +80,7 @@ declare x=$foo
 x=123
 echo "${x:-something}"
 echo "${x/foo/bar}"
+ENV_VAR=123 ANOTHER=456 some_command
 cat <<-HEREDOC
 	Here is
 	a

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -96,10 +96,9 @@ fi
 ...nor this
 EOF
 }
-readonly a=$( foo | bar || baz --quux 2>&1)
+readonly a=$(foo | bar || baz --quux 2>&1)
 foo <(bar || baz --something) | tee >(quux)
-export
-xyzzy=$(
+export xyzzy=$(
   something
   another_thing --foo
 )

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -90,3 +90,16 @@ another_thing <<< herestring
 if foo 2>/dev/null; then
   exit 1
 fi
+{
+  cat <<EOF
+  This shouldn't be indented
+...nor this
+EOF
+}
+readonly a=$( foo | bar || baz --quux 2>&1)
+foo <(bar || baz --something) | tee >(quux)
+export
+xyzzy=$(
+  something
+  another_thing --foo
+)

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -102,6 +102,7 @@ declare x=$foo
 x=123
 echo "${x:-something}"
 echo "${x/foo/bar}"
+ENV_VAR=123 ANOTHER=456 some_command
 
 cat <<-HEREDOC
 	Here is

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -91,6 +91,8 @@ fi
   other )
 
 function foo  () {
+  local x=1
+  x=2
   bar
   quux || xyzzy
 }

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -108,8 +108,25 @@ cat <<-HEREDOC
 	a
 	  heredoc
 	HEREDOC
+
 some_command > output < input
 another_thing <<< herestring
+
 if foo 2>/dev/null; then
   exit 1
 fi
+
+{
+  cat <<EOF
+This shouldn't be indented
+...nor this
+EOF
+}
+
+readonly a=$(foo | bar || baz --quux 2>&1)
+foo <(bar||baz --something) | tee >(quux)
+
+export xyzzy=$(
+  something
+  another_thing --foo
+)

--- a/tests/samples/input/bash.sh
+++ b/tests/samples/input/bash.sh
@@ -102,3 +102,14 @@ declare x=$foo
 x=123
 echo "${x:-something}"
 echo "${x/foo/bar}"
+
+cat <<-HEREDOC
+	Here is
+	a
+	  heredoc
+	HEREDOC
+some_command > output < input
+another_thing <<< herestring
+if foo 2>/dev/null; then
+  exit 1
+fi


### PR DESCRIPTION
This PR introduces formatting support for the following Bash constructs, in aid of #138:
* [x] Redirection statements
* [x] Herestrings and heredocs
* [x] Command and process substitution
* [x] Inline environment variable assignment (e.g., `FOO=bar quux`)
* [x] Opinionated line spacing
  * New line after multi-line syntactic blocks (e.g., `if` statements, subshells, etc.)
  * New line after a run of "units of execution" (± a few others) before a multi-line syntactic block or variable
  * New line after a run of variable declarations or assignments.

Notes:
* Process substitution "just works", without requiring special rules.
* There is an (unassailable) problem with heredocs having their first line affected by the indent level.
* This PR fixes new lines for variable assignment outside of declaration contexts. This further complicates the "unit of execution" alternation and speciation, given the lack of negative anchors in the Tree Sitter query language.