### PR TITLE
Introduce `prepend/append_multiline_delimiter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,29 @@ Otherwise, the `";"*` captures nothing and in this case the associated instructi
 
 Note that `@append_delimiter` is the same as `@append_space` when the delimiter is set to `" "` (space).
 
+### @append_multiline_delimiter / @prepend_multiline_delimiter
+
+The matched nodes will have a multi-line-only delimiter appended to them.
+It will be printed only in multi-line nodes, and omitted in single-line nodes. The delimiter must be specified using the predicate `#delimiter!`.
+
+#### Example
+
+```scheme
+; Add a semicolon at the end of lists only if they are multiline, to avoid [1; 2; 3;].
+(list_expression
+  (#delimiter! ";")
+  (_) @append_multiline_delimiter
+  .
+  ";"? @do_nothing
+  .
+  "]"
+  .
+)
+```
+
+If there is already a semicolon, the `@do_nothing` instruction will be activated
+and prevent the other instruction in the query (the `@append_multiline_delimiter`) to activate. Likewise, if the node is single-line, the delimiter will not be appended either.
+
 ### @append_empty_softline / @prepend_empty_softline
 
 The matched nodes will have an empty softline appended or prepended to them.

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1036,11 +1036,29 @@
   "]" @prepend_indent_end @prepend_empty_softline
   .
 )
+(list_expression
+  (#delimiter! ";")
+  (_) @append_multiline_delimiter
+  .
+  ";"? @do_nothing
+  .
+  "]"
+  .
+)
 
 (list_pattern
   .
   "[" @append_indent_start @append_empty_softline
   "]" @prepend_indent_end @prepend_empty_softline
+  .
+)
+(list_pattern
+  (#delimiter! ";")
+  (_) @append_multiline_delimiter
+  .
+  ";"? @do_nothing
+  .
+  "]"
   .
 )
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ pub enum Atom {
     },
     /// Represents a literal string, such as a semicolon.
     Literal(String),
+    /// Represents a literal string, such as a semicolon. It will be printed only
+    // in multi-line constructs
+    MultilineOnlyLiteral(String),
     /// Represents a softline. It will be turned into a hardline for multi-line
     /// constructs, and either a space or nothing for single-line constructs.
     Softline {

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -22,6 +22,7 @@ fn atoms_to_doc<'a>(i: &mut usize, atoms: &'a [Atom], indent_level: isize) -> Rc
                 &Atom::Hardline => RcDoc::hardline(),
                 Atom::Leaf { content, .. } => RcDoc::text(content.trim_end()),
                 Atom::Literal(s) => RcDoc::text(s),
+                Atom::MultilineOnlyLiteral { .. } => unreachable!(),
                 Atom::IndentEnd => unreachable!(),
                 Atom::IndentStart => {
                     *i += 1;

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -577,7 +577,7 @@ let _ =
   [
     1;
     2;
-    3
+    3;
   ]
 
 (* Showcase the usage of operator bindings *)


### PR DESCRIPTION
### @append_multiline_delimiter / @prepend_multiline_delimiter

The matched nodes will have a multiline-only delimiter appended to them.
It will be printed only in multi-line nodes, and omited in single-line nodes. The delimiter must be specified using the predicate `#delimiter!`.

#### Example

```scheme
; Add a semicolon at the end of lists only if they are multiline, to avoid [1; 2; 3;].
(list_expression
  (#delimiter! ";")
  (_) @append_multiline_delimiter
  .
  ";"? @do_nothing
  .
  "]"
  .
)
```

This allows proper formatting of the following:
```ocaml
let _ =
  [
    1;
    2;
    3;
  ]

let _ = [1; 2; 3]
```
Closes #199 