### PR TITLE
[OCaml] Remove wrong line breaks in nested match cases

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -315,11 +315,6 @@
 (
   "("* @do_nothing
   .
-  "match" @prepend_space
-)
-(
-  "("* @do_nothing
-  .
   "method" @prepend_space
 )
 (
@@ -665,11 +660,14 @@
   (else_clause)
   (infix_operator)
   (item_attribute)
-  (match_expression)
   "*"
   "|"
   "}"
 ] @prepend_spaced_softline
+
+[
+  (match_expression)
+] @prepend_empty_softline
 
 ; Softline before the first match case
 ;
@@ -767,13 +765,17 @@
   ) @end_scope
   (#scope_id! "function_definiton")
 )
-(
+(parenthesized_expression
+  (function_expression) @begin_scope @end_scope
+  (#scope_id! "function_definiton")
+)
+(function_expression
   "|"* @do_nothing
   .
   (match_case) @prepend_spaced_scoped_softline
   (#scope_id! "function_definiton")
 )
-(
+(function_expression
   "|"* @prepend_spaced_scoped_softline
   .
   (match_case)

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -949,3 +949,21 @@ module Foo = struct
   val bar
 # 1 "v1/pervasives.mli"
 end
+
+(* Nested match cases *)
+let foo = function
+  | x ->
+    (
+      try foo with _ -> None
+    )
+
+let f = function
+  | None -> ()
+  | Some x ->
+    (match x with None -> () | Some _ -> ())
+
+let foo = function
+  | Some _ ->
+    (function true -> false | false -> true)
+  | None ->
+    (function true -> true | false -> false)

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -901,3 +901,19 @@ module Foo = struct
 
 # 1 "v1/pervasives.mli"
 end
+
+(* Nested match cases *)
+let foo = function
+  | x -> (
+    try foo with _ -> None )
+
+let f = function
+  | None -> ()
+  | Some x ->
+    (match x with None -> () | Some _ -> ())
+
+let foo = function
+  | Some _ ->
+    (function true -> false | false -> true)
+  | None ->
+    (function true -> true | false -> false)


### PR DESCRIPTION
Format the following
```ocaml
let foo = function
  | x -> (
    try foo with _ -> None )

let f = function
  | None -> ()
  | Some x ->
    (match x with None -> () | Some _ -> ())

let foo = function
  | Some _ ->
    (function true -> false | false -> true)
  | None ->
    (function true -> true | false -> false)
```
as
```ocaml
let foo = function
  | x ->
    (
      try foo with _ -> None
    )

let f = function
  | None -> ()
  | Some x ->
    (match x with None -> () | Some _ -> ())

let foo = function
  | Some _ ->
    (function true -> false | false -> true)
  | None ->
    (function true -> true | false -> false)
```

Closes #291
Closes #293