### PR TITLE
[OCaml] identation and softlines in anonymous functions

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -848,16 +848,9 @@
 )
 
 ; Make an indented block after "=" in
-; * let bindings
 ; * class[_type] bindings
 ; * method definitions
 ; * instance variable definitions
-;
-(let_binding
-  "=" @append_indent_start
-  (_) @append_indent_end
-  .
-)
 
 (class_binding
   "=" @append_indent_start
@@ -979,9 +972,25 @@
   (_) @append_indent_start
   (_) @append_indent_end
   .
-  "="
 )
 (let_binding
+  (parameter) @prepend_input_softline
+)
+
+; Indent and allow softlines in anonymous function definitions, such as
+; fun
+;   (long_argument_1: int)
+;   (long_argument_2: int)
+;   (long_argument_3: int)
+;   (long_argument_4: int) ->
+;   ()
+(fun_expression
+  .
+  "fun" @append_indent_start
+  (_) @append_indent_end
+  .
+)
+(fun_expression
   (parameter) @prepend_input_softline
 )
 

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -509,7 +509,7 @@ let add_three_lines x =
   res
 
 let add_as_fun_multiline = fun x ->
-  x
+    x
 
 let add_as_fun_one_line = fun x -> x
 
@@ -563,6 +563,15 @@ let long_function
   (long_argument_3 : int)
   (long_argument_4 : int) =
   ()
+
+let large_const =
+  let val = 3 in
+  fun
+    (long_argument_1 : int)
+    (long_argument_2 : int)
+    (long_argument_3 : int)
+    (long_argument_4 : int) ->
+    val
 
 (* Showcase the usage of operator bindings *)
 let greetings =

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -560,6 +560,15 @@ let long_function
   (long_argument_4 : int) =
   ()
 
+let large_const =
+  let val = 3 in
+  fun
+    (long_argument_1 : int)
+    (long_argument_2 : int)
+    (long_argument_3 : int)
+    (long_argument_4 : int) ->
+    val
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind


### PR DESCRIPTION
Allows correct formatting of
```
fun
  (long_argument_1 : int)
  (long_argument_2 : int)
  (long_argument_3 : int)
  (long_argument_4 : int) ->
  ()
```
Note that with this PR, there will be a double indentation on the second line of
```
let f = fun
    x -> x
```
I think the code is still more correct with the PR, and we'll be able to address the double indentation problem in a separate issue.

This PR also simplifies queries for let bindings.