### PR TITLE
[OCaml] Softlines and indentation in functor arguments

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1164,6 +1164,26 @@
   .
 )
 
+; Allow softlines and indentation in functor definitions with many arguments, such as
+; module Lift
+;   (Credit: module type of CreditSignature)
+;   (Dance: module type of DanceSignature)
+;   (Tune: module type of TuneSignature)
+;   (Version: module type of VersionSignature)
+; = struct
+;   let foo = x
+; end
+(module_binding
+  (module_name) @append_indent_start @begin_scope
+  "=" @prepend_indent_end @end_scope
+  (#scope_id! "module_binding_before_equal")
+)
+(module_binding
+  (module_name) @append_empty_scoped_softline
+  (module_parameter) @append_spaced_scoped_softline
+  (#scope_id! "module_binding_before_equal")
+)
+
 ; Try block formatting
 ; A soft linebreak after the "try" (potentially "try%ppx") and one after the "with".
 (try_expression

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -789,3 +789,13 @@ open Bar
 let _ =
   let open Baz in
   ()
+
+(* Multi-line functor signatures *)
+module Lift
+  (Credit: module type of CreditSignature)
+  (Dance: module type of DanceSignature)
+  (Tune: module type of TuneSignature)
+  (Version: module type of VersionSignature)
+= struct
+  let foo = x
+end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -772,3 +772,13 @@ open Bar
 let _ =
   let open Baz in
   ()
+
+(* Multi-line functor signatures *)
+module Lift
+  (Credit: module type of CreditSignature)
+  (Dance: module type of DanceSignature)
+  (Tune: module type of TuneSignature)
+  (Version: module type of VersionSignature)
+= struct
+  let foo = x
+end


### PR DESCRIPTION
Allows correct formatting of
```ocaml
module Lift
  (Credit: module type of CreditSignature)
  (Dance: module type of DanceSignature)
  (Tune: module type of TuneSignature)
  (Version: module type of VersionSignature)
= struct
  let foo = x
end
```
Closes #217