### PR TITLE
[OCaml] List formatting

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -434,6 +434,7 @@
   [
     ; Don't add any space just before these.
     ","
+    ";"
     "."
     ".."
     ")"
@@ -1020,6 +1021,27 @@
 )
 (product_expression
   "," @append_spaced_softline
+)
+
+; Indent and add softlines in lists, such as
+; let _ =
+;   [
+;     long_value_1;
+;     long_value_2;
+;     long_value_3;
+;   ]
+(list_expression
+  .
+  "[" @append_indent_start @append_empty_softline
+  "]" @prepend_indent_end @prepend_empty_softline
+  .
+)
+
+(list_pattern
+  .
+  "[" @append_indent_start @append_empty_softline
+  "]" @prepend_indent_end @prepend_empty_softline
+  .
 )
 
 ; Try block formatting

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -573,6 +573,13 @@ let large_const =
     (long_argument_4 : int) ->
     val
 
+let _ =
+  [
+    1;
+    2;
+    3
+  ]
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind
@@ -588,11 +595,11 @@ let greetings =
   Some (msg1 ^ msg2)
 
 (* Some pattern-matching *)
-let hd::_ = [1, 2, 3]
+let hd::_ = [1; 2; 3]
 
 let Some message = Some "message"
 
-let [1, snd] = [1, 2]
+let [1; snd] = [1; 2]
 
 type a = int
 and b = float

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -569,6 +569,9 @@ let large_const =
     (long_argument_4 : int) ->
     val
 
+let _ = [1; 2;
+  3]
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind
@@ -584,11 +587,11 @@ let greetings =
   Some (msg1 ^ msg2)
 
 (* Some pattern-matching *)
-let hd::_ = [1, 2, 3]
+let hd::_ = [1; 2; 3]
 
 let Some message = Some "message"
 
-let [1, snd] = [1, 2]
+let [1; snd] = [1; 2]
 
 type a = int and
 b = float


### PR DESCRIPTION
Allows proper formatting of
```ocaml
let _ =
  [
    1;
    2;
    3
  ]
```

Ideally, we would want to add a final `;` to multiline lists, but we don't have the capacity to do that yet: see #199.

Closes #189 