### PR TITLE
[OCaml] line breaks between value specifications

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -95,7 +95,10 @@
 
 ; Consecutive definitions must be separated by line breaks
 (
-  (value_definition) @append_hardline
+  [
+    (value_definition)
+    (value_specification)
+  ] @append_hardline
   .
   [
     (exception_definition)
@@ -105,6 +108,7 @@
     (open_module)
     (type_definition)
     (value_definition)
+    (value_specification)
   ]
 )
 

--- a/tests/samples/expected/ocaml.mli
+++ b/tests/samples/expected/ocaml.mli
@@ -3695,14 +3695,10 @@ module Sc_rollup: sig
       type proof
 
       val proof_encoding : proof Data_encoding.t
-
       val proof_before : proof -> State_hash.t
-
       val proof_after : proof -> State_hash.t
-
       val verify_proof :
       proof -> (tree -> (tree * 'a ) Lwt.t) -> (tree * 'a ) option Lwt.t
-
       val produce_proof :
       Tree.t ->
       tree ->

--- a/tests/samples/input/ocaml.mli
+++ b/tests/samples/input/ocaml.mli
@@ -3670,14 +3670,10 @@ module Sc_rollup : sig
       type proof
 
       val proof_encoding : proof Data_encoding.t
-
       val proof_before : proof -> State_hash.t
-
       val proof_after : proof -> State_hash.t
-
       val verify_proof :
         proof -> (tree -> (tree * 'a) Lwt.t) -> (tree * 'a) option Lwt.t
-
       val produce_proof :
         Tree.t ->
         tree ->


### PR DESCRIPTION
Allows correct formatting of
```ocaml
val foo :
  bar ->
  baz
```
Closes #228