### PR TITLE
[OCaml] indent and allow softlines in tuples

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1002,6 +1002,26 @@
   (parameter) @prepend_input_softline
 )
 
+; Indent and allow softlines in tuples, such as
+; let _ =
+;   (
+;     long_value_1,
+;     long_value_2,
+;     long_value_3
+;   )
+(parenthesized_expression
+  .
+  "(" @append_empty_softline
+  .
+  (product_expression) @prepend_indent_start @append_indent_end
+  .
+  ")" @prepend_empty_softline
+  .
+)
+(product_expression
+  "," @append_spaced_softline
+)
+
 ; Try block formatting
 ; A soft linebreak after the "try" (potentially "try%ppx") and one after the "with".
 (try_expression

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -742,3 +742,11 @@ type t = {
 let _ =
   let open Printf in
   sprintf "hello world"
+
+let _ =
+  (
+    1,
+    2,
+    3,
+    4
+  )

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -735,3 +735,10 @@ type t =
 let _ =
   let open Printf in
   sprintf "hello world"
+
+let _ =
+  ( 1
+  , 2
+  , 3
+  , 4
+  )


### PR DESCRIPTION
Allows correct formatting of
```
(
  1,
  2,
  3,
  4
)
```
Note: because tuples in OCaml are actually left-associative couples, the following is formatted as above:
```
(
  1,
  2,
  3, 4
)
```
but the following is left as-is:
```
(
  1, 2,
  3,
  4
)
```