### PR TITLE
Fix panic and improve formatting of module bindings

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1432,19 +1432,16 @@
   "=" @prepend_empty_scoped_softline @prepend_indent_end @end_scope
   (#scope_id! "module_binding_before_equal")
 )
-; if a module binding has no equal sign, everything enters the scope
+; if a module binding has no equal sign and isn't just a signature, everything enters the scope
 (module_binding
   (#scope_id! "module_binding_before_equal")
   (module_name) @append_indent_start @begin_scope
-  [
-    (functor_type)
-    (module_type_constraint)
-  ] @append_indent_end @end_scope
   "="? @do_nothing
-)
+  (signature)? @do_nothing
+) @append_indent_end @end_scope
 (module_binding
   (module_name) @append_empty_scoped_softline
-  (module_parameter) @append_spaced_scoped_softline
+  (module_parameter) @prepend_spaced_scoped_softline
   (#scope_id! "module_binding_before_equal")
 )
 

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -938,3 +938,8 @@ module MFloat: SERIALISABLE with
   type t = float [@@deriving yojson]
   let _key = "float"
 end
+
+module Make
+  (R: sig end)
+  (S: sig end)
+  (T: sig end)

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -891,3 +891,6 @@ struct
   type t = float [@@deriving yojson]
   let _key = "float"
 end
+
+module Make (R : sig end)
+  (S : sig end) (T : sig end)


### PR DESCRIPTION
Allows the following:
```ocaml
module Make (R : sig end)
  (S : sig end) (T : sig end)
```
to be formatted as
```ocaml
module Make
  (R: sig end)
  (S: sig end)
  (T: sig end)
```
Also, closes #289 