### PR TITLE
Improvements to error handling and determining the location of query files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ The project can be built and installed with Cargo from the repository
 directory:
 
 ```bash
-export TOPIARY_LANGUAGE_DIR="$(pwd)/languages"
 cargo install --path .
 ```
 
-The `TOPIARY_LANGUAGE_DIR` variable can be set either at compile time or runtime. It should point to the directory where Topiary's language query files (`.scm`) are located.
+The `TOPIARY_LANGUAGE_DIR` variable can be set either at build time or
+runtime. It should point to the directory where Topiary's language query
+files (`.scm`) are located. Otherwise, Topiary will fall back to the
+`languages` directory in the current working directory.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on setting up
 a development environment.

--- a/default.nix
+++ b/default.nix
@@ -42,6 +42,15 @@ in
     postInstall = ''
       install -Dm444 languages/* -t $out/share/languages
     '';
+
+    # Set TOPIARY_LANGUAGE_DIR to the Nix store
+    # for the build
     TOPIARY_LANGUAGE_DIR = "${placeholder "out"}/share/languages";
+
+    # Set TOPIARY_LANGUAGE_DIR to the working directory
+    # in a development shell
+    shellHook = ''
+      export TOPIARY_LANGUAGE_DIR=$PWD/languages
+    '';
   });
 }

--- a/src/language.rs
+++ b/src/language.rs
@@ -116,7 +116,7 @@ impl Language {
         let query_file = Self::query_file_base_name(language);
 
         #[rustfmt::skip]
-        let potentials: Vec<Option<PathBuf>> = vec![
+        let potentials: [Option<PathBuf>; 3] = [
             std::env::var("TOPIARY_LANGUAGE_DIR").map(PathBuf::from).ok(),
             option_env!("TOPIARY_LANGUAGE_DIR").map(PathBuf::from),
             Some(PathBuf::from("./languages")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! [GitHub](https://github.com/tweag/topiary).
 
 use configuration::Configuration;
-pub use error::{FormatterError, ReadingError, WritingError};
+pub use error::{FormatterError, IoError};
 use itertools::Itertools;
 pub use language::Language;
 use pretty_assertions::StrComparison;
@@ -117,10 +117,16 @@ pub fn formatter(
     skip_idempotence: bool,
 ) -> FormatterResult<()> {
     let content = read_input(input).map_err(|e| {
-        FormatterError::Reading(ReadingError::Io("Failed to read input content".into(), e))
+        FormatterError::Io(IoError::Filesystem(
+            "Failed to read input contents".into(),
+            e,
+        ))
     })?;
     let query = read_input(query).map_err(|e| {
-        FormatterError::Reading(ReadingError::Io("Failed to read query content".into(), e))
+        FormatterError::Io(IoError::Filesystem(
+            "Failed to read query contents".into(),
+            e,
+        ))
     })?;
 
     let mut configuration = Configuration::parse(&query)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,8 +171,7 @@ fn run() -> FormatterResult<()> {
         args.skip_idempotence,
     )?;
 
-    // NOTE We should probably handle the potential for into_inner to fail
-    output.into_inner().unwrap().persist()?;
+    output.into_inner()?.persist()?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn run() -> FormatterResult<()> {
         query
     } else if let Some(language) = language {
         // Deduce the query file from the language, if the argument is missing
-        Language::query_path(language)
+        Language::query_path(language)?
     } else {
         // Clap ensures we won't get here
         unreachable!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,8 +177,8 @@ fn run() -> FormatterResult<()> {
 }
 
 fn print_error(e: &dyn Error) {
-    eprintln!("Error: {}", e);
+    log::error!("{e}");
     if let Some(source) = e.source() {
-        eprintln!("  Caused by: {}", source);
+        log::error!("Cause: {source}");
     }
 }

--- a/tests/cli-tester.rs
+++ b/tests/cli-tester.rs
@@ -40,7 +40,6 @@ fn test_file_output() {
 
     let mut topiary = Command::cargo_bin("topiary").unwrap();
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "languages")
         .arg("--language")
         .arg("json")
         .arg("--output-file")
@@ -59,7 +58,6 @@ fn test_no_clobber() {
 
     let mut topiary = Command::cargo_bin("topiary").unwrap();
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "languages")
         .arg("--language")
         .arg("json")
         .arg("--input-file")
@@ -81,7 +79,6 @@ fn test_in_place() {
 
     let mut topiary = Command::cargo_bin("topiary").unwrap();
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "languages")
         .arg("--language")
         .arg("json")
         .arg("--input-file")
@@ -99,7 +96,6 @@ fn test_in_place() {
 fn test_in_place_no_input() {
     let mut topiary = Command::cargo_bin("topiary").unwrap();
     topiary
-        .env("TOPIARY_LANGUAGE_DIR", "languages")
         .arg("--language")
         .arg("json")
         .arg("--in-place")


### PR DESCRIPTION
This PR:

* [x] Overhauls the I/O error handling

  We cannot distinguish, from `std::io::Error`, between a read error or a write error. This was returning invalid `WritingError`s, e.g., when attempting to read a query file that did not exist.

  As such, `ReadingError` and `WritingError` have been consolidated into `IoError`, which has two subtypes: `Filesystem` (which correlates directly to `std::io::Error`), and `Generic` (which is a "catch all" for everything else).

  Error outputting is now done with logging, rather than `eprintln!`.

* [x] Updates `Language::query_path`

  Using the same priority order as before (runtime envvar > build time envvar > `./languages`), also check if the query file exists. If it does, at whatever level, then all is well; otherwise, return an error.

* [x] Miscellany
  * [x] The `From<io::IntoInnerError>` implementation has been genericised to accept _any_ inner `Write`r. This allows us to properly handle errors when we persist the output to disk.
  * [x] The CLI integration tests no longer need to explicitly set the `TOPIARY_LANGUAGE_DIR` environment variable.
  * [x] Updated the Nix derivation to correct the `TOPIARY_LANGUAGE_DIR` setting and the documentation to match.

Resolves #256