### PR TITLE
Indentation of function and match cases in PPX syntax

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1086,11 +1086,15 @@
 )
 
 ; Make an indented block where a function type arrow starts. Only for the root
-; level, not for each arrow.
+; level of constructed types and PPX extensions, not for each arrow.
 ;
 ; (?used_slot:bool ref ->
 ;   Longident.t loc ->
 ;   Path.t * Env.t)
+;
+; let h =
+;   [%madcast: float ->
+;     bool]
 ;
 (constructed_type
   (function_type
@@ -1099,6 +1103,21 @@
     .
   )
 )
+
+(attribute_payload
+  (function_type
+    "->" @append_indent_start
+    (_) @append_indent_end
+    .
+  )
+)
+
+; Make an indented block where a function/match starts in PPX syntax.
+; NOTE This is probably a bit of a hack...
+(expression_item
+  .
+  (_) @prepend_indent_start
+) @append_indent_end
 
 ; Indent and add softlines in multiline application expressions, such as
 ; let _ =

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -747,10 +747,10 @@ let _ = [%sedlex.regexp R]
 
 let _ =
   [%sedlex
-  match lexbuf with
-  | R1 -> e1
-  | Rn -> en
-  | _ -> def]
+    match lexbuf with
+    | R1 -> e1
+    | Rn -> en
+    | _ -> def]
 
 let _ =
   match%sedlex lexbuf with
@@ -904,3 +904,14 @@ type foo = (int, int) result
 type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
   ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
   constraint 'meth = [< meth]
+
+(* Indentation of multi-line types in PPX syntax *)
+let h =
+  [%madcast: float ->
+    bool]
+
+(* Indentation of function cases in PPX syntax *)
+let x =
+  [%expr function
+    | false -> 0.
+    | true -> 1.]

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -915,3 +915,8 @@ let x =
   [%expr function
     | false -> 0.
     | true -> 1.]
+
+(* Indentation of multi-line types in PPX syntax *)
+let h =
+  [%madcast: float ->
+    bool]

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -861,3 +861,14 @@ type foo = (int, int) result
 type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
   ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
   constraint 'meth = [< meth]
+
+(* Indentation of multi-line types in PPX syntax *)
+let h =
+  [%madcast: float ->
+    bool]
+
+(* Indentation of function cases in PPX syntax *)
+let x =
+  [%expr function
+    | false -> 0.
+    | true -> 1.]

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -872,3 +872,8 @@ let x =
   [%expr function
     | false -> 0.
     | true -> 1.]
+
+(* Indentation of multi-line types in PPX syntax *)
+let h =
+  [%madcast: float ->
+    bool]


### PR DESCRIPTION
* Resolves #233 
* [ ] Based on #278 (merge first to avoid conflicts)

Note: This rule looks a little bit too general and may "over-format". It works on the minimal examples, but I cannot speak to how it affects other `(expression_item)` nodes.