### PR TITLE
Add `pre-commit-hooks.nix` integration in the flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ The `TOPIARY_LANGUAGE_DIR` variable can be set either at compile time or runtime
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on setting up
 a development environment.
 
+### Setting up as pre-commit hook
+
+Topiary integrates seamlessly with [pre-commit-hooks.nix]: add Topiary as input
+to your flake and, in [pre-commit-hooks.nix]'s setup, use:
+
+``` nix
+pre-commit-check = nix-pre-commit-hooks.run {
+  hooks = {
+    nixfmt.enable = true; ## keep your normal hooks
+    ...
+    ## Add the following:
+    topiary = topiary.lib.${system}.pre-commit-hook;
+  };
+};
+```
+
+[pre-commit-hooks.nix]: https://github.com/cachix/pre-commit-hooks.nix
+
 ### Usage
 
     topiary [OPTIONS] <--language <LANGUAGE>

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,24 @@
         checks = with code; {
           inherit app clippy fmt audit benchmark;
         };
+
+        ## For easy use in https://github.com/cachix/pre-commit-hooks.nix
+        lib.pre-commit-hook = {
+          enable = true;
+          name = "topiary";
+          description = "A general code formatter based on tree-sitter.";
+          entry = let
+            topiary-inplace = pkgs.writeShellApplication {
+              name = "topiary-inplace";
+              text = ''
+                for file; do
+                  ${code.app}/bin/topiary --in-place --input-file "$file"
+                done
+              '';
+            };
+          in "${topiary-inplace}/bin/topiary-inplace";
+          files = "(\\.json$)|(\\.toml$)|(\\.mli?$)";
+        };
       }
     );
 }


### PR DESCRIPTION
This PR adds to the flake an output `lib.${system}.pre-commit-hook` that contains a configuration allowing to use Topiary in [pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix). It is a first draft and I am fine changing everything again. In particular:

- I only enabled the pre-commit-hook on `.json`, `.toml`, `.ml` and `.mli` files (and not on `.sh` files). For that I based myself on the output of `--help` that mentions the legal uses of `--language`. I am happy to add `.sh` to the list of matched files.

- The bit of documentation the README is quite prominent, maybe too much for what this is. It made sense to me to put it in the “getting started” section. Maybe it should move after the usage examples though?