### PR TITLE
[OCaml] Line break after top-level open module

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -86,7 +86,7 @@
 ; Also append line breaks after open_module, except when it's
 ; preceded by "let", because in this case it's in a let_open_expression.
 (
-  "let" @do_nothing
+  "let"? @do_nothing
   .
   (open_module) @append_hardline
   .

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -766,3 +766,11 @@ let _ =
     5,
     6
   )
+
+(* Open and let open *)
+open Foo
+open Bar
+
+let _ =
+  let open Baz in
+  ()

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -749,3 +749,11 @@ let _ =
 let _ =
   (1, 2, (3, 4),
   5, 6)
+
+(* Open and let open *)
+open Foo
+open Bar
+
+let _ =
+  let open Baz in
+  ()


### PR DESCRIPTION
Allows proper formatting of:
```ocaml
open Foo
open Bar

let _ =
  let open Baz in
  ()
```

Closes #214