### PR TITLE
Remove leading and trailing blank lines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub fn formatter(
     // Pretty-print atoms
     log::info!("Pretty-print output");
     let rendered = pretty::render(&atoms[..], configuration.indent_level)?;
-    let trimmed = trim_trailing_spaces(&rendered);
+    let trimmed = trim_whitespace(&rendered);
 
     if !skip_idempotence {
         idempotence_check(&trimmed, &query, language)?
@@ -162,8 +162,11 @@ fn read_input(input: &mut dyn io::Read) -> Result<String, io::Error> {
     Ok(content)
 }
 
-fn trim_trailing_spaces(s: &str) -> String {
-    Itertools::intersperse(s.split('\n').map(|line| line.trim_end()), "\n").collect::<String>()
+fn trim_whitespace(s: &str) -> String {
+    // Trim whitespace from the end of each line,
+    // then trim any leading/trailing new lines,
+    // finally reinstate the new line at EOF.
+    format!("{}\n", s.lines().map(str::trim_end).join("\n").trim())
 }
 
 fn idempotence_check(

--- a/tests/samples/expected/bash.sh
+++ b/tests/samples/expected/bash.sh
@@ -150,4 +150,3 @@ export xyzzy=$(
   something
   another_thing --foo
 )
-


### PR DESCRIPTION
This PR changes the whitespace trimmer such that it:

1. Trims whitespace from the end of each formatted line (as before)
2. Trims any leading and/or trailing new lines
3. Reinstates the new line at EOF.

Note: The formatted output assumes Unix-style new lines (`\n`). That's no change from before this PR, but this could probably be improved to accommodate the different platforms'/input file's new line expectations.

Resolves #48