### PR TITLE
[Bash] Reverse new line strategy

### DIFF
--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -132,7 +132,7 @@
   "while"
 ] @append_space
 
-; Prepend a space to intra-statment keywords
+; Prepend a space to intra-statement keywords
 [
   "in"
 ] @prepend_space
@@ -534,14 +534,6 @@
 )
 
 ;; Loops
-
-; Start loops on a new line
-; FIXME We may not need this any more
-; FIXME ; [
-; FIXME ;   (c_style_for_statement)
-; FIXME ;   (for_statement)
-; FIXME ;   (while_statement)
-; FIXME ; ] @prepend_hardline
 
 ; Indentation block between the "do" and the "done"
 (do_group

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -202,37 +202,37 @@
 ; context needs to be individually enumerated to account for exceptions;
 ; the primary of which being the condition in if statements.
 (program
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
 )
 
 ; NOTE Single-line compound statements are a thing; hence the softline
 (compound_statement
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
 )
 
 ; NOTE Single-line subshells are a thing; hence the softline
 (subshell
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
 )
 
 (if_statement
   .
   _
   "then"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
 )
 
 (elif_clause
   .
   _
   "then"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
 )
 
 (else_clause
   .
   "else"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
 )
 
 ; NOTE Single-line switch branches are a thing; hence the softline
@@ -240,18 +240,18 @@
   .
   _
   ")"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
 )
 
 (do_group
   .
   "do"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_hardline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
 )
 
 ; NOTE Single-line command substitutions are a thing; hence the softline
 (command_substitution
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_empty_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_empty_softline
 )
 
 ; NOTE Single-line command substitutions are a thing; hence the softline
@@ -328,16 +328,16 @@
 ; there is a new line after their end marker
 ; NOTE This is a syntactic requirement
 (heredoc_start) @append_hardline
-(heredoc_body) @append_input_softline
+(heredoc_body) @append_hardline
 
 ;; Conditionals
 
-; Start conditional on a new line
+; New line after conditionals
 [
   (if_statement)
   (elif_clause)
   (else_clause)
-] @prepend_hardline
+] @append_hardline
 
 ; New line after "then" and start indent block
 [
@@ -389,8 +389,8 @@
 
 ;; Switch Statements
 
-; Start switch on a new line
-(case_statement) @prepend_hardline
+; New line after switch statement
+(case_statement) @append_hardline
 
 ; New line after "in" and start indent block
 (case_statement
@@ -416,22 +416,22 @@
   ] @prepend_empty_softline @append_hardline
 )
 
-; Finish indent blocks after switch branches and at the "esac", which
-; should appear on its own line
+; Finish indent blocks after switch branches and at the "esac"
 (case_item) @append_indent_end
 (case_statement
-  "esac" @prepend_hardline @prepend_indent_end
+  "esac" @prepend_indent_end
   .
 )
 
 ;; Loops
 
 ; Start loops on a new line
-[
-  (c_style_for_statement)
-  (for_statement)
-  (while_statement)
-] @prepend_hardline
+; FIXME We may not need this any more
+; FIXME ; [
+; FIXME ;   (c_style_for_statement)
+; FIXME ;   (for_statement)
+; FIXME ;   (while_statement)
+; FIXME ; ] @prepend_hardline
 
 ; Indentation block between the "do" and the "done"
 (do_group
@@ -440,7 +440,7 @@
 )
 
 (do_group
-  "done" @prepend_indent_end @prepend_hardline
+  "done" @prepend_indent_end @append_hardline
   .
 )
 
@@ -472,7 +472,8 @@
 ; whatever already-defined queries apply to the function body (e.g.,
 ; (compound_statement), etc.). All we do here is ensure functions get
 ; their own line and put a space between its name and the body.
-(function_definition) @prepend_hardline
+; FIXME We may not need this any more
+; FIXME ; (function_definition) @prepend_hardline
 
 (function_definition
   body: _ @prepend_space
@@ -494,7 +495,8 @@
 ; negative anchor!)
 
 ; Declaration on a new line
