### PR TITLE
Introduce `@single_line_no_indent` predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,18 @@ The matched nodes will have a newline appended or prepended to them.
 )
 ```
 
+### `@single_line_no_indent`
+
+The matched node will be printed alone, on a single line, with no indentation.
+
+#### Example
+
+```scheme
+(#language! ocaml)
+; line number directives must be alone on their line, and can't be indented
+(line_number_directive) @single_line_no_indent
+```
+
 ### `@append_indent_start` / `@prepend_indent_start`
 
 The matched nodes will trigger indentation before or after them. This

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -34,6 +34,9 @@
   ]
 ) @leaf
 
+; line number directives must be alone on their line, and can't be indented
+(line_number_directive) @single_line_no_indent
+
 ; Allow blank line before
 [
   (class_definition)

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -181,6 +181,22 @@ impl AtomCollection {
                     node,
                 )
             }
+            // Mark a leaf to be printed on an single line, with no indentation
+            "single_line_no_indent" => {
+                self.atoms = self
+                    .atoms
+                    .iter()
+                    .map(|atom| match atom {
+                        Atom::Leaf { content, id, .. } if *id == node.id() => Atom::Leaf {
+                            content: content.to_string(),
+                            id: *id,
+                            single_line_no_indent: true,
+                        },
+                        _ => atom.clone(),
+                    })
+                    .collect();
+                self.append(Atom::Hardline, node)
+            }
             // Return a query parsing error on unknown capture names
             unknown => {
                 return Err(FormatterError::Query(
@@ -242,6 +258,7 @@ impl AtomCollection {
             self.atoms.push(Atom::Leaf {
                 content: String::from(node.utf8_text(source)?),
                 id,
+                single_line_no_indent: false,
             });
         } else {
             for child in node.children(&mut node.walk()) {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,13 +3,13 @@ use regex::Regex;
 
 pub struct Configuration {
     pub language: Language,
-    pub indent_level: isize,
+    pub indent_level: usize,
 }
 
 impl Configuration {
     pub fn parse(query: &str) -> FormatterResult<Self> {
         let mut language: Option<Language> = None;
-        let mut indent_level: isize = 2;
+        let mut indent_level: usize = 2;
 
         // Match lines beginning with a predicate like this:
         // (#language! rust)
@@ -43,10 +43,10 @@ impl Configuration {
                 }
                 "indent-level" => {
                     if let Some(arg) = arguments.next() {
-                        indent_level = arg.parse::<isize>().map_err(|_| {
+                        indent_level = arg.parse::<usize>().map_err(|_| {
                             FormatterError::Query(
                                 format!(
-                                    "The #indent-level! parameter must be numeric, but got '{arg}'"
+                                    "The #indent-level! parameter must be a positive integer, but got '{arg}'"
                                 ),
                                 None,
                             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ pub enum Atom {
     Leaf {
         content: String,
         id: usize,
+        // marks the leaf to be printed on a single line, with no indentation
+        single_line_no_indent: bool,
     },
     /// Represents a literal string, such as a semicolon.
     Literal(String),

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -29,7 +29,17 @@ fn atoms_to_doc<'a>(
                 Atom::Empty => RcDoc::text(""),
                 &Atom::Hardline => RcDoc::hardline()
                     .append(RcDoc::concat(repeat(RcDoc::space()).take(*indent_level))),
-                Atom::Leaf { content, .. } => RcDoc::text(content.trim_end()),
+                Atom::Leaf {
+                    content,
+                    single_line_no_indent,
+                    ..
+                } => {
+                    if *single_line_no_indent {
+                        RcDoc::hardline().append(RcDoc::text(content.trim_end()))
+                    } else {
+                        RcDoc::text(content.trim_end())
+                    }
+                }
                 Atom::Literal(s) => RcDoc::text(s),
                 Atom::MultilineOnlyLiteral { .. } => unreachable!(),
                 Atom::IndentEnd => unreachable!(),

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -1,14 +1,20 @@
 use crate::{Atom, FormatterResult};
+use core::iter::repeat;
 use pretty::RcDoc;
 
-pub fn render(atoms: &[Atom], indent_level: isize) -> FormatterResult<String> {
-    let doc = atoms_to_doc(&mut 0, atoms, indent_level);
+pub fn render(atoms: &[Atom], indent_offset: usize) -> FormatterResult<String> {
+    let doc = atoms_to_doc(&mut 0, atoms, indent_offset, &mut 0);
     let mut rendered = String::new();
     doc.render_fmt(usize::max_value(), &mut rendered)?;
     Ok(rendered)
 }
 
-fn atoms_to_doc<'a>(i: &mut usize, atoms: &'a [Atom], indent_level: isize) -> RcDoc<'a, ()> {
+fn atoms_to_doc<'a>(
+    i: &mut usize,
+    atoms: &'a [Atom],
+    indent_offset: usize,
+    indent_level: &mut usize,
+) -> RcDoc<'a, ()> {
     let mut doc = RcDoc::nil();
 
     while *i < atoms.len() {
@@ -17,16 +23,22 @@ fn atoms_to_doc<'a>(i: &mut usize, atoms: &'a [Atom], indent_level: isize) -> Rc
             return doc;
         } else {
             doc = doc.append(match atom {
-                Atom::Blankline => RcDoc::hardline().append(RcDoc::hardline()),
+                Atom::Blankline => RcDoc::hardline()
+                    .append(RcDoc::hardline())
+                    .append(RcDoc::concat(repeat(RcDoc::space()).take(*indent_level))),
                 Atom::Empty => RcDoc::text(""),
-                &Atom::Hardline => RcDoc::hardline(),
+                &Atom::Hardline => RcDoc::hardline()
+                    .append(RcDoc::concat(repeat(RcDoc::space()).take(*indent_level))),
                 Atom::Leaf { content, .. } => RcDoc::text(content.trim_end()),
                 Atom::Literal(s) => RcDoc::text(s),
                 Atom::MultilineOnlyLiteral { .. } => unreachable!(),
                 Atom::IndentEnd => unreachable!(),
                 Atom::IndentStart => {
                     *i += 1;
-                    atoms_to_doc(i, atoms, indent_level).nest(indent_level)
+                    *indent_level += indent_offset;
+                    let res = atoms_to_doc(i, atoms, indent_offset, indent_level);
+                    *indent_level -= indent_offset;
+                    res
                 }
                 Atom::Softline { .. } => unreachable!(),
                 Atom::Space => RcDoc::space(),

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -943,3 +943,9 @@ module Make
   (R: sig end)
   (S: sig end)
   (T: sig end)
+
+(* Showcase usage of line number directive. Line breaks could be improved. *)
+module Foo = struct
+  val bar
+# 1 "v1/pervasives.mli"
+end

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -894,3 +894,10 @@ end
 
 module Make (R : sig end)
   (S : sig end) (T : sig end)
+
+(* Showcase usage of line number directive. Line breaks could be improved. *)
+module Foo = struct
+  val bar
+
+# 1 "v1/pervasives.mli"
+end


### PR DESCRIPTION
The matched node will be printed alone, on a single line, with no indentation.

#### Example

```scheme
(#language! ocaml)
; line number directives must be alone on their line, and can't be indented
(line_number_directive) @single_line_no_indent
```

With this PR, the following
```ocaml
module Foo = struct
  val bar

# 1 "v1/pervasives.mli"
end
```
will be formatted as
```ocaml
module Foo = struct
  val bar
# 1 "v1/pervasives.mli"
end
```
The loss of the line break is a bit of a pity, but given the low usage of the line number statement, I don't think it matters that much. We'll open a low-priority issue if we deem it necessary.

Closes #287