### PR TITLE
[OCaml] Support type constraints and polymorphic syntax

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -120,6 +120,7 @@
     "as"
     "assert"
     "class"
+    "constraint"
     "downto"
     "else"
     "exception"
@@ -170,6 +171,8 @@
     ":="
     ":>"
     "::"
+    "[>"
+    "[<"
   ] @append_space
   .
   "%"? @do_nothing
@@ -178,6 +181,7 @@
 ; Those keywords are not expected to come right after an open parenthesis.
 [
     "as"
+    "constraint"
     "do"
     "done"
     "downto"
@@ -571,6 +575,10 @@
   (comment)* @do_nothing
 )
 
+(type_binding
+  (type_constraint) @prepend_spaced_softline
+)
+
 ; only add softlines after "else" if it's not part of an "else if" construction
 (
   "else" @append_spaced_softline
@@ -696,6 +704,7 @@
   [
     (application_expression)
     (class_body_type)
+    (constructed_type)
     (if_expression)
     (function_type)
     (let_expression)
@@ -935,6 +944,28 @@
     (type_variable)
     (variant_declaration)
   ] @append_indent_end
+  .
+  (type_constraint)? @do_nothing
+)
+(type_binding
+  [
+    "="
+    "+="
+  ] @append_indent_start
+  .
+  [
+    (constructed_type)
+    (function_type)
+    (hash_type)
+    (object_type)
+    (parenthesized_type)
+    (tuple_type)
+    (type_constructor_path)
+    (type_variable)
+    (variant_declaration)
+  ]
+  .
+  (type_constraint) @append_indent_end
 )
 
 ; Make an indented block after "of" or ":" in constructor declarations

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -885,3 +885,8 @@ type x = ('any Slug.t -> bool) -> float
 let id (type s) (x : s) : s = x
 type foo = { a: 'a. ('a, mandatory) arg -> 'a; }
 type foo = (int, int) result
+
+(* exotic types *)
+type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
+  ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
+  constraint 'meth = [< meth]

--- a/tests/samples/expected/ocaml.mli
+++ b/tests/samples/expected/ocaml.mli
@@ -4444,9 +4444,11 @@ module Kind: sig
   type 'a double_consensus_operation_evidence =
     | Double_consensus_operation_evidence
 
-  type double_endorsement_evidence = endorsement_consensus_kind double_consensus_operation_evidence
+  type double_endorsement_evidence =
+    endorsement_consensus_kind double_consensus_operation_evidence
 
-  type double_preendorsement_evidence = preendorsement_consensus_kind double_consensus_operation_evidence
+  type double_preendorsement_evidence =
+    preendorsement_consensus_kind double_consensus_operation_evidence
 
   type double_baking_evidence = Double_baking_evidence_kind
 
@@ -4890,7 +4892,8 @@ module Operation: sig
 
   val contents_list_encoding : packed_contents_list Data_encoding.t
 
-  type 'kind t = 'kind operation = {
+  type 'kind t =
+    'kind operation = {
     shell: Operation.shell_header;
     protocol_data: 'kind protocol_data;
   }
@@ -5372,15 +5375,15 @@ module Token: sig
   val transfer_n :
     ?origin: Receipt.update_origin ->
     context ->
-    ([<source] * Tez.t) list ->
-    [<sink] ->
+    ([< source] * Tez.t) list ->
+    [< sink] ->
     (context * Receipt.balance_updates) tzresult Lwt.t
 
   val transfer :
     ?origin: Receipt.update_origin ->
     context ->
-    [<source] ->
-    [<sink] ->
+    [< source] ->
+    [< sink] ->
     Tez.t ->
     (context * Receipt.balance_updates) tzresult Lwt.t
 end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -844,3 +844,8 @@ type x = ('any Slug.t -> bool) -> float
 let id (type s) (x : s) : s = x
 type foo = { a : 'a. ('a, mandatory) arg -> 'a; }
 type foo = (int, int) result
+
+(* exotic types *)
+type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
+  ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
+  constraint 'meth = [< meth]


### PR DESCRIPTION
Add correct support for the following:
```ocaml
type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
  ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
  constraint 'meth = [< meth]
```