-(declaration_command) @prepend_hardline
+; FIXME We may not need this any more
+; FIXME ; (declaration_command) @prepend_hardline
 
 ; Multiple variables can be exported (and assigned) at once
 (declaration_command

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -254,7 +254,7 @@
 
 ; NOTE Single-line command substitutions are a thing; hence the softline
 (command_substitution
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_empty_softline
 )
 
 ; Surround command list and pipeline delimiters with spaces

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -5,10 +5,11 @@
 ; any which are encountered by Topiary will be forcibly collapsed on to
 ; a single line. (See Issue #172)
 
-; Don't modify string literals, heredocs, atomic "words" or variable
-; expansions (simple or otherwise)
+; Don't modify string literals, heredocs, comments, atomic "words" or
+; variable expansions (simple or otherwise)
 ; FIXME The first line of heredocs are affected by the indent level
 [
+  (comment)
   (expansion)
   (heredoc_body)
   (simple_expansion)
@@ -74,7 +75,6 @@
   [
     (c_style_for_statement)
     (case_statement)
-    (comment)
     (compound_statement)
     (declaration_command)
     (for_statement)
@@ -98,7 +98,6 @@
     (c_style_for_statement)
     (case_statement)
     (command)
-    (comment)
     (compound_statement)
     (compound_statement)
     (for_statement)
@@ -136,7 +135,10 @@
   "while"
 ] @append_space @prepend_space
 
-(comment) @prepend_hardline
+;; Comments
+
+; FIXME
+(comment) @append_hardline
 
 ;; Compound Statements and Subshells
 

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -252,6 +252,11 @@
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_empty_softline
 )
 
+; NOTE Single-line command substitutions are a thing; hence the softline
+(command_substitution
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)] @prepend_spaced_softline
+)
+
 ; Surround command list and pipeline delimiters with spaces
 ; NOTE These queries could be subsumed into the list of symbols that are
 ; surrounded by spaces (above), as the context is irrelevant. However,

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -42,75 +42,75 @@
 ; Insert a new line after multi-line syntactic blocks or, for where
 ; single-line variants exists, after the "closing" subnodes (the
 ; specificity is to avoid targeting the single-line context)
-[
-  (if_statement)
-  (case_statement)
-  (do_group)
-] @append_hardline
-
-(subshell
-  ")" @append_empty_softline
-  .
-)
-
-(compound_statement
-  "}" @append_empty_softline
-  .
-)
+; FIXME ; [
+; FIXME ;   (if_statement)
+; FIXME ;   (case_statement)
+; FIXME ;   (do_group)
+; FIXME ; ] @append_hardline
+; FIXME ;
+; FIXME ; (subshell
+; FIXME ;   ")" @append_empty_softline
+; FIXME ;   .
+; FIXME ; )
+; FIXME ;
+; FIXME ; (compound_statement
+; FIXME ;   "}" @append_empty_softline
+; FIXME ;   .
+; FIXME ; )
 
 ; A run of "units of execution" (see below, sans variables which are
 ; special) and function definitions should be followed by a new line,
 ; before a multi-line syntactic block or variable.
-(
-  [
-    (command)
-    (compound_statement)
-    (function_definition)
-    (list)
-    (pipeline)
-    (redirected_statement)
-    (subshell)
-  ] @append_empty_softline
-  .
-  [
-    (c_style_for_statement)
-    (case_statement)
-    (compound_statement)
-    (declaration_command)
-    (for_statement)
-    (function_definition)
-    (if_statement)
-    (subshell)
-    (variable_assignment)
-    (while_statement)
-  ]
-)
+; FIXME ; (
+; FIXME ;   [
+; FIXME ;     (command)
+; FIXME ;     (compound_statement)
+; FIXME ;     (function_definition)
+; FIXME ;     (list)
+; FIXME ;     (pipeline)
+; FIXME ;     (redirected_statement)
+; FIXME ;     (subshell)
+; FIXME ;   ] @append_empty_softline
+; FIXME ;   .
+; FIXME ;   [
+; FIXME ;     (c_style_for_statement)
+; FIXME ;     (case_statement)
+; FIXME ;     (compound_statement)
+; FIXME ;     (declaration_command)
+; FIXME ;     (for_statement)
+; FIXME ;     (function_definition)
+; FIXME ;     (if_statement)
+; FIXME ;     (subshell)
+; FIXME ;     (variable_assignment)
+; FIXME ;     (while_statement)
+; FIXME ;   ]
+; FIXME ; )
 
 ; A run of variable declarations and assignments should be followed by a
 ; new line, before anything else
