### PR TITLE
[OCaml] indendation and softlines in parenthesized expressions

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1080,9 +1080,8 @@
 ;   )
 (parenthesized_expression
   .
-  "(" @append_empty_softline
-  (product_expression) @prepend_indent_start @append_indent_end
-  ")" @prepend_empty_softline
+  "(" @append_empty_softline @append_indent_start
+  ")" @prepend_indent_end @prepend_empty_softline
   .
 )
 ; Parenthesis are optional when using tuples, so scopes must be tied

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -587,6 +587,12 @@ let [|a; _; _|] =
     3;
   |]
 
+let _ =
+  (
+    let x = 42 in
+    x
+  )
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -575,6 +575,9 @@ let [a; _; _] = [1; 2;
 let [|a; _; _|] = [|1; 2;
   3|]
 
+let _ = (let x = 42 in
+  x)
+
 (* Showcase the usage of operator bindings *)
 let greetings =
   let (let*) = Option.bind


### PR DESCRIPTION
Formats
```ocaml
let _ = (let x = 42 in
  x)
```
as
```ocaml
let _ =
  (
    let x = 42 in
    x
  )
```
Closes #218 