### PR TITLE
[OCaml] Don't always enforce line break after `include_module`

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -73,9 +73,6 @@
   [
     (exception_definition)
     (external)
-    ; equivalence class
-      (include_module)
-      (include_module_type)
     (module_definition)
     (module_type_definition)
     (type_definition)
@@ -93,6 +90,28 @@
   (open_module) @append_hardline
   .
   (comment)* @do_nothing
+)
+
+; Append line break after module include, except if it's alone in a single-lined struct
+(
+  [
+    ; equivalence class
+    (include_module)
+    (include_module_type)
+  ] @append_hardline
+  .
+  "end"? @do_nothing
+)
+(structure
+  "struct"
+  .
+  [
+    ; equivalence class
+    (include_module)
+    (include_module_type)
+  ] @append_spaced_softline
+  .
+  "end"
 )
 
 ; Consecutive definitions must be separated by line breaks

--- a/tests/samples/expected/ocaml.mli
+++ b/tests/samples/expected/ocaml.mli
@@ -5458,3 +5458,5 @@ type foo =
   (b -> c) ->
   d ->
   e
+
+include module type of (struct include Time end)

--- a/tests/samples/input/ocaml.mli
+++ b/tests/samples/input/ocaml.mli
@@ -5394,3 +5394,5 @@ type foo =
 a ->
 (b -> c) ->
 d -> e
+
+include module type of (struct include Time end)


### PR DESCRIPTION
Allows the following to be left as is:
```ocaml
include module type of (struct include Time end)
```
Closes #290 