### PR TITLE
[OCaml] no hardlines after `let module`

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -81,6 +81,8 @@
     (type_definition)
   ] @append_hardline
   .
+  "in"? @do_nothing
+  .
   (comment)* @do_nothing
 )
 ; Also append line breaks after open_module, except when it's

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -872,6 +872,11 @@ let _ =
   let open Baz in
   ()
 
+(* let module *)
+let x =
+  let module IMap = Map.Make(Int) in
+  IMap.empty
+
 (* Multi-line functor signatures *)
 module Lift
   (Credit: module type of CreditSignature)

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -829,6 +829,11 @@ let _ =
   let open Baz in
   ()
 
+(* let module *)
+let x =
+  let module IMap = Map.Make(Int) in
+  IMap.empty
+
 (* Multi-line functor signatures *)
 module Lift
   (Credit: module type of CreditSignature)


### PR DESCRIPTION
Formats the following as is:
```ocaml
let x =
  let module IMap = Map.Make(Int) in
  IMap.empty
```
Closes #255 