### PR TITLE
[OCaml] Indentation and softlines in arrays

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1125,7 +1125,7 @@
   (#scope_id! "function_type")
 )
 
-; Indent and add softlines in lists, such as
+; Indent and add softlines in lists and arrays, such as
 ; let _ =
 ;   [
 ;     long_value_1;
@@ -1161,6 +1161,38 @@
   ";"? @do_nothing
   .
   "]"
+  .
+)
+
+(array_expression
+  .
+  "[|" @append_indent_start @append_empty_softline
+  "|]" @prepend_indent_end @prepend_empty_softline
+  .
+)
+(array_expression
+  (#delimiter! ";")
+  (_) @append_multiline_delimiter
+  .
+  ";"? @do_nothing
+  .
+  "|]"
+  .
+)
+
+(array_pattern
+  .
+  "[|" @append_indent_start @append_empty_softline
+  "|]" @prepend_indent_end @prepend_empty_softline
+  .
+)
+(array_pattern
+  (#delimiter! ";")
+  (_) @append_multiline_delimiter
+  .
+  ";"? @do_nothing
+  .
+  "|]"
   .
 )
 

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -573,12 +573,19 @@ let large_const =
     (long_argument_4 : int) ->
     val
 
-let _ =
+let [a; _; _] =
   [
     1;
     2;
     3;
   ]
+
+let [|a; _; _|] =
+  [|
+    1;
+    2;
+    3;
+  |]
 
 (* Showcase the usage of operator bindings *)
 let greetings =

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -569,8 +569,11 @@ let large_const =
     (long_argument_4 : int) ->
     val
 
-let _ = [1; 2;
+let [a; _; _] = [1; 2;
   3]
+
+let [|a; _; _|] = [|1; 2;
+  3|]
 
 (* Showcase the usage of operator bindings *)
 let greetings =


### PR DESCRIPTION
Formats
```ocaml
let [|a; _; _|] = [|1; 2;
  3|]
```
as
```ocaml
let [|a; _; _|] =
  [|
    1;
    2;
    3;
  |]
```

Closes #230