-(
-  [
-    (declaration_command)
-    (variable_assignment)
-  ] @append_hardline
-  .
-  [
-    (c_style_for_statement)
-    (case_statement)
-    (command)
-    (compound_statement)
-    (compound_statement)
-    (for_statement)
-    (function_definition)
-    (if_statement)
-    (list)
-    (pipeline)
-    (redirected_statement)
-    (subshell)
-    (subshell)
-    (while_statement)
-  ]
-)
+; FIXME ; (
+; FIXME ;   [
+; FIXME ;     (declaration_command)
+; FIXME ;     (variable_assignment)
+; FIXME ;   ] @append_hardline
+; FIXME ;   .
+; FIXME ;   [
+; FIXME ;     (c_style_for_statement)
+; FIXME ;     (case_statement)
+; FIXME ;     (command)
+; FIXME ;     (compound_statement)
+; FIXME ;     (compound_statement)
+; FIXME ;     (for_statement)
+; FIXME ;     (function_definition)
+; FIXME ;     (if_statement)
+; FIXME ;     (list)
+; FIXME ;     (pipeline)
+; FIXME ;     (redirected_statement)
+; FIXME ;     (subshell)
+; FIXME ;     (subshell)
+; FIXME ;     (while_statement)
+; FIXME ;   ]
+; FIXME ; )
 
 ; Surround keywords with spaces
 [

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -137,6 +137,28 @@
 
 ;; Comments
 
+; Comments come in two flavours: standalone (i.e., it's the only thing
+; on a line, starting at the current indent level); and trailing (i.e.,
+; following some other statement on the same line, with a space
+; interposed). Bash does not have multi-line comments; they are all
+; single-line.
+;
+; The grammar parses all comments as the (comment) node, which are
+; siblings under a common parent.
+;
+; Formatting Rules:
+;
+; 1. A comment's contents must not be touched; some (namely the shebang)
+;    have a syntactic purpose.
+; 2. All comments must end with a new line.
+; 3. Comments can be interposed by blank lines, if they exist in the
+;    input (i.e., blank lines shouldn't be engineered elsewhere).
+; 4. A run of standalone comments (i.e., without anything, including
+;    blank lines, interposing) should be kept together.
+; 5. Trailing comments should only appear after "units of execution" or
+;    variable declarations/assignment. (This is despite it being
+;    syntactically valid to put them elsewhere.)
+
 ; FIXME
 (comment) @append_hardline
 

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -262,7 +262,7 @@
 ; * Top-level
 ; * Multi-line compound statements and subshells
 ; * In any branch of a conditional
-; * In any branch of a switch statement
+; * In any branch of a case statement
 ; * Within loops
 ; * Multi-line command substitutions
 ;
@@ -300,7 +300,7 @@
 ; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
 ; FIXME ; )
 ; FIXME ;
-; FIXME ; ; NOTE Single-line switch branches are a thing; hence the softline
+; FIXME ; ; NOTE Single-line case branches are a thing; hence the softline
 ; FIXME ; (case_item
 ; FIXME ;   .
 ; FIXME ;   _
@@ -452,39 +452,34 @@
    right: _ @prepend_space
 )
 
-;; Switch Statements
+;; Case Statements
 
-; New line after switch statement
-(case_statement) @append_hardline
-
-; New line after "in" and start indent block
+; Indentation block between the "in" and the "esac"
 (case_statement
   .
+  "case" . _ .  "in" @append_hardline @append_indent_start
   _
-  "in" @append_hardline @append_indent_start
-)
+  "esac" @prepend_hardline @prepend_indent_end
+  .
+) @append_hardline
 
-; New (soft)line after switch branch and start indent block
+; New (soft)line after branch, which starts an indentation block up
+; until its end
 (case_item
   ")" @append_spaced_softline @append_indent_start
-)
+) @append_indent_end
 
-; Ensure switch branch terminators appear on their own line, in a
-; multi-line context; or, at least, push the next switch branch on to a
+; Ensure case branch terminators appear on their own line, in a
+; multi-line context; or, at least, push the next case branch on to a
 ; new line in a single-line context
-; NOTE The terminator is optional in the final condition
+; NOTE The terminator is optional in the final condition, which is why
+; we deal with closing the indent block above
 (case_item
   [
     ";;"
     ";;&"
     ";&"
   ] @prepend_empty_softline @append_hardline
-)
-
-; Finish indent blocks after switch branches and at the "esac"
-(case_item) @append_indent_end
-(case_statement
-  "esac" @prepend_indent_end
   .
 )
 

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -427,10 +427,15 @@
 (herestring_redirect (_) @prepend_space)
 
 ; Ensure heredocs start on a new line, after their start marker, and
-; there is a new line after their end marker
-; NOTE This is a syntactic requirement
+; there is a new line after their end marker, when followed by any named
+; node. (NOTE This may need some refinement...)
+; NOTE These are a syntactic requirements
 (heredoc_start) @append_hardline
