### PR TITLE
Write out the diff to the error log, rather than panicking

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -103,7 +103,7 @@ impl fmt::Display for FormatterError {
             Self::Formatting(_err) => {
                 write!(
                     f,
-                    "The formatter errored when trying to format the code twice (idempotence check).\nThis probably means that the formatter produced invalid code.\n{please_log_message}"
+                    "The formatter failed when trying to format the code twice (idempotence check).\nThis probably means that the formatter produced invalid code.\n{please_log_message}"
                 )
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use configuration::Configuration;
 pub use error::{FormatterError, ReadingError, WritingError};
 use itertools::Itertools;
 pub use language::Language;
-use pretty_assertions::assert_eq;
+use pretty_assertions::StrComparison;
 use std::io;
 
 mod atom_collection;
@@ -177,7 +177,7 @@ fn idempotence_check(
             Ok(())
         } else {
             log::error!("Failed idempotence check");
-            assert_eq!(content, reformatted);
+            log::error!("{}", StrComparison::new(content, &reformatted));
             Err(FormatterError::Idempotence)
         }
     };


### PR DESCRIPTION
This PR changes the error message when there is an idempotency failure by outputting the colourised diff, as before, but without panicking.

Error style before change:

![image](https://user-images.githubusercontent.com/5920602/216139895-8aafb2ac-7930-4db2-8054-a6c6d63c8d4d.png)

Error style after change:

![image](https://user-images.githubusercontent.com/384987/216981410-47a51f06-5c40-4066-926c-06e69b1387ff.png)

Resolves #221