### PR TITLE
[OCaml] function type indentation in interface files

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -900,6 +900,12 @@
   ; well as the final non-named node, causing double indentation.
 )
 
+(value_specification
+  ":" @append_indent_start
+  (_) @append_indent_end
+  .
+)
+
 ; Make an indented block after "=" in
 ; * class[_type] bindings
 ; * method definitions

--- a/tests/samples/expected/ocaml.mli
+++ b/tests/samples/expected/ocaml.mli
@@ -91,10 +91,10 @@ module Slot: sig
     val fold : ( 'a -> slot -> 'a) -> 'a -> t -> 'a
 
     val fold_es :
-    ( 'a -> slot -> 'a tzresult Lwt.t) -> 'a -> t -> 'a tzresult Lwt.t
+      ( 'a -> slot -> 'a tzresult Lwt.t) -> 'a -> t -> 'a tzresult Lwt.t
 
     val rev_fold_es :
-    ( 'a -> slot -> 'a tzresult Lwt.t) -> 'a -> t -> 'a tzresult Lwt.t
+      ( 'a -> slot -> 'a tzresult Lwt.t) -> 'a -> t -> 'a tzresult Lwt.t
   end
 
   module Map: Map.S with type key = t
@@ -322,38 +322,38 @@ module Round: sig
 
   module Durations: sig
     val create :
-    first_round_duration: Period.t ->
-    delay_increment_per_round: Period.t ->
-    round_durations tzresult
+      first_round_duration: Period.t ->
+      delay_increment_per_round: Period.t ->
+      round_durations tzresult
 
     val create_opt :
-    first_round_duration: Period.t ->
-    delay_increment_per_round: Period.t ->
-    round_durations option
+      first_round_duration: Period.t ->
+      delay_increment_per_round: Period.t ->
+      round_durations option
   end
 
   val level_offset_of_round : round_durations -> round: t -> Period.t tzresult
 
   val timestamp_of_round :
-  round_durations ->
-  predecessor_timestamp: Time.t ->
-  predecessor_round: t ->
-  round: t ->
-  Time.t tzresult
+    round_durations ->
+    predecessor_timestamp: Time.t ->
+    predecessor_round: t ->
+    round: t ->
+    Time.t tzresult
 
   val timestamp_of_another_round_same_level :
-  round_durations ->
-  current_timestamp: Time.t ->
-  current_round: t ->
-  considered_round: t ->
-  Time.t tzresult
+    round_durations ->
+    current_timestamp: Time.t ->
+    current_round: t ->
+    considered_round: t ->
+    Time.t tzresult
 
   val round_of_timestamp :
-  round_durations ->
-  predecessor_timestamp: Time.t ->
-  predecessor_round: t ->
-  timestamp: Time.t ->
-  t tzresult
+    round_durations ->
+    predecessor_timestamp: Time.t ->
+    predecessor_round: t ->
+    timestamp: Time.t ->
+    t tzresult
 
   (* retrieve a round from the context *)
   val get : context -> t tzresult Lwt.t
@@ -468,9 +468,9 @@ module Gas: sig
       @return [Error Gas_limit_too_high] if [gas_limit] is greater
       than [hard_gas_limit_per_operation] or negative. *)
   val check_gas_limit :
-  hard_gas_limit_per_operation: Arith.integral ->
-  gas_limit: Arith.integral ->
-  unit tzresult
+    hard_gas_limit_per_operation: Arith.integral ->
+    gas_limit: Arith.integral ->
+    unit tzresult
 
   (** The cost of free operation is [0]. *)
   val free : cost
@@ -734,15 +734,15 @@ module Script: sig
   (** Decode an expression in the context after consuming the deserialization
       gas cost (see {!consume_deserialization_gas}). *)
   val force_decode_in_context :
-  consume_deserialization_gas: consume_deserialization_gas ->
-  context ->
-  lazy_expr ->
-  (expr * context ) tzresult
+    consume_deserialization_gas: consume_deserialization_gas ->
+    context ->
+    lazy_expr ->
+    (expr * context ) tzresult
 
   (** Decode an expression in the context after consuming the deserialization
       gas cost. *)
   val force_bytes_in_context :
-  context -> lazy_expr -> (bytes * context ) tzresult
+    context -> lazy_expr -> (bytes * context ) tzresult
 
   (** [consume_decoding_gas available_gas lexpr] subtracts (a lower
       bound on) the cost to deserialize [lexpr] from [available_gas].
@@ -901,7 +901,7 @@ module Constants: sig
     }
 
     val generate :
-    consensus_committee_size: int -> blocks_per_minute: Ratio.t -> t
+      consensus_committee_size: int -> blocks_per_minute: Ratio.t -> t
   end
 
   val parametric : context -> Parametric.t
@@ -976,7 +976,7 @@ module Constants: sig
   val double_baking_punishment : context -> Tez.t
 
   val ratio_of_frozen_deposits_slashed_per_double_endorsement :
-  context -> Ratio.t
+    context -> Ratio.t
 
   val testnet_dictator : context -> public_key_hash option
 
@@ -1084,7 +1084,7 @@ module Global_constants_storage: sig
     Consumes [Gas_repr.write_bytes_cost <size>] where size is the number
     of bytes in the binary serialization provided by [Script.expr_encoding].*)
   val register :
-  t -> Script.expr -> (t * Script_expr_hash.t * Z.t ) tzresult Lwt.t
+    t -> Script.expr -> (t * Script_expr_hash.t * Z.t ) tzresult Lwt.t
 
   (** [expand context expr] Replaces every constant in the
     given Michelson expression with its value stored in the global table.
@@ -1121,14 +1121,14 @@ module Global_constants_storage: sig
         Notice that a common source of bug is to forget to properly call the
         continuation in `f`. *)
     val bottom_up_fold_cps :
