### PR TITLE
Introduce custom scopes and scoped softlines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,18 @@ pub enum Atom {
     // it might happen that it contains several leaves.
     DeleteBegin,
     DeleteEnd,
+    /// Scoped commands
+    // ScopedSoftline works together with the @open_scope and @end_scope query tags.
+    // To decide if a scoped softline must be expanded into a hardline, we look at
+    // the innermost scope having the corresponding `scope_id`, that encompasses it.
+    // We expand the softline if that scope is multi-line.
+    // The `id` value is here for technical reasons, it allows tracking of the atom
+    // during post-processing.
+    ScopedSoftline {
+        id: usize,
+        scope_id: String,
+        spaced: bool,
+    },
 }
 
 /// A convenience wrapper around `std::result::Result<T, FormatterError>`.

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -31,6 +31,7 @@ fn atoms_to_doc<'a>(i: &mut usize, atoms: &'a [Atom], indent_level: isize) -> Rc
                 Atom::Space => RcDoc::space(),
                 Atom::DeleteBegin => unreachable!(),
                 Atom::DeleteEnd => unreachable!(),
+                Atom::ScopedSoftline { .. } => unreachable!(),
             });
         }
         *i += 1;

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -657,8 +657,7 @@ module Inner2 = struct
       inherit ['a] Inner1.poppable
     end
 
-  class ['a] stack_impl:
-  ['a] stack =
+  class ['a] stack_impl: ['a] stack =
     object
       inherit ['a] Inner1.poppable as super
 
@@ -750,10 +749,20 @@ let _ =
   let open Printf in
   sprintf "hello world"
 
+(* Playing with nested structures *)
 let _ =
   (
     1,
     2,
     3,
     4
+  )
+
+let _ =
+  (
+    1,
+    2,
+    (3, 4),
+    5,
+    6
   )

--- a/tests/samples/expected/ocaml.mli
+++ b/tests/samples/expected/ocaml.mli
@@ -5598,3 +5598,10 @@ sig
 
   val check_storage_limit : context -> storage_limit: Z.t -> unit tzresult
 end
+
+(* Playing with nested structures *)
+type foo =
+a ->
+(b -> c) ->
+d ->
+e

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -739,9 +739,13 @@ let _ =
   let open Printf in
   sprintf "hello world"
 
+(* Playing with nested structures *)
 let _ =
-  ( 1
-  , 2
+  ( 1, 2
   , 3
   , 4
   )
+
+let _ =
+  (1, 2, (3, 4),
+  5, 6)

--- a/tests/samples/input/ocaml.mli
+++ b/tests/samples/input/ocaml.mli
@@ -5392,3 +5392,9 @@ module Fees : sig
 
   val check_storage_limit : context -> storage_limit:Z.t -> unit tzresult
 end
+
+(* Playing with nested structures *)
+type foo =
+a ->
+(b -> c) ->
+d -> e


### PR DESCRIPTION
This PR introduce scope commands and softlines.
This allows to open a scope with a query, close it with another, and add softlines that expand if and only if their encompassing scope is multi-line.
In essence, it allows to add the "multiline tag" to broader subsets of nodes than just single nodes of the AST.

For instance, to format OCaml tuples, you can use the following queries:
```
(parenthesized_expression
  .
  "(" @begin_scope
  (#scope_id! "tuple")
)

(parenthesized_expression
  (#scope_id! "tuple")
  ")" @end_scope
  .
)
(product_expression
  "," @append_spaced_scoped_softline
  (#scope_id! "tuple")
)
```
TODO:
* [X] Support nested scopes with the same id
* [X] Document the usage of the feature

Closes #190 
Closes #87