### PR TITLE
Fix various PPX indentation issues

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1086,13 +1086,25 @@
 )
 
 ; Make an indented block where a function type arrow starts. Only for the root
-; level, not for each arrow.
+; level of constructed types and PPX extensions, not for each arrow.
 ;
 ; (?used_slot:bool ref ->
 ;   Longident.t loc ->
 ;   Path.t * Env.t)
 ;
+; let h =
+;   [%madcast: float ->
+;     bool]
+;
 (constructed_type
+  (function_type
+    "->" @append_indent_start
+    (_) @append_indent_end
+    .
+  )
+)
+
+(attribute_payload
   (function_type
     "->" @append_indent_start
     (_) @append_indent_end

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1086,25 +1086,13 @@
 )
 
 ; Make an indented block where a function type arrow starts. Only for the root
-; level of constructed types and PPX extensions, not for each arrow.
+; level, not for each arrow.
 ;
 ; (?used_slot:bool ref ->
 ;   Longident.t loc ->
 ;   Path.t * Env.t)
 ;
-; let h =
-;   [%madcast: float ->
-;     bool]
-;
 (constructed_type
-  (function_type
-    "->" @append_indent_start
-    (_) @append_indent_end
-    .
-  )
-)
-
-(attribute_payload
   (function_type
     "->" @append_indent_start
     (_) @append_indent_end

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1113,11 +1113,10 @@
 )
 
 ; Make an indented block where a function/match starts in PPX syntax.
-; NOTE This is probably a bit of a hack...
-(expression_item
-  .
-  (_) @prepend_indent_start
-) @append_indent_end
+(extension
+  "[%" @append_indent_start
+  "]" @prepend_indent_end @prepend_empty_softline
+)
 
 ; Indent and add softlines in multiline application expressions, such as
 ; let _ =

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -750,7 +750,8 @@ let _ =
     match lexbuf with
     | R1 -> e1
     | Rn -> en
-    | _ -> def]
+    | _ -> def
+  ]
 
 let _ =
   match%sedlex lexbuf with
@@ -908,10 +909,12 @@ type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
 (* Indentation of multi-line types in PPX syntax *)
 let h =
   [%madcast: float ->
-    bool]
+      bool
+  ]
 
 (* Indentation of function cases in PPX syntax *)
 let x =
   [%expr function
     | false -> 0.
-    | true -> 1.]
+    | true -> 1.
+  ]

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -909,7 +909,7 @@ type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
 (* Indentation of multi-line types in PPX syntax *)
 let h =
   [%madcast: float ->
-      bool
+    bool
   ]
 
 (* Indentation of function cases in PPX syntax *)

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -904,3 +904,8 @@ type foo = (int, int) result
 type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
   ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
   constraint 'meth = [< meth]
+
+(* Indentation of multi-line types in PPX syntax *)
+let h =
+  [%madcast: float ->
+    bool]

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -861,3 +861,8 @@ type foo = (int, int) result
 type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
   ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
   constraint 'meth = [< meth]
+
+(* Indentation of multi-line types in PPX syntax *)
+let h =
+  [%madcast: float ->
+    bool]


### PR DESCRIPTION
This PR supersedes #278 and #279, to simplify the commit history after bad rebases:

* Resolves #231 
* Resolves #233
  
Notes:
* The `function`/`match` rule looks a little bit too general and may "over-format". It works on the minimal examples, but I cannot speak to how it affects other `(expression_item)` nodes.
* The history is still a bit of a mess :confounded: Best to just review the diff from `main`.