-(heredoc_body) @append_hardline
+(
+  (heredoc_body) @append_hardline
+  .
+  (_)
+)
 
 ;; Conditionals
 

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -234,101 +234,99 @@
 ;   context; see Variables section, below)
 
 ; When a "command" is followed by another "command", it should be
-; interposed by a softline, for the sake of single-line compound
-; statements and subshells.
-(
-  [
-    (command)
-    (list)
-    (pipeline)
-    (subshell)
-    (compound_statement)
-    (redirected_statement)
-    (variable_assignment)
-  ] @append_empty_softline
+; interposed by a new line (a softline, for the sake of single-line
+; compound statements and subshells). This, however, is only true in the
+; following contexts:
+;
+; * Top-level statements
+; * Multi-line compound statements and subshells
+; * In any branch of a conditional or case statement
+; * Loop bodies
+; * Multi-line command substitutions
+
+(program
+  [(command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)] @append_hardline
   .
-  [
-    (command)
-    (list)
-    (pipeline)
-    (subshell)
-    (compound_statement)
-    (redirected_statement)
-    (variable_assignment)
-  ]
+  [(command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)]
 )
 
-; One command per line in the following contexts:
-; * Top-level
-; * Multi-line compound statements and subshells
-; * In any branch of a conditional
-; * In any branch of a case statement
-; * Within loops
-; * Multi-line command substitutions
-;
-; FIXME ; (program
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
-; FIXME ; )
-; FIXME ;
-; FIXME ; ; NOTE Single-line compound statements are a thing; hence the softline
-; FIXME ; (compound_statement
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
-; FIXME ; )
-; FIXME ;
-; FIXME ; ; NOTE Single-line subshells are a thing; hence the softline
-; FIXME ; (subshell
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
-; FIXME ; )
-; FIXME ;
-; FIXME ; (if_statement
-; FIXME ;   .
-; FIXME ;   _
-; FIXME ;   "then"
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
-; FIXME ; )
-; FIXME ;
-; FIXME ; (elif_clause
-; FIXME ;   .
-; FIXME ;   _
-; FIXME ;   "then"
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
-; FIXME ; )
-; FIXME ;
-; FIXME ; (else_clause
-; FIXME ;   .
-; FIXME ;   "else"
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
-; FIXME ; )
-; FIXME ;
-; FIXME ; ; NOTE Single-line case branches are a thing; hence the softline
-; FIXME ; (case_item
-; FIXME ;   .
-; FIXME ;   _
-; FIXME ;   ")"
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
-; FIXME ; )
-; FIXME ;
-; FIXME ; (do_group
-; FIXME ;   .
-; FIXME ;   "do"
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
-; FIXME ; )
-; FIXME ;
-; FIXME ; ; NOTE Single-line command substitutions are a thing; hence the softline
-; FIXME ; (command_substitution
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_empty_softline
-; FIXME ; )
-; FIXME ;
-; FIXME ; ; NOTE Single-line command substitutions are a thing; hence the softline
-; FIXME ; (command_substitution
-; FIXME ;   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_empty_softline
-; FIXME ; )
+; NOTE Single-line compound statements are a thing; hence the softline
+(compound_statement
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
+
+; NOTE Single-line subshells are a thing; hence the softline
+(subshell
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
+
+(if_statement
+  .
+  _
+  "then"
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
+
+(elif_clause
+  .
+  _
+  "then"
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
+
+(else_clause
+  .
+  "else"
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
+
+; NOTE Single-line case branches are a thing; hence the softline
+(case_item
+  .
+  _
+  ")"
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
+
+(do_group
+  .
+  "do"
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
+
+; NOTE Single-line command substitutions are a thing; hence the softline
+(command_substitution
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_empty_softline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
+
+; NOTE Single-line command substitutions are a thing; hence the softline
+(command_substitution
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_empty_softline
+  .
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+)
 
 ; Surround command list and pipeline delimiters with spaces
-; NOTE These queries could be subsumed into the list of symbols that are
-; surrounded by spaces (above), as the context is irrelevant. However,
-; they're kept here, separately, in anticipation of line continuation
-; support in multi-line contexts.
+; NOTE The context here may be irrelevant -- i.e., these operators
+; should always be surrounded by spaces -- but they're kept here,
+; separately, in anticipation of line continuation support in multi-line
+; contexts.
 (list
   [
     "&&"
@@ -416,16 +414,6 @@
   "else" @append_hardline @append_indent_start
 )
 
-; Keep the "if"/"elif" and the "then" on the same line,
-; inserting a delimiter when necessary
-(_
-  ";"* @do_nothing
-  .
-  "then" @prepend_delimiter
-
-  (#delimiter! ";")
-)
-
 ; Finish indent block at "fi", "else" or "elif"
 (if_statement
   [
@@ -433,6 +421,17 @@
     (else_clause)
     (elif_clause)
   ] @prepend_indent_end @prepend_hardline
+)
+
+; Keep the "if"/"elif" and the "then" on the same line,
+; inserting a spaced delimiter when necessary
+; FIXME Why does the space need to be explicitly inserted?
+(_
+  ";"* @do_nothing
+  .
+  "then" @prepend_delimiter @prepend_space
+
+  (#delimiter! ";")
 )
 
 ;; Test Commands

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -258,7 +258,7 @@
 
 ; NOTE Single-line compound statements are a thing; hence the softline
 (compound_statement
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_empty_softline
   .
   [
     ; Commands
@@ -270,7 +270,7 @@
 
 ; NOTE Single-line subshells are a thing; hence the softline
 (subshell
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_empty_softline
   .
   [
     ; Commands
@@ -326,7 +326,7 @@
   .
   _
   ")"
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
+  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_empty_softline
   .
   [
     ; Commands
@@ -352,18 +352,6 @@
 ; NOTE Single-line command substitutions are a thing; hence the softline
 (command_substitution
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_empty_softline
-  .
-  [
-    ; Commands
-    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
-    ; Contexts
-    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
-  ]
-)
-
-; NOTE Single-line command substitutions are a thing; hence the softline
-(command_substitution
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_empty_softline
   .
   [
     ; Commands

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -252,7 +252,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -264,7 +264,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -276,7 +276,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -290,7 +290,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -304,7 +304,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -317,7 +317,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -332,7 +332,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -345,7 +345,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -357,7 +357,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -369,7 +369,7 @@
     ; Commands
     (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
     ; Contexts
-    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+    (c_style_for_statement) (case_statement) (declaration_command) (for_statement) (function_definition) (if_statement) (while_statement)
   ]
 )
 
@@ -593,14 +593,17 @@
 
 ;; Variable Declaration, Assignment and Expansion
 
+; NOTE It would be nice to convert (simple_expansion) nodes into
+; (expansion) nodes by inserting "delimiters" in appropriate places.
+; This doesn't appear to currently be possible (see Issue #187).
+
 ; NOTE Assignment only gets a new line when not part of a declaration;
 ; that is, all the contexts in which units of execution can appear.
 ; Hence the queries for this are defined above. (My kingdom for a
 ; negative anchor!)
 
-; Declaration on a new line
-; FIXME We may not need this any more
-; FIXME ; (declaration_command) @prepend_hardline
+; Declarations always end with a new line
+(declaration_command) @append_hardline
 
 ; Multiple variables can be exported (and assigned) at once
 (declaration_command
@@ -613,14 +616,3 @@
 (command
   (variable_assignment) @append_space
 )
-
-; NOTE The (simple_expansion), for `$foo`, and (expansion), for `${foo}`
-; and friends, node types exist. We consider them as leaves (see above).
-; However, it would be _really_ nice if we could write a query that
-; converts all (simple_expansions) into (expansions). It can almost be
-; done with delimiters, but it doesn't quite work :( For example:
-;
-; (simple_expansion (variable_name) @prepend_delimiter (#delimiter! "{"))
-; (simple_expansion (variable_name) @append_delimiter (#delimiter! "}"))
-;
-; See https://github.com/tweag/topiary/pull/179#discussion_r1073202151

--- a/languages/bash.scm
+++ b/languages/bash.scm
@@ -179,9 +179,7 @@
 (compound_statement
   .
   "{" @append_spaced_softline @append_indent_start
-)
-
-(compound_statement
+  _
   "}" @prepend_spaced_softline @prepend_indent_end
   .
 )
@@ -189,9 +187,7 @@
 (subshell
   .
   "(" @append_spaced_softline @append_indent_start
-)
-
-(subshell
+  _
   ")" @prepend_spaced_softline @prepend_indent_end
   .
 )
@@ -233,35 +229,55 @@
 ;   but are treated as such to isolate them from their declaration
 ;   context; see Variables section, below)
 
-; When a "command" is followed by another "command", it should be
-; interposed by a new line (a softline, for the sake of single-line
-; compound statements and subshells). This, however, is only true in the
+; We care about the line spacing of "commands" that appear in any of the
 ; following contexts:
 ;
 ; * Top-level statements
 ; * Multi-line compound statements and subshells
-; * In any branch of a conditional or case statement
+; * Any branch of a conditional or case statement
 ; * Loop bodies
 ; * Multi-line command substitutions
+;
+; We address each context individually, as there's no way to isolate the
+; exceptional contexts, where no line spacing is required.
+;
+; When a "command" is followed by another "command" or context, it
+; should be interposed by a new (soft)line, for the sake of single-line
+; compound statements and subshells.
 
 (program
   [(command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)] @append_hardline
   .
-  [(command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 ; NOTE Single-line compound statements are a thing; hence the softline
 (compound_statement
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 ; NOTE Single-line subshells are a thing; hence the softline
 (subshell
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 (if_statement
@@ -270,7 +286,12 @@
   "then"
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 (elif_clause
@@ -279,7 +300,12 @@
   "then"
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 (else_clause
@@ -287,7 +313,12 @@
   "else"
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 ; NOTE Single-line case branches are a thing; hence the softline
@@ -297,7 +328,12 @@
   ")"
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_spaced_softline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 (do_group
@@ -305,21 +341,36 @@
   "do"
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_hardline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 ; NOTE Single-line command substitutions are a thing; hence the softline
 (command_substitution
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @append_empty_softline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 ; NOTE Single-line command substitutions are a thing; hence the softline
 (command_substitution
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)] @prepend_empty_softline
   .
-  [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement) (variable_assignment)]
+  [
+    ; Commands
+    (command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement) (variable_assignment)
+    ; Contexts
+    (c_style_for_statement) (case_statement) (for_statement) (function_definition) (if_statement) (while_statement)
+  ]
 )
 
 ; Surround command list and pipeline delimiters with spaces
@@ -379,7 +430,7 @@
 
 ;; Redirections
 
-; Insert a space before all redirections, but _not_ after the operator
+; Insert a space before all redirection operators, but _not_ after
 (redirected_statement
   redirect: _* @prepend_space
 )
@@ -528,17 +579,13 @@
 ; NOTE Much of the formatting work for function definitions is done by
 ; whatever already-defined queries apply to the function body (e.g.,
 ; (compound_statement), etc.). All we do here is ensure functions get
-; their own line and put a space between its name and the body.
-; FIXME We may not need this any more
-; FIXME ; (function_definition) @prepend_hardline
+; a space between its name and body, a new line afterwards and deleting
+; the redundant "function" keyword, if it exists in the input.
 
 (function_definition
-  body: _ @prepend_space
+  body: _ @prepend_space @append_hardline
 )
 
-; NOTE The "function" keyword in function definitions is optional and
-; thus usually considered redundant. Therefore we delete it, if it's
-; present in the input.
 (function_definition
   .
   "function" @delete

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -58,7 +58,6 @@ esac
 {
   here
   is
-
   { a; nested; compound; }
 }
 
@@ -69,7 +68,6 @@ fi
 (
   here
   is
-
   ( a; nested; subshell )
 )
 
@@ -81,12 +79,10 @@ fi
 
 (
   one
-
   {
     inside
     the
   }
-
   other
 )
 
@@ -134,3 +130,4 @@ export xyzzy=$(
   something
   another_thing --foo
 )
+


### PR DESCRIPTION
This PR reverses the new line strategy from prepending to appending, this has two benefits:

1. The intention is clearer (i.e., it's more familiar to think of appending new lines to the end of a node than prepending one to its beginning).
2. In theory, it should make the rules for comments easier/possible to write. In particular, the prepending strategy conflicts with how to deal with trailing comments. (Rules for comments will be addressed in a subsequent PR: #186.)

Notes:
* The only way I could get indentation blocks to work correctly (see https://github.com/tweag/topiary/pull/182#discussion_r1083931668) was to prepend a new line before the block's closing node. When this is preceded by a node that appends a new line, you end up with a blank line in between, like this:

  ```bash
  while true; do
    foo
    bar

  done
  ```

  To work around this, new lines are not appended to the last node in the block. Because we have to enumerate rules over large complementary sets of nodes (to avoid the exceptions), that makes the new rules rather verbose.
* Some nodes, at the end of the input source, will introduce an errant trailing blank line. This can be fixed, relatively easily but at the expense of further complication to the queries, but it is not a priority.