-    'accumulator ->
-    'loc Script.michelson_node ->
-    ( 'accumulator -> 'loc Script.michelson_node -> 'return) ->
-    ( 'accumulator ->
-    'loc Script.michelson_node ->
-    ( 'accumulator -> 'loc Script.michelson_node -> 'return) ->
-    'return) ->
-    'return
+      'accumulator ->
+      'loc Script.michelson_node ->
+      ( 'accumulator -> 'loc Script.michelson_node -> 'return) ->
+      ( 'accumulator ->
+      'loc Script.michelson_node ->
+      ( 'accumulator -> 'loc Script.michelson_node -> 'return) ->
+      'return) ->
+      'return
 
     (** [expr_to_address_in_context context expr] converts [expr]
        into a unique hash represented by a [Script_expr_hash.t].
@@ -1136,7 +1136,7 @@ module Global_constants_storage: sig
        Consumes gas corresponding to the cost of converting [expr]
        to bytes and hashing the bytes. *)
     val expr_to_address_in_context :
-    t -> Script.expr -> (t * Script_expr_hash.t ) tzresult
+      t -> Script.expr -> (t * Script_expr_hash.t ) tzresult
   end
 end
 
@@ -1173,7 +1173,7 @@ module Level: sig
 
   (** Fails with [Negative_level_and_offset_sum] if the sum of the raw_level and the offset is negative. *)
   val from_raw_with_offset :
-  context -> offset: int32 -> Raw_level.t -> level tzresult
+    context -> offset: int32 -> Raw_level.t -> level tzresult
 
   (** [add c level i] i must be positive *)
   val add : context -> level -> int -> level
@@ -1213,14 +1213,14 @@ module Fitness: sig
   val pp : Format.formatter -> t -> unit
 
   val create :
-  level: Raw_level.t ->
-  locked_round: Round.t option ->
-  predecessor_round: Round.t ->
-  round: Round.t ->
-  t tzresult
+    level: Raw_level.t ->
+    locked_round: Round.t option ->
+    predecessor_round: Round.t ->
+    round: Round.t ->
+    t tzresult
 
   val create_without_locked_round :
-  level: Raw_level.t -> predecessor_round: Round.t -> round: Round.t -> t
+    level: Raw_level.t -> predecessor_round: Round.t -> round: Round.t -> t
 
   val to_raw : t -> raw
 
@@ -1288,7 +1288,7 @@ module Seed: sig
     | Too_early_revelation
 
   val generate_vdf_setup :
-  seed_discriminant: seed -> seed_challenge: seed -> vdf_setup
+    seed_discriminant: seed -> seed_challenge: seed -> vdf_setup
 
   (** See {!Seed_storage.check_vdf}. *)
   val check_vdf : context -> vdf_solution -> unit tzresult Lwt.t
@@ -1310,7 +1310,7 @@ module Seed: sig
   val for_cycle : context -> Cycle.t -> seed tzresult Lwt.t
 
   val get_seed_computation_status :
-  context -> seed_computation_status tzresult Lwt.t
+    context -> seed_computation_status tzresult Lwt.t
 end
 
 (** Big maps are a data structure storing key-value associations, just like
@@ -1340,22 +1340,22 @@ module Big_map: sig
 
   (** Carbonated membership of a key (from its hash) in a big map. *)
   val mem :
-  context -> Id.t -> Script_expr_hash.t -> (context * bool ) tzresult Lwt.t
+    context -> Id.t -> Script_expr_hash.t -> (context * bool ) tzresult Lwt.t
 
   (** Carbonated retrieval of the value associated to a key (from its hash) in
       a big map, if any. *)
   val get_opt :
-  context ->
-  Id.t ->
-  Script_expr_hash.t ->
-  (context * Script.expr option ) tzresult Lwt.t
+    context ->
+    Id.t ->
+    Script_expr_hash.t ->
+    (context * Script.expr option ) tzresult Lwt.t
 
   (** Carbonated retrieval of the key and value types of the bindings in a big
       map referenced by its identifier, if this identifier is actually bound to a big map in the context. *)
   val exists :
-  context ->
-  Id.t ->
-  (context * (Script.expr * Script.expr ) option ) tzresult Lwt.t
+    context ->
+    Id.t ->
+    (context * (Script.expr * Script.expr ) option ) tzresult Lwt.t
 
   (** [list_key_values ?offset ?length ctxt id] lists the key hash and value for
       each entry in big map [id]. The first [offset] values are ignored (if
@@ -1366,11 +1366,11 @@ module Big_map: sig
       The returned {!context} takes into account gas consumption of traversing
       the keys and loading values. *)
   val list_key_values :
-  ?offset: int ->
-  ?length: int ->
-  context ->
-  Id.t ->
-  (context * (Script_expr_hash.t * Script.expr ) list ) tzresult Lwt.t
+    ?offset: int ->
+    ?length: int ->
+    context ->
+    Id.t ->
+    (context * (Script_expr_hash.t * Script.expr ) list ) tzresult Lwt.t
 
   (** The type of big map updates. When [value = None], the potential binding
       associated to the [key] will be removed. *)
@@ -1458,19 +1458,19 @@ module Sapling: sig
   (* Function exposed as RPC. Returns the root and a diff of a state starting
      from an optional offset which is zero by default. *)
   val get_diff :
-  context ->
-  Id.t ->
-  ?offset_commitment: Int64.t ->
-  ?offset_nullifier: Int64.t ->
-  unit ->
-  (root * diff ) tzresult Lwt.t
+    context ->
+    Id.t ->
+    ?offset_commitment: Int64.t ->
+    ?offset_nullifier: Int64.t ->
+    unit ->
+    (root * diff ) tzresult Lwt.t
 
   val verify_update :
-  context ->
-  state ->
-  transaction ->
-  string ->
-  (context * (Int64.t * state ) option ) tzresult Lwt.t
+    context ->
+    state ->
+    transaction ->
+    string ->
+    (context * (Int64.t * state ) option ) tzresult Lwt.t
 
   (** See {!Lazy_storage_kind.Sapling_state.alloc}. *)
   type alloc = { memo_size: Memo_size.t; }
@@ -1489,14 +1489,14 @@ module Sapling: sig
     val transaction_get_memo_size : transaction -> Memo_size.t option
 
     val transaction_in_memory_size :
-    transaction -> Saturation_repr.may_saturate Saturation_repr.t
+      transaction -> Saturation_repr.may_saturate Saturation_repr.t
 
     val verify_update :
-    context ->
-    state ->
-    transaction ->
-    string ->
-    (context * (Int64.t * state ) option ) tzresult Lwt.t
+      context ->
+      state ->
+      transaction ->
+      string ->
+      (context * (Int64.t * state ) option ) tzresult Lwt.t
   end
 end
 
@@ -1600,22 +1600,22 @@ module Ticket_hash: sig
   val compare : t -> t -> int
 
   val make :
-  context ->
-  ticketer: Script.node ->
-  ty: Script.node ->
-  contents: Script.node ->
-  owner: Script.node ->
-  (t * context ) tzresult
+    context ->
+    ticketer: Script.node ->
+    ty: Script.node ->
+    contents: Script.node ->
+    owner: Script.node ->
+    (t * context ) tzresult
 
   (** This module discloses definitions that are only useful for tests and must
       not be used otherwise. *)
   module Internal_for_tests: sig
     val make_uncarbonated :
-    ticketer: Script.node ->
-    ty: Script.node ->
-    contents: Script.node ->
-    owner: Script.node ->
-    t tzresult
+      ticketer: Script.node ->
+      ty: Script.node ->
+      contents: Script.node ->
+      owner: Script.node ->
+      t tzresult
   end
 end
 
@@ -1692,82 +1692,82 @@ module Contract: sig
 
   (** See {!Contract_manager_storage.get_manager_key}. *)
   val get_manager_key :
-  ?error: error -> context -> public_key_hash -> public_key tzresult Lwt.t
+    ?error: error -> context -> public_key_hash -> public_key tzresult Lwt.t
 
   (** See {!Contract_manager_storage.is_manager_key_revealed}. *)
   val is_manager_key_revealed :
-  context -> public_key_hash -> bool tzresult Lwt.t
+    context -> public_key_hash -> bool tzresult Lwt.t
 
   (** See {!Contract_manager_storage.check_public_key}. *)
   val check_public_key : public_key -> public_key_hash -> unit tzresult
 
   (** See {!Contract_manager_storage.reveal_manager_key}. *)
   val reveal_manager_key :
-  ?check_consistency: bool ->
-  context ->
-  public_key_hash ->
-  public_key ->
-  context tzresult Lwt.t
+    ?check_consistency: bool ->
+    context ->
+    public_key_hash ->
+    public_key ->
+    context tzresult Lwt.t
 
   val get_counter :
-  context -> public_key_hash -> Manager_counter.t tzresult Lwt.t
+    context -> public_key_hash -> Manager_counter.t tzresult Lwt.t
 
   val increment_counter : context -> public_key_hash -> context tzresult Lwt.t
 
   val check_counter_increment :
-  context -> public_key_hash -> Manager_counter.t -> unit tzresult Lwt.t
+    context -> public_key_hash -> Manager_counter.t -> unit tzresult Lwt.t
 
   (** See {!Contract_storage.check_allocated_and_get_balance}. *)
   val check_allocated_and_get_balance :
-  context -> public_key_hash -> Tez.t tzresult Lwt.t
+    context -> public_key_hash -> Tez.t tzresult Lwt.t
 
   (** See {!Contract_storage.simulate_spending}. *)
   val simulate_spending :
-  context ->
-  balance: Tez.t ->
-  amount: Tez.t ->
-  public_key_hash ->
-  (Tez.t * bool ) tzresult Lwt.t
+    context ->
+    balance: Tez.t ->
+    amount: Tez.t ->
+    public_key_hash ->
+    (Tez.t * bool ) tzresult Lwt.t
 
   (** Functions related to smart contracts. *)
 
   val get_script_code :
-  context ->
-  Contract_hash.t ->
-  (context * Script.lazy_expr option ) tzresult Lwt.t
+    context ->
+    Contract_hash.t ->
+    (context * Script.lazy_expr option ) tzresult Lwt.t
 
   val get_script :
-  context -> Contract_hash.t -> (context * Script.t option ) tzresult Lwt.t
+    context -> Contract_hash.t -> (context * Script.t option ) tzresult Lwt.t
 
   val get_storage :
-  context -> Contract_hash.t -> (context * Script.expr option ) tzresult Lwt.t
+    context -> Contract_hash.t -> (context * Script.expr option ) tzresult Lwt.t
 
   val used_storage_space : context -> t -> Z.t tzresult Lwt.t
 
   val paid_storage_space : context -> t -> Z.t tzresult Lwt.t
 
   val increase_paid_storage :
-  context -> Contract_hash.t -> amount_in_bytes: Z.t -> context tzresult Lwt.t
+    context -> Contract_hash.t -> amount_in_bytes: Z.t -> context tzresult Lwt.t
 
   val fresh_contract_from_current_nonce :
-  context -> (context * Contract_hash.t ) tzresult
+    context -> (context * Contract_hash.t ) tzresult
 
   val originated_from_current_nonce :
-  since: context -> until: context -> Contract_hash.t list tzresult Lwt.t
+    since: context -> until: context -> Contract_hash.t list tzresult Lwt.t
 
   val update_script_storage :
-  context ->
-  Contract_hash.t ->
-  Script.expr ->
-  Lazy_storage.diffs option ->
-  context tzresult Lwt.t
+    context ->
+    Contract_hash.t ->
+    Script.expr ->
+    Lazy_storage.diffs option ->
+    context tzresult Lwt.t
 
   val raw_originate :
-  context ->
-  prepaid_bootstrap_storage: bool ->
-  Contract_hash.t ->
-  script: Script.t * Lazy_storage.diffs option ->
-  context tzresult Lwt.t
+    context ->
+    prepaid_bootstrap_storage: bool ->
+    Contract_hash.t ->
+    script: Script.t * Lazy_storage.diffs option ->
+    context tzresult Lwt.t
 
   module Legacy_big_map_diff: sig
     type item = private
@@ -1947,7 +1947,7 @@ module Tx_rollup_state: sig
   val check_level_can_be_rejected : t -> Tx_rollup_level.t -> unit tzresult
 
   val last_removed_commitment_hashes :
-  t -> (Tx_rollup_message_result_hash.t * Tx_rollup_commitment_hash.t ) option
+    t -> (Tx_rollup_message_result_hash.t * Tx_rollup_commitment_hash.t ) option
 
   val adjust_storage_allocation : t -> delta: Z.t -> (t * Z.t ) tzresult
 
@@ -1955,23 +1955,23 @@ module Tx_rollup_state: sig
       not be used otherwise. *)
   module Internal_for_tests: sig
     val make :
-    ?burn_per_byte: Tez.t ->
-    ?inbox_ema: int ->
-    ?last_removed_commitment_hashes:
-    Tx_rollup_message_result_hash.t * Tx_rollup_commitment_hash.t ->
-    ?finalized_commitments: Tx_rollup_level.t * Tx_rollup_level.t ->
-    ?unfinalized_commitments: Tx_rollup_level.t * Tx_rollup_level.t ->
-    ?uncommitted_inboxes: Tx_rollup_level.t * Tx_rollup_level.t ->
-    ?commitment_newest_hash: Tx_rollup_commitment_hash.t ->
-    ?tezos_head_level: Raw_level.t ->
-    ?occupied_storage: Z.t ->
-    ?commitments_watermark: Tx_rollup_level.t ->
-    allocated_storage: Z.t ->
-    unit ->
-    t
+      ?burn_per_byte: Tez.t ->
+      ?inbox_ema: int ->
+      ?last_removed_commitment_hashes:
+      Tx_rollup_message_result_hash.t * Tx_rollup_commitment_hash.t ->
+      ?finalized_commitments: Tx_rollup_level.t * Tx_rollup_level.t ->
+      ?unfinalized_commitments: Tx_rollup_level.t * Tx_rollup_level.t ->
+      ?uncommitted_inboxes: Tx_rollup_level.t * Tx_rollup_level.t ->
+      ?commitment_newest_hash: Tx_rollup_commitment_hash.t ->
+      ?tezos_head_level: Raw_level.t ->
+      ?occupied_storage: Z.t ->
+      ?commitments_watermark: Tx_rollup_level.t ->
+      allocated_storage: Z.t ->
+      unit ->
+      t
 
     val update_burn_per_byte :
-    t -> elapsed: int -> factor: int -> final_size: int -> hard_limit: int -> t
+      t -> elapsed: int -> factor: int -> final_size: int -> hard_limit: int -> t
 
     val get_inbox_ema : t -> int
 
@@ -2009,21 +2009,21 @@ module Tx_rollup_reveal: sig
   val encoding : t Data_encoding.t
 
   val record :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_level.t ->
-  message_position: int ->
-  context tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_level.t ->
+    message_position: int ->
+    context tzresult Lwt.t
 
   val mem :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_level.t ->
-  message_position: int ->
-  (context * bool ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_level.t ->
+    message_position: int ->
+    (context * bool ) tzresult Lwt.t
 
   val remove :
-  context -> Tx_rollup.t -> Tx_rollup_level.t -> context tzresult Lwt.t
+    context -> Tx_rollup.t -> Tx_rollup_level.t -> context tzresult Lwt.t
 end
 
 (** This module re-exports definitions from {!Tx_rollup_message_repr}. *)
@@ -2047,11 +2047,11 @@ module Tx_rollup_message: sig
       along with its size in bytes. See
       {!Tx_rollup_message_repr.size}. *)
   val make_deposit :
-  public_key_hash ->
-  Tx_rollup_l2_address.t Indexable.value ->
-  Ticket_hash.t ->
-  Tx_rollup_l2_qty.t ->
-  t * int
+    public_key_hash ->
+    Tx_rollup_l2_address.t Indexable.value ->
+    Ticket_hash.t ->
+    Tx_rollup_l2_qty.t ->
+    t * int
 
   val encoding : t Data_encoding.t
 
@@ -2097,29 +2097,29 @@ module Tx_rollup_inbox: sig
   val encoding : t Data_encoding.t
 
   val append_message :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  Tx_rollup_message.t ->
-  (context * Tx_rollup_state.t * Z.t ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    Tx_rollup_message.t ->
+    (context * Tx_rollup_state.t * Z.t ) tzresult Lwt.t
 
   val get :
-  context -> Tx_rollup_level.t -> Tx_rollup.t -> (context * t ) tzresult Lwt.t
+    context -> Tx_rollup_level.t -> Tx_rollup.t -> (context * t ) tzresult Lwt.t
 
   val find :
-  context ->
-  Tx_rollup_level.t ->
-  Tx_rollup.t ->
-  (context * t option ) tzresult Lwt.t
+    context ->
+    Tx_rollup_level.t ->
+    Tx_rollup.t ->
+    (context * t option ) tzresult Lwt.t
 
   val check_message_hash :
-  context ->
-  Tx_rollup_level.t ->
-  Tx_rollup.t ->
-  position: int ->
-  Tx_rollup_message.t ->
-  Merkle.path ->
-  context tzresult Lwt.t
+    context ->
+    Tx_rollup_level.t ->
+    Tx_rollup.t ->
+    position: int ->
+    Tx_rollup_message.t ->
+    Merkle.path ->
+    context tzresult Lwt.t
 end
 
 (** This module re-exports definitions from {!Tx_rollup_commitment_repr}. *)
@@ -2177,103 +2177,103 @@ module Tx_rollup_commitment: sig
   end
 
   val check_message_result :
-  context ->
-  Compact.t ->
-  [`Hash of Tx_rollup_message_result_hash.t
-  | `Result of Tx_rollup_message_result.t] ->
-  path: Merkle.path ->
-  index: int ->
-  context tzresult
+    context ->
+    Compact.t ->
+    [`Hash of Tx_rollup_message_result_hash.t
+    | `Result of Tx_rollup_message_result.t] ->
+    path: Merkle.path ->
+    index: int ->
+    context tzresult
 
   val add_commitment :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  public_key_hash ->
-  Full.t ->
-  (context * Tx_rollup_state.t * public_key_hash option ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    public_key_hash ->
+    Full.t ->
+    (context * Tx_rollup_state.t * public_key_hash option ) tzresult Lwt.t
 
   val find :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  Tx_rollup_level.t ->
-  (context * Submitted_commitment.t option ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    Tx_rollup_level.t ->
+    (context * Submitted_commitment.t option ) tzresult Lwt.t
 
   val get :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  Tx_rollup_level.t ->
-  (context * Submitted_commitment.t ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    Tx_rollup_level.t ->
+    (context * Submitted_commitment.t ) tzresult Lwt.t
 
   val check_agreed_and_disputed_results :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  Submitted_commitment.t ->
-  agreed_result: Tx_rollup_message_result.t ->
-  agreed_result_path: Merkle.path ->
-  disputed_result: Tx_rollup_message_result_hash.t ->
-  disputed_position: int ->
-  disputed_result_path: Merkle.path ->
-  context tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    Submitted_commitment.t ->
+    agreed_result: Tx_rollup_message_result.t ->
+    agreed_result_path: Merkle.path ->
+    disputed_result: Tx_rollup_message_result_hash.t ->
+    disputed_position: int ->
+    disputed_result_path: Merkle.path ->
+    context tzresult Lwt.t
 
   val get_finalized :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  Tx_rollup_level.t ->
-  (context * Submitted_commitment.t ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    Tx_rollup_level.t ->
+    (context * Submitted_commitment.t ) tzresult Lwt.t
 
   val pending_bonded_commitments :
-  context -> Tx_rollup.t -> public_key_hash -> (context * int ) tzresult Lwt.t
+    context -> Tx_rollup.t -> public_key_hash -> (context * int ) tzresult Lwt.t
 
   val has_bond :
-  context -> Tx_rollup.t -> public_key_hash -> (context * bool ) tzresult Lwt.t
+    context -> Tx_rollup.t -> public_key_hash -> (context * bool ) tzresult Lwt.t
 
   val finalize_commitment :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  (context * Tx_rollup_state.t * Tx_rollup_level.t ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    (context * Tx_rollup_state.t * Tx_rollup_level.t ) tzresult Lwt.t
 
   val remove_commitment :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  (context * Tx_rollup_state.t * Tx_rollup_level.t ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    (context * Tx_rollup_state.t * Tx_rollup_level.t ) tzresult Lwt.t
 
   val remove_bond :
-  context -> Tx_rollup.t -> public_key_hash -> context tzresult Lwt.t
+    context -> Tx_rollup.t -> public_key_hash -> context tzresult Lwt.t
 
   val slash_bond :
-  context -> Tx_rollup.t -> public_key_hash -> (context * bool ) tzresult Lwt.t
+    context -> Tx_rollup.t -> public_key_hash -> (context * bool ) tzresult Lwt.t
 
   val reject_commitment :
-  context ->
-  Tx_rollup.t ->
-  Tx_rollup_state.t ->
-  Tx_rollup_level.t ->
-  (context * Tx_rollup_state.t ) tzresult Lwt.t
+    context ->
+    Tx_rollup.t ->
+    Tx_rollup_state.t ->
+    Tx_rollup_level.t ->
+    (context * Tx_rollup_state.t ) tzresult Lwt.t
 end
 
 (** This module re-exports definitions from {!Tx_rollup_hash_builder}. *)
 module Tx_rollup_hash: sig
   val message_result :
-  context ->
-  Tx_rollup_message_result.t ->
-  (context * Tx_rollup_message_result_hash.t ) tzresult
+    context ->
+    Tx_rollup_message_result.t ->
+    (context * Tx_rollup_message_result_hash.t ) tzresult
 
   val compact_commitment :
-  context ->
-  Tx_rollup_commitment.Compact.t ->
-  (context * Tx_rollup_commitment_hash.t ) tzresult
+    context ->
+    Tx_rollup_commitment.Compact.t ->
+    (context * Tx_rollup_commitment_hash.t ) tzresult
 
   val withdraw_list :
-  context ->
-  Tx_rollup_withdraw.t list ->
-  (context * Tx_rollup_withdraw_list_hash.t ) tzresult
+    context ->
+    Tx_rollup_withdraw.t list ->
+    (context * Tx_rollup_withdraw_list_hash.t ) tzresult
 end
 
 (** This module re-exports definitions from {!Tx_rollup_errors_repr}. *)
@@ -2356,7 +2356,7 @@ module Tx_rollup_errors: sig
     | No_withdrawals_to_dispatch
 
   val check_path_depth :
-  [`Inbox | `Commitment] -> int -> count_limit: int -> unit tzresult
+    [`Inbox | `Commitment] -> int -> count_limit: int -> unit tzresult
 end
 
 (** This is a forward declaration to avoid circular dependencies.
@@ -2383,12 +2383,12 @@ module Bond_id: sig
       not be used otherwise. *)
   module Internal_for_tests: sig
     val fold_on_bond_ids :
-    context ->
-    Contract.t ->
-    order: [`Sorted | `Undefined] ->
-    init: 'a ->
-    f: (t -> 'a -> 'a Lwt.t) ->
-    'a Lwt.t
+      context ->
+      Contract.t ->
+      order: [`Sorted | `Undefined] ->
+      init: 'a ->
+      f: (t -> 'a -> 'a Lwt.t) ->
+      'a Lwt.t
   end
 end
 
@@ -2432,7 +2432,7 @@ module Zk_rollup: sig
     val encoding : t Data_encoding.t
 
     val circuits_info_encoding :
-    [`Public | `Private | `Fee] SMap.t Data_encoding.t
+      [`Public | `Private | `Fee] SMap.t Data_encoding.t
   end
 
   (** This module re-exports definitions from {!Zk_rollup_operation_repr}. *)
@@ -2515,42 +2515,42 @@ module Zk_rollup: sig
   val in_memory_size : t -> Cache_memory_helpers.sint
 
   val originate :
-  context ->
-  Account.static ->
-  init_state: State.t ->
-  (context * Address.t * Z.t ) tzresult Lwt.t
+    context ->
+    Account.static ->
+    init_state: State.t ->
+    (context * Address.t * Z.t ) tzresult Lwt.t
 
   val add_to_pending :
-  context ->
-  Address.t ->
-  (Operation.t * Ticket_hash.t option ) list ->
-  (context * Z.t ) tzresult Lwt.t
+    context ->
+    Address.t ->
+    (Operation.t * Ticket_hash.t option ) list ->
+    (context * Z.t ) tzresult Lwt.t
 
   val get_pending_length :
-  context -> Address.t -> (context * int ) tzresult Lwt.t
+    context -> Address.t -> (context * int ) tzresult Lwt.t
 
   val get_prefix :
-  context ->
-  Address.t ->
-  int ->
-  (context * (Operation.t * Ticket_hash.t option ) list ) tzresult Lwt.t
+    context ->
+    Address.t ->
+    int ->
+    (context * (Operation.t * Ticket_hash.t option ) list ) tzresult Lwt.t
 
   val update :
-  context ->
-  Address.t ->
-  pending_to_drop: int ->
-  new_account: Account.t ->
-  context tzresult Lwt.t
+    context ->
+    Address.t ->
+    pending_to_drop: int ->
+    new_account: Account.t ->
+    context tzresult Lwt.t
 
   val account : context -> t -> (context * Account.t ) tzresult Lwt.t
 
   val pending_list : context -> t -> (context * pending_list ) tzresult Lwt.t
 
   val pending_op :
-  context ->
-  t ->
-  Int64.t ->
-  (context * (Operation.t * Ticket_hash.t option) ) tzresult Lwt.t
+    context ->
+    t ->
+    Int64.t ->
+    (context * (Operation.t * Ticket_hash.t option) ) tzresult Lwt.t
 
   val assert_exist : context -> t -> context tzresult Lwt.t
 
@@ -2651,25 +2651,25 @@ module Delegate: sig
   val check_not_tz4 : Signature.public_key_hash -> unit tzresult
 
   val frozen_deposits_limit :
-  context -> public_key_hash -> Tez.t option tzresult Lwt.t
+    context -> public_key_hash -> Tez.t option tzresult Lwt.t
 
   val set_frozen_deposits_limit :
-  context -> public_key_hash -> Tez.t option -> context Lwt.t
+    context -> public_key_hash -> Tez.t option -> context Lwt.t
 
   val fold :
-  context ->
-  order: [`Sorted | `Undefined] ->
-  init: 'a ->
-  f: (public_key_hash -> 'a -> 'a Lwt.t) ->
-  'a Lwt.t
+    context ->
+    order: [`Sorted | `Undefined] ->
+    init: 'a ->
+    f: (public_key_hash -> 'a -> 'a Lwt.t) ->
+    'a Lwt.t
 
   val list : context -> public_key_hash list Lwt.t
 
   val drain :
-  context ->
-  delegate: public_key_hash ->
-  destination: public_key_hash ->
-  (context * bool * Tez.t * Receipt.balance_updates ) tzresult Lwt.t
+    context ->
+    delegate: public_key_hash ->
+    destination: public_key_hash ->
+    (context * bool * Tez.t * Receipt.balance_updates ) tzresult Lwt.t
 
   type participation_info = {
     expected_cycle_activity: int;
@@ -2681,49 +2681,49 @@ module Delegate: sig
   }
 
   val participation_info :
-  context -> public_key_hash -> participation_info tzresult Lwt.t
+    context -> public_key_hash -> participation_info tzresult Lwt.t
 
   val cycle_end :
-  context ->
-  Cycle.t ->
-  (context * Receipt.balance_updates * public_key_hash list ) tzresult Lwt.t
+    context ->
+    Cycle.t ->
+    (context * Receipt.balance_updates * public_key_hash list ) tzresult Lwt.t
 
   val already_slashed_for_double_endorsing :
-  context -> public_key_hash -> Level.t -> bool tzresult Lwt.t
+    context -> public_key_hash -> Level.t -> bool tzresult Lwt.t
 
   val already_slashed_for_double_baking :
-  context -> public_key_hash -> Level.t -> bool tzresult Lwt.t
+    context -> public_key_hash -> Level.t -> bool tzresult Lwt.t
 
   val punish_double_endorsing :
-  context ->
-  public_key_hash ->
-  Level.t ->
-  (context * Tez.t * Receipt.balance_updates ) tzresult Lwt.t
+    context ->
+    public_key_hash ->
+    Level.t ->
+    (context * Tez.t * Receipt.balance_updates ) tzresult Lwt.t
 
   val punish_double_baking :
-  context ->
-  public_key_hash ->
-  Level.t ->
-  (context * Tez.t * Receipt.balance_updates ) tzresult Lwt.t
+    context ->
+    public_key_hash ->
+    Level.t ->
+    (context * Tez.t * Receipt.balance_updates ) tzresult Lwt.t
 
   val full_balance : context -> public_key_hash -> Tez.t tzresult Lwt.t
 
   type level_participation = Participated | Didn't_participate
 
   val record_baking_activity_and_pay_rewards_and_fees :
-  context ->
-  payload_producer: public_key_hash ->
-  block_producer: public_key_hash ->
-  baking_reward: Tez.t ->
-  reward_bonus: Tez.t option ->
-  (context * Receipt.balance_updates ) tzresult Lwt.t
+    context ->
+    payload_producer: public_key_hash ->
+    block_producer: public_key_hash ->
+    baking_reward: Tez.t ->
+    reward_bonus: Tez.t option ->
+    (context * Receipt.balance_updates ) tzresult Lwt.t
 
   val record_endorsing_participation :
-  context ->
-  delegate: public_key_hash ->
-  participation: level_participation ->
-  endorsing_power: int ->
-  context tzresult Lwt.t
+    context ->
+    delegate: public_key_hash ->
+    participation: level_participation ->
+    endorsing_power: int ->
+    context tzresult Lwt.t
 
   type deposits = { initial_amount: Tez.t; current_amount: Tez.t; }
 
@@ -2742,21 +2742,21 @@ module Delegate: sig
 
   (** See {!Delegate_activation_storage.last_cycle_before_deactivation}. *)
   val last_cycle_before_deactivation :
-  context -> public_key_hash -> Cycle.t tzresult Lwt.t
+    context -> public_key_hash -> Cycle.t tzresult Lwt.t
 
   module Consensus_key: sig
     val check_not_tz4 : Signature.public_key -> unit tzresult
 
     val active_pubkey :
-    context -> public_key_hash -> Consensus_key.pk tzresult Lwt.t
+      context -> public_key_hash -> Consensus_key.pk tzresult Lwt.t
 
     val pending_updates :
-    context ->
-    public_key_hash ->
-    (Cycle.t * public_key_hash ) list tzresult Lwt.t
+      context ->
+      public_key_hash ->
+      (Cycle.t * public_key_hash ) list tzresult Lwt.t
 
     val register_update :
-    context -> public_key_hash -> public_key -> context tzresult Lwt.t
+      context -> public_key_hash -> public_key -> context tzresult Lwt.t
   end
 
   (** See {!Stake_storage.prepare_stake_distribution}. *)
@@ -2810,7 +2810,7 @@ module Voting_period: sig
   module Testnet_dictator: sig
     (** See {!Voting_period_storage.Testnet_dictator.overwrite_current_kind}. *)
     val overwrite_current_kind :
-    context -> Chain_id.t -> Voting_period_repr.kind -> context tzresult Lwt.t
+      context -> Chain_id.t -> Voting_period_repr.kind -> context tzresult Lwt.t
   end
 end
 
@@ -2820,11 +2820,11 @@ module Vote: sig
 
   (** See {!Vote_storage.get_delegate_proposal_count}. *)
   val get_delegate_proposal_count :
-  context -> public_key_hash -> int tzresult Lwt.t
+    context -> public_key_hash -> int tzresult Lwt.t
 
   (** See {!Vote_storage.set_delegate_proposal_count}. *)
   val set_delegate_proposal_count :
-  context -> public_key_hash -> int -> context Lwt.t
+    context -> public_key_hash -> int -> context Lwt.t
 
   (** See {!Vote_storage.has_proposed}. *)
   val has_proposed : context -> public_key_hash -> proposal -> bool Lwt.t
@@ -2862,12 +2862,12 @@ module Vote: sig
   val delegate_info_encoding : delegate_info Data_encoding.t
 
   val get_delegate_info :
-  context -> public_key_hash -> delegate_info tzresult Lwt.t
+    context -> public_key_hash -> delegate_info tzresult Lwt.t
 
   val get_voting_power_free : context -> public_key_hash -> int64 tzresult Lwt.t
 
   val get_voting_power :
-  context -> public_key_hash -> (context * int64 ) tzresult Lwt.t
+    context -> public_key_hash -> (context * int64 ) tzresult Lwt.t
 
   val get_total_voting_power_free : context -> int64 tzresult Lwt.t
 
@@ -2892,7 +2892,7 @@ module Vote: sig
   val has_recorded_ballot : context -> public_key_hash -> bool Lwt.t
 
   val record_ballot :
-  context -> public_key_hash -> ballot -> context tzresult Lwt.t
+    context -> public_key_hash -> ballot -> context tzresult Lwt.t
 
   val get_ballots : context -> ballots tzresult Lwt.t
 
@@ -2990,7 +2990,7 @@ module Dal: sig
     val expected_size_in_bits : max_index: Slot_index.t -> int
 
     val shards_of_attestor :
-    context -> attestor: public_key_hash -> shard_index list option
+      context -> attestor: public_key_hash -> shard_index list option
 
     val record_attested_shards : context -> t -> int list -> context
 
@@ -3000,9 +3000,9 @@ module Dal: sig
     }
 
     val compute_committee :
-    context ->
-    (Slot.t -> (context * Signature.Public_key_hash.t ) tzresult Lwt.t) ->
-    committee tzresult Lwt.t
+      context ->
+      (Slot.t -> (context * Signature.Public_key_hash.t ) tzresult Lwt.t) ->
+      committee tzresult Lwt.t
 
     val init_committee : context -> committee -> context
   end
@@ -3078,12 +3078,12 @@ module Dal: sig
     val register_slot_header : context -> Header.t -> context tzresult
 
     val find_slot_headers :
-    context -> Raw_level.t -> Header.t list option tzresult Lwt.t
+      context -> Raw_level.t -> Header.t list option tzresult Lwt.t
 
     val finalize_current_slot_headers : context -> context Lwt.t
 
     val finalize_pending_slot_headers :
-    context -> (context * Attestation.t ) tzresult Lwt.t
+      context -> (context * Attestation.t ) tzresult Lwt.t
   end
 
   module Operations: sig module Publish_slot_header: sig
@@ -3101,11 +3101,11 @@ module Dal: sig
       val check_level : current_level: Raw_level.t -> t -> unit tzresult
 
       val slot_header :
-      cryptobox: cryptobox ->
-      number_of_slots: int ->
-      current_level: Raw_level.t ->
-      t ->
-      Slot.Header.t tzresult
+        cryptobox: cryptobox ->
+        number_of_slots: int ->
+        current_level: Raw_level.t ->
+        t ->
+        Slot.Header.t tzresult
     end
   end
 
@@ -3128,13 +3128,13 @@ module Dal: sig
     Bounded_history_repr.S with type key = hash and type value = t
 
     val add_confirmed_slot_headers_no_cache :
-    t -> Slot.Header.t list -> t tzresult
+      t -> Slot.Header.t list -> t tzresult
 
     val add_confirmed_slot_headers :
-    t ->
-    History_cache.t ->
-    Slot.Header.t list ->
-    (t * History_cache.t ) tzresult
+      t ->
+      History_cache.t ->
+      Slot.Header.t list ->
+      (t * History_cache.t ) tzresult
 
     type proof
   end
@@ -3327,17 +3327,17 @@ module Sc_rollup: sig
     end
 
     val genesis :
-    History.t -> Inbox_message.serialized -> (History.t * t ) tzresult
+      History.t -> Inbox_message.serialized -> (History.t * t ) tzresult
 
     val add_payload :
-    History.t -> t -> Inbox_message.serialized -> (History.t * t ) tzresult
+      History.t -> t -> Inbox_message.serialized -> (History.t * t ) tzresult
 
     type proof = private t list
 
     val proof_encoding : proof Data_encoding.t
 
     val produce_proof :
-    History.t -> index: Z.t -> t -> (merkelized_and_payload * proof ) option
+      History.t -> index: Z.t -> t -> (merkelized_and_payload * proof ) option
 
     val verify_proof : proof -> (t * t ) tzresult
 
@@ -3423,21 +3423,21 @@ module Sc_rollup: sig
     val serialized_proof_encoding : serialized_proof Data_encoding.t
 
     val add_all_messages :
-    predecessor_timestamp: Time.t ->
-    predecessor: Block_hash.t ->
-    History.t ->
-    t ->
-    Inbox_message.t list ->
-    (Inbox_merkelized_payload_hashes.History.t
-    * History.t
-    * t
-    * Inbox_merkelized_payload_hashes.t
-    * Inbox_message.t list ) tzresult
+      predecessor_timestamp: Time.t ->
+      predecessor: Block_hash.t ->
+      History.t ->
+      t ->
+      Inbox_message.t list ->
+      (Inbox_merkelized_payload_hashes.History.t
+      * History.t
+      * t
+      * Inbox_merkelized_payload_hashes.t
+      * Inbox_message.t list ) tzresult
 
     val add_messages_no_history :
-    Inbox_message.serialized list ->
-    Inbox_merkelized_payload_hashes.t ->
-    Inbox_merkelized_payload_hashes.t tzresult
+      Inbox_message.serialized list ->
+      Inbox_merkelized_payload_hashes.t ->
+      Inbox_merkelized_payload_hashes.t tzresult
 
     val take_snapshot : t -> history_proof
 
@@ -3448,7 +3448,7 @@ module Sc_rollup: sig
     val pp_inclusion_proof : Format.formatter -> inclusion_proof -> unit
 
     val verify_inclusion_proof :
-    inclusion_proof -> history_proof -> history_proof tzresult
+      inclusion_proof -> history_proof -> history_proof tzresult
 
     type proof
 
@@ -3459,43 +3459,43 @@ module Sc_rollup: sig
     val of_serialized_proof : serialized_proof -> proof option
 
     val verify_proof :
-    Raw_level.t * Z.t ->
-    history_proof ->
-    proof ->
-    inbox_message option tzresult
+      Raw_level.t * Z.t ->
+      history_proof ->
+      proof ->
+      inbox_message option tzresult
 
     val produce_proof :
-    get_payloads_history:
-    (Inbox_merkelized_payload_hashes.Hash.t ->
-    Inbox_merkelized_payload_hashes.History.t Lwt.t) ->
-    get_history: (Hash.t -> history_proof option Lwt.t) ->
-    history_proof ->
-    Raw_level.t * Z.t ->
-    (proof * inbox_message option ) tzresult Lwt.t
+      get_payloads_history:
+      (Inbox_merkelized_payload_hashes.Hash.t ->
+      Inbox_merkelized_payload_hashes.History.t Lwt.t) ->
+      get_history: (Hash.t -> history_proof option Lwt.t) ->
+      history_proof ->
+      Raw_level.t * Z.t ->
+      (proof * inbox_message option ) tzresult Lwt.t
 
     val finalize_inbox_level_no_history :
-    t -> Inbox_merkelized_payload_hashes.t -> t tzresult
+      t -> Inbox_merkelized_payload_hashes.t -> t tzresult
 
     val init_witness_no_history : Inbox_merkelized_payload_hashes.t
 
     val add_info_per_level_no_history :
-    predecessor_timestamp: Time.t ->
-    predecessor: Block_hash.t ->
-    Inbox_merkelized_payload_hashes.t ->
-    Inbox_merkelized_payload_hashes.t tzresult
+      predecessor_timestamp: Time.t ->
+      predecessor: Block_hash.t ->
+      Inbox_merkelized_payload_hashes.t ->
+      Inbox_merkelized_payload_hashes.t tzresult
 
     val genesis :
-    predecessor_timestamp: Time.t ->
-    predecessor: Block_hash.t ->
-    Raw_level.t ->
-    t tzresult
+      predecessor_timestamp: Time.t ->
+      predecessor: Block_hash.t ->
+      Raw_level.t ->
+      t tzresult
 
     module Internal_for_tests: sig
       val produce_inclusion_proof :
-      (Hash.t -> history_proof option Lwt.t) ->
-      history_proof ->
-      Raw_level.t ->
-      (inclusion_proof * history_proof ) tzresult Lwt.t
+        (Hash.t -> history_proof option Lwt.t) ->
+        history_proof ->
+        Raw_level.t ->
+        (inclusion_proof * history_proof ) tzresult Lwt.t
 
       val serialized_proof_of_string : string -> serialized_proof
     end
@@ -3503,17 +3503,17 @@ module Sc_rollup: sig
     val add_external_messages : context -> string list -> context tzresult Lwt.t
 
     val add_deposit :
-    context ->
-    payload: Script.expr ->
-    sender: Contract_hash.t ->
-    source: public_key_hash ->
-    destination: rollup ->
-    context tzresult Lwt.t
+      context ->
+      payload: Script.expr ->
+      sender: Contract_hash.t ->
+      source: public_key_hash ->
+      destination: rollup ->
+      context tzresult Lwt.t
 
     val finalize_inbox_level : context -> context Lwt.t
 
     val add_info_per_level :
-    predecessor: Block_hash.t -> context -> context Lwt.t
+      predecessor: Block_hash.t -> context -> context Lwt.t
 
     val get_inbox : context -> (t * context ) tzresult Lwt.t
   end
@@ -3541,11 +3541,11 @@ module Sc_rollup: sig
     end
 
     val record_applied_message :
-    context ->
-    t ->
-    Raw_level.t ->
-    message_index: int ->
-    (Z.t * context ) tzresult Lwt.t
+      context ->
+      t ->
+      Raw_level.t ->
+      message_index: int ->
+      (Z.t * context ) tzresult Lwt.t
   end
 
   type output = {
@@ -3623,7 +3623,7 @@ module Sc_rollup: sig
       val verify_proof : input option -> proof -> input_request tzresult Lwt.t
 
       val produce_proof :
-      context -> input option -> state -> proof tzresult Lwt.t
+        context -> input option -> state -> proof tzresult Lwt.t
 
       val verify_origination_proof : proof -> string -> bool Lwt.t
 
@@ -3640,14 +3640,14 @@ module Sc_rollup: sig
       val verify_output_proof : output_proof -> bool Lwt.t
 
       val produce_output_proof :
-      context -> state -> output -> (output_proof , error ) result Lwt.t
+        context -> state -> output -> (output_proof , error ) result Lwt.t
 
       val check_dissection :
-      default_number_of_sections: int ->
-      start_chunk: Dissection_chunk.t ->
-      stop_chunk: Dissection_chunk.t ->
-      Dissection_chunk.t list ->
-      unit tzresult
+        default_number_of_sections: int ->
+        start_chunk: Dissection_chunk.t ->
+        stop_chunk: Dissection_chunk.t ->
+        Dissection_chunk.t list ->
+        unit tzresult
 
       val get_current_level : state -> Raw_level.t option Lwt.t
 
@@ -3698,12 +3698,12 @@ module Sc_rollup: sig
       val proof_before : proof -> State_hash.t
       val proof_after : proof -> State_hash.t
       val verify_proof :
-      proof -> (tree -> (tree * 'a ) Lwt.t) -> (tree * 'a ) option Lwt.t
+        proof -> (tree -> (tree * 'a ) Lwt.t) -> (tree * 'a ) option Lwt.t
       val produce_proof :
-      Tree.t ->
-      tree ->
-      (tree -> (tree * 'a ) Lwt.t) ->
-      (proof * 'a ) option Lwt.t
+        Tree.t ->
+        tree ->
+        (tree -> (tree * 'a ) Lwt.t) ->
+        (proof * 'a ) option Lwt.t
     end
 
     module Make (C: P) : sig
@@ -3762,13 +3762,13 @@ module Sc_rollup: sig
       val proof_after : proof -> State_hash.t
 
       val verify_proof :
-      proof -> (tree -> (tree * 'a ) Lwt.t) -> (tree * 'a ) option Lwt.t
+        proof -> (tree -> (tree * 'a ) Lwt.t) -> (tree * 'a ) option Lwt.t
 
       val produce_proof :
-      Tree.t ->
-      tree ->
-      (tree -> (tree * 'a ) Lwt.t) ->
-      (proof * 'a ) option Lwt.t
+        Tree.t ->
+        tree ->
+        (tree -> (tree * 'a ) Lwt.t) ->
+        (proof * 'a ) option Lwt.t
     end
 
     module type Make_wasm = module type of Wasm_2_0_0.Make
@@ -3791,7 +3791,7 @@ module Sc_rollup: sig
       val get_outbox : Raw_level.t -> state -> output list Lwt.t
 
       val produce_proof :
-      context -> input option -> state -> proof tzresult Lwt.t
+        context -> input option -> state -> proof tzresult Lwt.t
     end
 
     module Protocol_implementation:
@@ -3828,35 +3828,35 @@ module Sc_rollup: sig
     val hash : context -> t -> (context * Hash.t ) tzresult
 
     val genesis_commitment :
-    origination_level: Raw_level.t -> genesis_state_hash: State_hash.t -> t
+      origination_level: Raw_level.t -> genesis_state_hash: State_hash.t -> t
 
     type genesis_info = { level: Raw_level.t; commitment_hash: Hash.t; }
 
     val genesis_info_encoding : genesis_info Data_encoding.t
 
     val get_commitment :
-    context -> rollup -> Hash.t -> (t * context ) tzresult Lwt.t
+      context -> rollup -> Hash.t -> (t * context ) tzresult Lwt.t
 
     val last_cemented_commitment_hash_with_level :
-    context -> rollup -> (Hash.t * Raw_level.t * context ) tzresult Lwt.t
+      context -> rollup -> (Hash.t * Raw_level.t * context ) tzresult Lwt.t
 
     val check_if_commitments_are_related :
-    context ->
-    rollup ->
-    descendant: Hash.t ->
-    ancestor: Hash.t ->
-    (bool * context ) tzresult Lwt.t
+      context ->
+      rollup ->
+      descendant: Hash.t ->
+      ancestor: Hash.t ->
+      (bool * context ) tzresult Lwt.t
   end
 
   val originate :
-  context ->
-  kind: Kind.t ->
-  parameters_ty: Script.lazy_expr ->
-  genesis_commitment: Commitment.t ->
-  (t * Z.t * Commitment.Hash.t * context ) tzresult Lwt.t
+    context ->
+    kind: Kind.t ->
+    parameters_ty: Script.lazy_expr ->
+    genesis_commitment: Commitment.t ->
+    (t * Z.t * Commitment.Hash.t * context ) tzresult Lwt.t
 
   val parameters_type :
-  context -> t -> (Script.lazy_expr option * context ) tzresult Lwt.t
+    context -> t -> (Script.lazy_expr option * context ) tzresult Lwt.t
 
   val kind : context -> t -> (context * Kind.t ) tzresult Lwt.t
 
@@ -3889,14 +3889,14 @@ module Sc_rollup: sig
     type serialized = private string
 
     val serialize_pvm_step :
-    pvm: ('state , 'proof , 'output ) PVM.implementation ->
-    'proof ->
-    serialized tzresult
+      pvm: ('state , 'proof , 'output ) PVM.implementation ->
+      'proof ->
+      serialized tzresult
 
     val unserialize_pvm_step :
-    pvm: ('state , 'proof , 'output ) PVM.implementation ->
-    serialized ->
-    'proof tzresult
+      pvm: ('state , 'proof , 'output ) PVM.implementation ->
+      serialized ->
+      'proof tzresult
 
     val serialized_encoding : serialized Data_encoding.t
 
@@ -3919,15 +3919,15 @@ module Sc_rollup: sig
         val get_history : Inbox.Hash.t -> Inbox.history_proof option Lwt.t
 
         val get_payloads_history :
-        Inbox_merkelized_payload_hashes.Hash.t ->
-        Inbox_merkelized_payload_hashes.History.t Lwt.t
+          Inbox_merkelized_payload_hashes.Hash.t ->
+          Inbox_merkelized_payload_hashes.History.t Lwt.t
       end
 
       module Dal_with_history: sig
         val confirmed_slots_history : Dal.Slots_history.t
 
         val get_history :
-        Dal.Slots_history.hash -> Dal.Slots_history.t option Lwt.t
+          Dal.Slots_history.hash -> Dal.Slots_history.t option Lwt.t
 
         val page_info : (Dal.Page.content * Dal.Page.proof ) option
 
@@ -3940,21 +3940,21 @@ module Sc_rollup: sig
     type error += Sc_rollup_proof_check of string
 
     val valid :
-    pvm: ('state , 'proof , 'output ) PVM.implementation ->
-    metadata: Metadata.t ->
-    Inbox.history_proof ->
-    Raw_level.t ->
-    Dal.Slots_history.t ->
-    Dal.parameters ->
-    dal_attestation_lag: int ->
-    'proof t ->
-    (input option * input_request ) tzresult Lwt.t
+      pvm: ('state , 'proof , 'output ) PVM.implementation ->
+      metadata: Metadata.t ->
+      Inbox.history_proof ->
+      Raw_level.t ->
+      Dal.Slots_history.t ->
+      Dal.parameters ->
+      dal_attestation_lag: int ->
+      'proof t ->
+      (input option * input_request ) tzresult Lwt.t
 
     val produce :
-    metadata: Metadata.t ->
-    (module PVM_with_context_and_state) ->
-    Raw_level.t ->
-    serialized t tzresult Lwt.t
+      metadata: Metadata.t ->
+      (module PVM_with_context_and_state) ->
+      Raw_level.t ->
+      serialized t tzresult Lwt.t
   end
 
   module Game: sig
@@ -4042,26 +4042,26 @@ module Sc_rollup: sig
     val status_encoding : status Data_encoding.t
 
     val initial :
-    Inbox.history_proof ->
-    Dal.Slots_history.t ->
-    start_level: Raw_level.t ->
-    parent_commitment: Commitment.t ->
-    defender_commitment: Commitment.t ->
-    refuter: Staker.t ->
-    defender: Staker.t ->
-    default_number_of_sections: int ->
-    t
+      Inbox.history_proof ->
+      Dal.Slots_history.t ->
+      start_level: Raw_level.t ->
+      parent_commitment: Commitment.t ->
+      defender_commitment: Commitment.t ->
+      refuter: Staker.t ->
+      defender: Staker.t ->
+      default_number_of_sections: int ->
+      t
 
     val play :
-    Kind.t ->
-    Dal.parameters ->
-    dal_attestation_lag: int ->
-    stakers: Index.t ->
-    Metadata.t ->
-    t ->
-    step: step ->
-    choice: Tick.t ->
-    (game_result , t ) Either.t tzresult Lwt.t
+      Kind.t ->
+      Dal.parameters ->
+      dal_attestation_lag: int ->
+      stakers: Index.t ->
+      Metadata.t ->
+      t ->
+      step: step ->
+      choice: Tick.t ->
+      (game_result , t ) Either.t tzresult Lwt.t
 
     type timeout = { alice: int; bob: int; last_turn_level: Raw_level.t; }
 
@@ -4089,42 +4089,42 @@ module Sc_rollup: sig
 
     module Internal_for_tests: sig
       val check_dissection :
-      default_number_of_sections: int ->
-      start_chunk: dissection_chunk ->
-      stop_chunk: dissection_chunk ->
-      dissection_chunk list ->
-      unit tzresult
+        default_number_of_sections: int ->
+        start_chunk: dissection_chunk ->
+        stop_chunk: dissection_chunk ->
+        dissection_chunk list ->
+        unit tzresult
     end
   end
 
   module Stake_storage: sig
     val find_staker :
-    context ->
-    t ->
-    Staker.t ->
-    (context * Commitment.Hash.t option ) tzresult Lwt.t
+      context ->
+      t ->
+      Staker.t ->
+      (context * Commitment.Hash.t option ) tzresult Lwt.t
 
     val publish_commitment :
-    context ->
-    t ->
-    Staker.t ->
-    Commitment.t ->
-    (Commitment.Hash.t * Raw_level.t * context * Receipt.balance_updates ) tzresult Lwt.t
+      context ->
+      t ->
+      Staker.t ->
+      Commitment.t ->
+      (Commitment.Hash.t * Raw_level.t * context * Receipt.balance_updates ) tzresult Lwt.t
 
     val cement_commitment :
-    context ->
-    t ->
-    Commitment.Hash.t ->
-    (context * Commitment.t ) tzresult Lwt.t
+      context ->
+      t ->
+      Commitment.Hash.t ->
+      (context * Commitment.t ) tzresult Lwt.t
 
     val withdraw_stake :
-    context ->
-    t ->
-    Staker.t ->
-    (context * Receipt.balance_updates ) tzresult Lwt.t
+      context ->
+      t ->
+      Staker.t ->
+      (context * Receipt.balance_updates ) tzresult Lwt.t
 
     val stakers_commitments_uncarbonated :
-    context -> t -> (Staker.t * Commitment.Hash.t option ) list tzresult Lwt.t
+      context -> t -> (Staker.t * Commitment.Hash.t option ) list tzresult Lwt.t
   end
 
   module Refutation_storage: sig
@@ -4142,53 +4142,53 @@ module Sc_rollup: sig
     val conflict_encoding : conflict Data_encoding.t
 
     val conflicting_stakers_uncarbonated :
-    context -> t -> Staker.t -> conflict list tzresult Lwt.t
+      context -> t -> Staker.t -> conflict list tzresult Lwt.t
 
     val get_ongoing_games_for_staker :
-    context ->
-    t ->
-    Staker.t ->
-    ((Game.t * Game.Index.t ) list * context ) tzresult Lwt.t
-
-    val start_game :
-    context ->
-    t ->
-    player: public_key_hash * Commitment.Hash.t ->
-    opponent: public_key_hash * Commitment.Hash.t ->
-    context tzresult Lwt.t
-
-    val game_move :
-    context ->
-    t ->
-    player: Staker.t ->
-    opponent: Staker.t ->
-    step: Game.step ->
-    choice: Tick.t ->
-    (Game.game_result option * context ) tzresult Lwt.t
-
-    val get_timeout :
-    context -> t -> Game.Index.t -> (Game.timeout * context ) tzresult Lwt.t
-
-    val timeout :
-    context ->
-    t ->
-    Game.Index.t ->
-    (Game.game_result * context ) tzresult Lwt.t
-
-    val apply_game_result :
-    context ->
-    t ->
-    Game.Index.t ->
-    Game.game_result ->
-    (Game.status * context * Receipt.balance_updates ) tzresult Lwt.t
-
-    module Internal_for_tests: sig
-      val get_conflict_point :
       context ->
       t ->
       Staker.t ->
-      Staker.t ->
-      (conflict_point * context ) tzresult Lwt.t
+      ((Game.t * Game.Index.t ) list * context ) tzresult Lwt.t
+
+    val start_game :
+      context ->
+      t ->
+      player: public_key_hash * Commitment.Hash.t ->
+      opponent: public_key_hash * Commitment.Hash.t ->
+      context tzresult Lwt.t
+
+    val game_move :
+      context ->
+      t ->
+      player: Staker.t ->
+      opponent: Staker.t ->
+      step: Game.step ->
+      choice: Tick.t ->
+      (Game.game_result option * context ) tzresult Lwt.t
+
+    val get_timeout :
+      context -> t -> Game.Index.t -> (Game.timeout * context ) tzresult Lwt.t
+
+    val timeout :
+      context ->
+      t ->
+      Game.Index.t ->
+      (Game.game_result * context ) tzresult Lwt.t
+
+    val apply_game_result :
+      context ->
+      t ->
+      Game.Index.t ->
+      Game.game_result ->
+      (Game.status * context * Receipt.balance_updates ) tzresult Lwt.t
+
+    module Internal_for_tests: sig
+      val get_conflict_point :
+        context ->
+        t ->
+        Staker.t ->
+        Staker.t ->
+        (conflict_point * context ) tzresult Lwt.t
     end
   end
 
@@ -4197,7 +4197,7 @@ module Sc_rollup: sig
   val list_unaccounted : context -> t list tzresult Lwt.t
 
   val genesis_info :
-  context -> rollup -> (context * Commitment.genesis_info ) tzresult Lwt.t
+    context -> rollup -> (context * Commitment.genesis_info ) tzresult Lwt.t
 
   (** This module discloses definitions that are only useful for tests and
     must not be used otherwise. *)
@@ -4237,10 +4237,10 @@ end
 module Block_payload: sig
   (** See {!Block_payload_repr.hash}. *)
   val hash :
-  predecessor_hash: Block_hash.t ->
-  payload_round: Round.t ->
-  Operation_list_hash.elt list ->
-  Block_payload_hash.t
+    predecessor_hash: Block_hash.t ->
+    payload_round: Round.t ->
+    Operation_list_hash.elt list ->
+    Block_payload_hash.t
 end
 
 (** This module re-exports definitions from {!Block_header_repr}. *)
@@ -4274,10 +4274,10 @@ module Block_header: sig
     val check_hash : Block_hash.t -> int64 -> bool
 
     val check_header_proof_of_work_stamp :
-    shell_header -> contents -> int64 -> bool
+      shell_header -> contents -> int64 -> bool
 
     val check_proof_of_work_stamp :
-    proof_of_work_threshold: int64 -> block_header -> unit tzresult
+      proof_of_work_threshold: int64 -> block_header -> unit tzresult
   end
 
   val raw : block_header -> raw
@@ -4304,27 +4304,27 @@ module Block_header: sig
   type error += Invalid_stamp
 
   val check_timestamp :
-  Round.round_durations ->
-  timestamp: Time.t ->
-  round: Round.t ->
-  predecessor_timestamp: Time.t ->
-  predecessor_round: Round.t ->
-  unit tzresult
+    Round.round_durations ->
+    timestamp: Time.t ->
+    round: Round.t ->
+    predecessor_timestamp: Time.t ->
+    predecessor_round: Round.t ->
+    unit tzresult
 
   val check_signature : t -> Chain_id.t -> public_key -> unit tzresult
 
   val begin_validate_block_header :
-  block_header: t ->
-  chain_id: Chain_id.t ->
-  predecessor_timestamp: Time.t ->
-  predecessor_round: Round.t ->
-  fitness: Fitness.t ->
-  timestamp: Time.t ->
-  delegate_pk: public_key ->
-  round_durations: Round.round_durations ->
-  proof_of_work_threshold: int64 ->
-  expected_commitment: bool ->
-  unit tzresult
+    block_header: t ->
+    chain_id: Chain_id.t ->
+    predecessor_timestamp: Time.t ->
+    predecessor_round: Round.t ->
+    fitness: Fitness.t ->
+    timestamp: Time.t ->
+    delegate_pk: public_key ->
+    round_durations: Round.round_durations ->
+    proof_of_work_threshold: int64 ->
+    expected_commitment: bool ->
+    unit tzresult
 
   type locked_round_evidence = {
     preendorsement_round: Round.t;
@@ -4336,13 +4336,13 @@ module Block_header: sig
     | Expected_payload_hash of Block_payload_hash.t
 
   val finalize_validate_block_header :
-  block_header_contents: contents ->
-  round: Round.t ->
-  fitness: Fitness.t ->
-  checkable_payload_hash: checkable_payload_hash ->
-  locked_round_evidence: locked_round_evidence option ->
-  consensus_threshold: int ->
-  unit tzresult
+    block_header_contents: contents ->
+    round: Round.t ->
+    fitness: Fitness.t ->
+    checkable_payload_hash: checkable_payload_hash ->
+    locked_round_evidence: locked_round_evidence option ->
+    consensus_threshold: int ->
+    unit tzresult
 end
 
 (** This module re-exports definitions from {!Cache_repr}. *)
@@ -4363,17 +4363,17 @@ module Cache: sig
     val sync : context -> cache_nonce -> context Lwt.t
 
     val future_cache_expectation :
-    ?blocks_before_activation: int32 ->
-    context ->
-    time_in_blocks: int ->
-    context tzresult Lwt.t
+      ?blocks_before_activation: int32 ->
+      context ->
+      time_in_blocks: int ->
+      context tzresult Lwt.t
 
     val cache_size : context -> cache_index: int -> size option
 
     val cache_size_limit : context -> cache_index: int -> size option
 
     val value_of_key :
-    context -> Context.Cache.key -> Context.Cache.value tzresult Lwt.t
+      context -> Context.Cache.key -> Context.Cache.value tzresult Lwt.t
   end
 
   type namespace = private string
@@ -4390,14 +4390,14 @@ module Cache: sig
     val namespace : namespace
 
     val value_of_identifier :
-    context -> identifier -> cached_value tzresult Lwt.t
+      context -> identifier -> cached_value tzresult Lwt.t
   end
 
   module type INTERFACE = sig
     type cached_value
 
     val update :
-    context -> identifier -> (cached_value * size ) option -> context tzresult
+      context -> identifier -> (cached_value * size ) option -> context tzresult
 
     val find : context -> identifier -> cached_value option tzresult Lwt.t
 
@@ -4411,11 +4411,11 @@ module Cache: sig
   end
 
   val register_exn :
-  (module CLIENT with type cached_value = 'a) ->
-  (module INTERFACE with type cached_value = 'a)
+    (module CLIENT with type cached_value = 'a) ->
+    (module INTERFACE with type cached_value = 'a)
 
   val cache_nonce_from_block_header :
-  Block_header.shell_header -> Block_header.contents -> cache_nonce
+    Block_header.shell_header -> Block_header.contents -> cache_nonce
 end
 
 (** This module re-exports definitions from {!Lazy_storage_kind}. *)
@@ -4560,7 +4560,7 @@ type 'a consensus_operation_type =
   | Preendorsement : Kind.preendorsement consensus_operation_type
 
 val pp_operation_kind :
-Format.formatter -> 'kind consensus_operation_type -> unit
+  Format.formatter -> 'kind consensus_operation_type -> unit
 
 type consensus_content = {
   slot: Slot.t;
@@ -4874,7 +4874,7 @@ module Operation: sig
   val protocol_data_encoding : packed_protocol_data Data_encoding.t
 
   val unsigned_encoding :
-  (Operation.shell_header * packed_contents_list ) Data_encoding.t
+    (Operation.shell_header * packed_contents_list ) Data_encoding.t
 
   type raw = Operation.t = { shell: Operation.shell_header; proto: bytes; }
 
@@ -4914,9 +4914,9 @@ module Operation: sig
   val pack : 'kind operation -> packed_operation
 
   val compare :
-  Operation_hash.t * packed_operation ->
-  Operation_hash.t * packed_operation ->
-  int
+    Operation_hash.t * packed_operation ->
+    Operation_hash.t * packed_operation ->
+    int
 
   type ('a , 'b )eq = Eq : ('a , 'a ) eq
 
@@ -4946,7 +4946,7 @@ module Operation: sig
     val vdf_revelation_case : Kind.vdf_revelation case
 
     val double_preendorsement_evidence_case :
-    Kind.double_preendorsement_evidence case
+      Kind.double_preendorsement_evidence case
 
     val double_endorsement_evidence_case : Kind.double_endorsement_evidence case
 
@@ -4973,44 +4973,44 @@ module Operation: sig
     val update_consensus_key_case : Kind.update_consensus_key Kind.manager case
 
     val tx_rollup_origination_case :
-    Kind.tx_rollup_origination Kind.manager case
+      Kind.tx_rollup_origination Kind.manager case
 
     val tx_rollup_submit_batch_case :
-    Kind.tx_rollup_submit_batch Kind.manager case
+      Kind.tx_rollup_submit_batch Kind.manager case
 
     val tx_rollup_commit_case : Kind.tx_rollup_commit Kind.manager case
 
     val tx_rollup_return_bond_case :
-    Kind.tx_rollup_return_bond Kind.manager case
+      Kind.tx_rollup_return_bond Kind.manager case
 
     val tx_rollup_finalize_commitment_case :
-    Kind.tx_rollup_finalize_commitment Kind.manager case
+      Kind.tx_rollup_finalize_commitment Kind.manager case
 
     val tx_rollup_remove_commitment_case :
-    Kind.tx_rollup_remove_commitment Kind.manager case
+      Kind.tx_rollup_remove_commitment Kind.manager case
 
     val tx_rollup_rejection_case : Kind.tx_rollup_rejection Kind.manager case
 
     val tx_rollup_dispatch_tickets_case :
-    Kind.tx_rollup_dispatch_tickets Kind.manager case
+      Kind.tx_rollup_dispatch_tickets Kind.manager case
 
     val transfer_ticket_case : Kind.transfer_ticket Kind.manager case
 
     val dal_publish_slot_header_case :
-    Kind.dal_publish_slot_header Kind.manager case
+      Kind.dal_publish_slot_header Kind.manager case
 
     val register_global_constant_case :
-    Kind.register_global_constant Kind.manager case
+      Kind.register_global_constant Kind.manager case
 
     val set_deposits_limit_case : Kind.set_deposits_limit Kind.manager case
 
     val increase_paid_storage_case :
-    Kind.increase_paid_storage Kind.manager case
+      Kind.increase_paid_storage Kind.manager case
 
     val sc_rollup_originate_case : Kind.sc_rollup_originate Kind.manager case
 
     val sc_rollup_add_messages_case :
-    Kind.sc_rollup_add_messages Kind.manager case
+      Kind.sc_rollup_add_messages Kind.manager case
 
     val sc_rollup_cement_case : Kind.sc_rollup_cement Kind.manager case
 
@@ -5021,13 +5021,13 @@ module Operation: sig
     val sc_rollup_timeout_case : Kind.sc_rollup_timeout Kind.manager case
 
     val sc_rollup_execute_outbox_message_case :
-    Kind.sc_rollup_execute_outbox_message Kind.manager case
+      Kind.sc_rollup_execute_outbox_message Kind.manager case
 
     val sc_rollup_recover_bond_case :
-    Kind.sc_rollup_recover_bond Kind.manager case
+      Kind.sc_rollup_recover_bond Kind.manager case
 
     val zk_rollup_origination_case :
-    Kind.zk_rollup_origination Kind.manager case
+      Kind.zk_rollup_origination Kind.manager case
 
     val zk_rollup_publish_case : Kind.zk_rollup_publish Kind.manager case
 
@@ -5073,10 +5073,10 @@ module Operation: sig
       val tx_rollup_return_bond_case : Kind.tx_rollup_return_bond case
 
       val tx_rollup_finalize_commitment_case :
-      Kind.tx_rollup_finalize_commitment case
+        Kind.tx_rollup_finalize_commitment case
 
       val tx_rollup_remove_commitment_case :
-      Kind.tx_rollup_remove_commitment case
+        Kind.tx_rollup_remove_commitment case
 
       val tx_rollup_rejection_case : Kind.tx_rollup_rejection case
 
@@ -5099,7 +5099,7 @@ module Operation: sig
       val sc_rollup_timeout_case : Kind.sc_rollup_timeout case
 
       val sc_rollup_execute_outbox_message_case :
-      Kind.sc_rollup_execute_outbox_message case
+        Kind.sc_rollup_execute_outbox_message case
 
       val sc_rollup_recover_bond_case : Kind.sc_rollup_recover_bond case
 
@@ -5122,16 +5122,16 @@ module Stake_distribution: sig
   val snapshot : context -> context tzresult Lwt.t
 
   val compute_snapshot_index :
-  context -> Cycle.t -> max_snapshot_index: int -> int tzresult Lwt.t
+    context -> Cycle.t -> max_snapshot_index: int -> int tzresult Lwt.t
 
   val baking_rights_owner :
-  context ->
-  Level.t ->
-  round: Round.t ->
-  (context * Slot.t * Consensus_key.pk ) tzresult Lwt.t
+    context ->
+    Level.t ->
+    round: Round.t ->
+    (context * Slot.t * Consensus_key.pk ) tzresult Lwt.t
 
   val slot_owner :
-  context -> Level.t -> Slot.t -> (context * Consensus_key.pk ) tzresult Lwt.t
+    context -> Level.t -> Slot.t -> (context * Consensus_key.pk ) tzresult Lwt.t
 end
 
 (** This module re-exports definitions from {!Commitment_repr} and,
@@ -5165,24 +5165,24 @@ end
 
 (** Create an [Alpha_context.t] from an untyped context (first block in the chain only). *)
 val prepare_first_block :
-Chain_id.t ->
-Context.t ->
-typecheck:
-(context ->
-Script.t ->
-((Script.t * Lazy_storage.diffs option) * context ) tzresult Lwt.t) ->
-level: Int32.t ->
-timestamp: Time.t ->
-predecessor: Block_hash.t ->
-context tzresult Lwt.t
+  Chain_id.t ->
+  Context.t ->
+  typecheck:
+  (context ->
+  Script.t ->
+  ((Script.t * Lazy_storage.diffs option) * context ) tzresult Lwt.t) ->
+  level: Int32.t ->
+  timestamp: Time.t ->
+  predecessor: Block_hash.t ->
+  context tzresult Lwt.t
 
 (** Create an [Alpha_context.t] from an untyped context. *)
 val prepare :
-Context.t ->
-level: Int32.t ->
-predecessor_timestamp: Time.t ->
-timestamp: Time.t ->
-(context * Receipt.balance_updates * Migration.origination_result list ) tzresult Lwt.t
+  Context.t ->
+  level: Int32.t ->
+  predecessor_timestamp: Time.t ->
+  timestamp: Time.t ->
+  (context * Receipt.balance_updates * Migration.origination_result list ) tzresult Lwt.t
 
 (** All the definitions below are re-exported from {!Raw_context}. *)
 
@@ -5209,7 +5209,7 @@ val dictator_proposal_seen : t -> bool
 (** Finalize an {{!t} [Alpha_context.t]}, producing a [validation_result].
  *)
 val finalize :
-?commit_message: string -> context -> Fitness.raw -> Updater.validation_result
+  ?commit_message: string -> context -> Fitness.raw -> Updater.validation_result
 
 (** Should only be used by [Main.current_context] to return a context usable for RPCs *)
 val current_context : context -> Context.t
@@ -5253,7 +5253,7 @@ module Liquidity_baking: sig
     | LB_pass
 
   val liquidity_baking_toggle_vote_encoding :
-  liquidity_baking_toggle_vote Data_encoding.encoding
+    liquidity_baking_toggle_vote Data_encoding.encoding
 
   val get_cpmm_address : context -> Contract_hash.t tzresult Lwt.t
 
@@ -5268,10 +5268,10 @@ module Liquidity_baking: sig
   end
 
   val on_subsidy_allowed :
-  context ->
-  toggle_vote: liquidity_baking_toggle_vote ->
-  (context -> Contract_hash.t -> (context * 'a list ) tzresult Lwt.t) ->
-  (context * 'a list * Toggle_EMA.t ) tzresult Lwt.t
+    context ->
+    toggle_vote: liquidity_baking_toggle_vote ->
+    (context -> Contract_hash.t -> (context * 'a list ) tzresult Lwt.t) ->
+    (context * 'a list * Toggle_EMA.t ) tzresult Lwt.t
 end
 
 (** This module re-exports definitions from {!Ticket_storage}. *)
@@ -5281,13 +5281,13 @@ module Ticket_balance: sig
     | Used_storage_space_underflow
 
   val adjust_balance :
-  context -> Ticket_hash.t -> delta: Z.t -> (Z.t * context ) tzresult Lwt.t
+    context -> Ticket_hash.t -> delta: Z.t -> (Z.t * context ) tzresult Lwt.t
 
   val adjust_storage_space :
-  context -> storage_diff: Z.t -> (Z.t * context ) tzresult Lwt.t
+    context -> storage_diff: Z.t -> (Z.t * context ) tzresult Lwt.t
 
   val get_balance :
-  context -> Ticket_hash.t -> (Z.t option * context ) tzresult Lwt.t
+    context -> Ticket_hash.t -> (Z.t option * context ) tzresult Lwt.t
 
   (** This module discloses definitions that are only useful for tests and
       must not be used otherwise. *)
@@ -5317,13 +5317,13 @@ module Consensus: sig
       (see {!Storage.Tenderbake.Endorsement_branch} to [branch] in both the disk
       storage and RAM. *)
   val store_endorsement_branch :
-  context -> Block_hash.t * Block_payload_hash.t -> context Lwt.t
+    context -> Block_hash.t * Block_payload_hash.t -> context Lwt.t
 
   (** [store_grand_parent_branch context branch] sets the "grand-parent branch"
       (see {!Storage.Tenderbake.Grand_parent_branch} to [branch] in both the
       disk storage and RAM. *)
   val store_grand_parent_branch :
-  context -> Block_hash.t * Block_payload_hash.t -> context Lwt.t
+    context -> Block_hash.t * Block_payload_hash.t -> context Lwt.t
 end
 
 (** This module re-exports definitions from {!Token}. *)
@@ -5362,72 +5362,72 @@ module Token: sig
   val balance : context -> container -> (context * Tez.t ) tzresult Lwt.t
 
   val transfer_n :
-  ?origin: Receipt.update_origin ->
-  context ->
-  ([<source] * Tez.t ) list ->
-  [<sink] ->
-  (context * Receipt.balance_updates ) tzresult Lwt.t
+    ?origin: Receipt.update_origin ->
+    context ->
+    ([<source] * Tez.t ) list ->
+    [<sink] ->
+    (context * Receipt.balance_updates ) tzresult Lwt.t
 
   val transfer :
-  ?origin: Receipt.update_origin ->
-  context ->
-  [<source] ->
-  [<sink] ->
-  Tez.t ->
-  (context * Receipt.balance_updates ) tzresult Lwt.t
+    ?origin: Receipt.update_origin ->
+    context ->
+    [<source] ->
+    [<sink] ->
+    Tez.t ->
+    (context * Receipt.balance_updates ) tzresult Lwt.t
 end
 
 (** This module re-exports definitions from {!Fees_storage}. *)
 module Fees: sig
   val record_paid_storage_space :
-  context -> Contract_hash.t -> (context * Z.t * Z.t ) tzresult Lwt.t
+    context -> Contract_hash.t -> (context * Z.t * Z.t ) tzresult Lwt.t
 
   val record_global_constant_storage_space : context -> Z.t -> context * Z.t
 
   val burn_storage_fees :
-  ?origin: Receipt.update_origin ->
-  context ->
-  storage_limit: Z.t ->
-  payer: Token.source ->
-  Z.t ->
-  (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
+    ?origin: Receipt.update_origin ->
+    context ->
+    storage_limit: Z.t ->
+    payer: Token.source ->
+    Z.t ->
+    (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
 
   val burn_storage_increase_fees :
-  ?origin: Receipt_repr.update_origin ->
-  context ->
-  payer: Token.source ->
-  Z.t ->
-  (context * Receipt.balance_updates ) tzresult Lwt.t
+    ?origin: Receipt_repr.update_origin ->
+    context ->
+    payer: Token.source ->
+    Z.t ->
+    (context * Receipt.balance_updates ) tzresult Lwt.t
 
   val burn_origination_fees :
-  ?origin: Receipt.update_origin ->
-  context ->
-  storage_limit: Z.t ->
-  payer: Token.source ->
-  (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
+    ?origin: Receipt.update_origin ->
+    context ->
+    storage_limit: Z.t ->
+    payer: Token.source ->
+    (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
 
   val burn_tx_rollup_origination_fees :
-  ?origin: Receipt.update_origin ->
-  context ->
-  storage_limit: Z.t ->
-  payer: Token.source ->
-  (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
+    ?origin: Receipt.update_origin ->
+    context ->
+    storage_limit: Z.t ->
+    payer: Token.source ->
+    (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
 
   val burn_sc_rollup_origination_fees :
-  ?origin: Receipt.update_origin ->
-  context ->
-  storage_limit: Z.t ->
-  payer: Token.source ->
-  Z.t ->
-  (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
+    ?origin: Receipt.update_origin ->
+    context ->
+    storage_limit: Z.t ->
+    payer: Token.source ->
+    Z.t ->
+    (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
 
   val burn_zk_rollup_origination_fees :
-  ?origin: Receipt.update_origin ->
-  context ->
-  storage_limit: Z.t ->
-  payer: Token.source ->
-  Z.t ->
-  (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
+    ?origin: Receipt.update_origin ->
+    context ->
+    storage_limit: Z.t ->
+    payer: Token.source ->
+    Z.t ->
+    (context * Z.t * Receipt.balance_updates ) tzresult Lwt.t
 
   type error += Cannot_pay_storage_fee
   (* `Temporary *)


### PR DESCRIPTION
Allows correct formatting of
```ocaml
val foo :
  bar ->
  baz
```
Closes #228