### PR TITLE
Refactor pretty-printer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,18 +514,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f3aa1e3ca87d3b124db7461265ac176b40c277f37e503eaa29c9c75c037846"
-dependencies = [
- "arrayvec",
- "log",
- "typed-arena",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,7 +765,6 @@ dependencies = [
  "env_logger",
  "itertools",
  "log",
- "pretty",
  "pretty_assertions",
  "regex",
  "tempfile",
@@ -865,22 +846,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ clap = { version = "3.2", features = ["derive"]}
 env_logger = "0.9"
 itertools = "0.10"
 log = "0.4"
-pretty = "0.11"
 pretty_assertions = "1.3"
 regex = "1.6.0"
 tempfile = "3.3.0"

--- a/src/pretty.rs
+++ b/src/pretty.rs
@@ -1,64 +1,51 @@
+use std::fmt::Write;
+
 use crate::{Atom, FormatterResult};
-use core::iter::repeat;
-use pretty::RcDoc;
 
 pub fn render(atoms: &[Atom], indent_offset: usize) -> FormatterResult<String> {
-    let doc = atoms_to_doc(&mut 0, atoms, indent_offset, &mut 0);
-    let mut rendered = String::new();
-    doc.render_fmt(usize::max_value(), &mut rendered)?;
+    let rendered = atoms_to_str(atoms, indent_offset);
     Ok(rendered)
 }
 
-fn atoms_to_doc<'a>(
-    i: &mut usize,
-    atoms: &'a [Atom],
+fn atoms_to_str(
+    atoms: &[Atom],
     indent_offset: usize,
-    indent_level: &mut usize,
-) -> RcDoc<'a, ()> {
-    let mut doc = RcDoc::nil();
+) -> String {
+    let mut buffer = String::new();
+    let mut indent_level = 0;
 
-    while *i < atoms.len() {
-        let atom = &atoms[*i];
-        if let Atom::IndentEnd = atom {
-            return doc;
-        } else {
-            doc = doc.append(match atom {
-                Atom::Blankline => RcDoc::hardline()
-                    .append(RcDoc::hardline())
-                    .append(RcDoc::concat(repeat(RcDoc::space()).take(*indent_level))),
-                Atom::Empty => RcDoc::text(""),
-                &Atom::Hardline => RcDoc::hardline()
-                    .append(RcDoc::concat(repeat(RcDoc::space()).take(*indent_level))),
-                Atom::Leaf {
-                    content,
-                    single_line_no_indent,
-                    ..
-                } => {
-                    if *single_line_no_indent {
-                        RcDoc::hardline().append(RcDoc::text(content.trim_end()))
-                    } else {
-                        RcDoc::text(content.trim_end())
-                    }
+    for atom in atoms {
+        let extra = match atom {
+            Atom::Blankline => format!("\n\n{}", " ".repeat(indent_level)),
+            Atom::Empty => String::new(),
+            Atom::Hardline => format!("\n{}", " ".repeat(indent_level)),
+            Atom::IndentEnd => {
+                indent_level -= indent_offset;
+                String::new()
+            },
+            Atom::IndentStart => {
+                indent_level += indent_offset;
+                String::new()
+            }
+            Atom::Leaf {
+                content,
+                single_line_no_indent,
+                ..
+            } => {
+                if *single_line_no_indent {
+                    // The line break after the content has been previously added
+                    // as a `Hardline` in the atom stream.
+                    format!("\n{}", content.trim_end())
+                } else {
+                    content.trim_end().to_string()
                 }
-                Atom::Literal(s) => RcDoc::text(s),
-                Atom::MultilineOnlyLiteral { .. } => unreachable!(),
-                Atom::IndentEnd => unreachable!(),
-                Atom::IndentStart => {
-                    *i += 1;
-                    *indent_level += indent_offset;
-                    let res = atoms_to_doc(i, atoms, indent_offset, indent_level);
-                    *indent_level -= indent_offset;
-                    res
-                }
-                Atom::Softline { .. } => unreachable!(),
-                Atom::Space => RcDoc::space(),
-                Atom::DeleteBegin => unreachable!(),
-                Atom::DeleteEnd => unreachable!(),
-                Atom::ScopedSoftline { .. } => unreachable!(),
-            });
-        }
-        *i += 1;
+            }
+            Atom::Literal(s) => s.to_string(),
+            Atom::Space => " ".to_string(),
+            // All other atom kinds should have been post-processed at that point
+            _ => unreachable!(),
+        };
+        write!(buffer, "{}", extra)?;
     }
-
-    doc
+    buffer
 }


### PR DESCRIPTION
* Get rid of `RcDoc`, as we no longer need its capabilities.
* Streamilne the pretty-printing function.
* Return errors instead of panicking or silently clipping output.

Closes #299 