### PR TITLE
Handling of indentation for modules with a `with`

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1386,35 +1386,25 @@
 ; end
 (module_binding
   (module_name) @append_indent_start @begin_scope
-  "=" @prepend_indent_end @end_scope
+  "=" @prepend_empty_scoped_softline @prepend_indent_end @end_scope
   (#scope_id! "module_binding_before_equal")
 )
 ; if a module binding has no equal sign, everything enters the scope
 (module_binding
   (#scope_id! "module_binding_before_equal")
   (module_name) @append_indent_start @begin_scope
-  "="? @do_nothing
   [
-    (signature)? @do_nothing
     [
       (functor_type)
       (module_type_constraint)
     ] @append_indent_end @end_scope
   ]
-  .
+  "="? @do_nothing
 )
 (module_binding
   (module_name) @append_empty_scoped_softline
   (module_parameter) @append_spaced_scoped_softline
   (#scope_id! "module_binding_before_equal")
-)
-
-; Input softline after an equals sign that is followed by a structure
-; in a module binding
-(module_binding
-  "=" @append_input_softline
-  .
-  (structure)
 )
 
 ; Try block formatting

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1409,6 +1409,14 @@
   (#scope_id! "module_binding_before_equal")
 )
 
+; Input softline after an equals sign that is followed by a structure
+; in a module binding
+(module_binding
+  "=" @append_input_softline
+  .
+  (structure)
+)
+
 ; Try block formatting
 ; A soft linebreak after the "try" (potentially "try%ppx") and one after the "with".
 (try_expression

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -923,3 +923,11 @@ let x =
     | false -> 0.
     | true -> 1.
   ]
+
+(* New line for structures in module definitions if they appear in the input *)
+module MFloat: SERIALISABLE with
+    type t = float =
+struct
+  type t = float [@@deriving yojson]
+  let _key = "float"
+end

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -926,8 +926,8 @@ let x =
 
 (* New line for structures in module definitions if they appear in the input *)
 module MFloat: SERIALISABLE with
-    type t = float =
-struct
+  type t = float
+= struct
   type t = float [@@deriving yojson]
   let _key = "float"
 end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -877,3 +877,11 @@ let x =
   [%expr function
     | false -> 0.
     | true -> 1.]
+
+(* New line for structures in module definitions if they appear in the input *)
+module MFloat : SERIALISABLE
+  with type t = float =
+struct
+  type t = float [@@deriving yojson]
+  let _key = "float"
+end


### PR DESCRIPTION
* Resolves #248 
* [x] Based on #282 (merge first to avoid conflicts)