### PR TITLE
[OCaml] Support set expressions

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1483,6 +1483,11 @@
   .
 )
 
+; Formatting set expressions
+(set_expression
+  "<-" @append_spaced_softline @append_indent_start
+) @append_indent_end
+
 ; Input softlines before and after all comments. This means that the input
 ; decides if a comment should have line breaks before or after. But don't put a
 ; softline directly in front of commas or semicolons.

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -982,3 +982,11 @@ let foo = function
     (function true -> false | false -> true)
   | None ->
     (function true -> true | false -> false)
+
+(* set expressions *)
+let _ =
+  x <-
+    if foo then
+      bar
+    else
+      baz

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -931,3 +931,11 @@ let foo = function
     (function true -> false | false -> true)
   | None ->
     (function true -> true | false -> false)
+
+(* set expressions *)
+let _ =
+  x <-
+    if foo then
+      bar
+    else
+      baz


### PR DESCRIPTION
Allows the following to be formatted as is:
```ocaml
let _ =
  x <-
    if foo then
      bar
    else
      baz
```

Closes #306 