### PR TITLE
[OCaml] Scoped softlines for sequences and infix expressions

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1112,6 +1112,54 @@
   (#scope_id! "function_type")
 )
 
+; Allow softlines in infix expressions, such as
+; let b =
+;   foo
+;   || bar
+;   || baz
+
+; As above, infix expressions are nested grammar elements, so we must identify the
+; top-level one: it is the one that is not preceded by an infix operator.
+; We only consider the common logic operators, as not to mess with arithmetic expressions
+(
+  (infix_operator
+    [
+      "||"
+      "&&"
+    ]
+  )? @do_nothing
+  .
+  (infix_expression) @begin_scope @end_scope
+  (#scope_id! "infix_expression")
+)
+(infix_expression
+  (infix_operator
+    [
+      "||"
+      "&&"
+    ]
+  ) @prepend_spaced_scoped_softline
+  (#scope_id! "infix_expression")
+)
+
+; Allow softlines in sequences, such as
+; let b =
+;   foo;
+;   bar;
+;   baz
+; As above, sequences are nested grammar elements, so we must identify the
+; top-level one: it is the one that is not preceded by a ";".
+(
+  ";"? @do_nothing
+  .
+  (sequence_expression) @begin_scope @end_scope
+  (#scope_id! "sequence_expression")
+)
+(sequence_expression
+  ";" @append_spaced_scoped_softline
+  (#scope_id! "sequence_expression")
+)
+
 ; Indent and add softlines in lists and arrays, such as
 ; let _ =
 ;   [

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -46,7 +46,8 @@ let blit src srcoff dst dstoff len =
   if len < 0
     || srcoff < 0
     || srcoff > src.position - len
-    || dstoff < 0 || dstoff > (Bytes.length dst) - len then
+    || dstoff < 0
+    || dstoff > (Bytes.length dst) - len then
     invalid_arg "Buffer.blit"
   else
     Bytes.unsafe_blit src.buffer srcoff dst dstoff len
@@ -817,6 +818,18 @@ let _ =
     5,
     6
   )
+
+let x =
+  foo
+  || foo
+  || bar
+  || bar
+
+let x =
+  foo;
+  foo;
+  bar;
+  bar
 
 (* Open and let open *)
 open Foo

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -783,6 +783,12 @@ let _ =
   (1, 2, (3, 4),
   5, 6)
 
+let x = foo || foo
+  || bar || bar
+
+let x = foo; foo;
+  bar; bar
+
 (* Open and let open *)
 open Foo
 open Bar


### PR DESCRIPTION
Formats
```ocaml
let x = foo || foo
  || bar || bar

let x = foo; foo;
  bar; bar
```
as
```ocaml
let x =
  foo
  || foo
  || bar
  || bar

let x =
  foo;
  foo;
  bar;
  bar
```
Closes #251