### PR TITLE
[OCaml] process "else if" as an "elif" keyword

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -536,7 +536,6 @@
   [
     "begin"
     "do"
-    "else"
     "in"
     "of"
     "struct"
@@ -556,7 +555,6 @@
   [
     "begin"
     "do"
-    "else"
     "in"
     "of"
     "struct"
@@ -571,6 +569,30 @@
   (attribute_id) @append_spaced_softline
   .
   (comment)* @do_nothing
+)
+
+; only add softlines after "else" if it's not part of an "else if" construction
+(
+  "else" @append_spaced_softline
+  .
+  [
+    (comment)
+    (if_expression)
+    "%"
+  ]? @do_nothing
+)
+
+(
+  "else"
+  .
+  "%"
+  .
+  (attribute_id) @append_spaced_softline
+  .
+  [
+    (comment)
+    (if_expression)
+  ]? @do_nothing
 )
 
 ; ":" must not always be followed by a softline, we explicitly enumerate
@@ -807,7 +829,6 @@
 [
   "begin"
   "do"
-  "else"
   "object"
   "sig"
   "struct"
@@ -836,12 +857,17 @@
   "}" @prepend_indent_end
 )
 
+; Only indent after "else" if it's not an "else if" construction
+(
+  (else_clause
+    "else" @append_indent_start
+    (if_expression)? @do_nothing
+  ) @append_indent_end
+)
+
 ; End the indented block after these
 (
-  [
-    (else_clause)
-    (then_clause)
-  ] @append_indent_end
+  (then_clause) @append_indent_end
 )
 
 ; Make an indented block after ":" in typed expressions

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -235,12 +235,10 @@ let closing = function
 let advance_to_closing opening closing k s start =
   let rec advance k i lim =
     if i >= lim then raise Not_found
-    else
-      if s.[i] = opening then advance (k + 1) (i + 1) lim
-      else
-        if s.[i] = closing then
-          if k = 0 then i else advance (k - 1) (i + 1) lim
-        else advance k (i + 1) lim
+    else if s.[i] = opening then advance (k + 1) (i + 1) lim
+    else if s.[i] = closing then
+      if k = 0 then i else advance (k - 1) (i + 1) lim
+    else advance k (i + 1) lim
   in
   advance k start (String.length s)
 
@@ -295,8 +293,7 @@ let add_substitute b f s =
           add_char b current;
           subst current (i + 1)
       end
-    else
-      if previous = '\\' then add_char b previous
+    else if previous = '\\' then add_char b previous
   in
   subst ' ' 0
 


### PR DESCRIPTION
Leaves the following as is:
```ocaml
let kind c =
  if is_letter c then Letter
  else if is_digit c then Digit
  else if is_space c then Space
  else if is_symbol c then Symbol
  else Other
```
Closes #252