### PR TITLE
[OCaml] Don't indent after open modules in let open

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -78,9 +78,17 @@
       (include_module_type)
     (module_definition)
     (module_type_definition)
-    (open_module)
     (type_definition)
   ] @append_hardline
+  .
+  (comment)* @do_nothing
+)
+; Also append line breaks after open_module, except when it's
+; preceded by "let", because in this case it's in a let_open_expression.
+(
+  "let" @do_nothing
+  .
+  (open_module) @append_hardline
   .
   (comment)* @do_nothing
 )

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -738,3 +738,7 @@ type t = {
   bflags: bool StrMap.t;
   (** Boolean flags. *)
 }
+
+let _ =
+  let open Printf in
+  sprintf "hello world"

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -731,3 +731,7 @@ type t =
   ; bflags: bool StrMap.t
   (** Boolean flags. *)
   }
+
+let _ =
+  let open Printf in
+  sprintf "hello world"


### PR DESCRIPTION
Allows correct formatting of
```
let _ =
  let open Printf in
  sprintf "hello world"
```