### PR TITLE
Separate error handling code for binary

### DIFF
--- a/src/bin/topiary/error.rs
+++ b/src/bin/topiary/error.rs
@@ -1,0 +1,82 @@
+use std::{error, fmt, io, result};
+use topiary::FormatterError;
+
+/// A convenience wrapper around `std::result::Result<T, TopiaryError>`.
+pub type CLIResult<T> = result::Result<T, TopiaryError>;
+
+/// The errors that can be raised by either the Topiary CLI, or passed through by the formatter
+/// library code. This acts as a supertype of `FormatterError`, with additional members to denote
+/// CLI-specific failures.
+#[derive(Debug)]
+pub enum TopiaryError {
+    Lib(FormatterError),
+    Bin(String, CLIError),
+}
+
+/// A subtype of `TopiaryError::Bin`
+#[derive(Debug)]
+pub enum CLIError {
+    IOError(io::Error),
+    Generic(Box<dyn error::Error>),
+}
+
+impl fmt::Display for TopiaryError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Lib(error) => write!(f, "{error}"),
+            Self::Bin(message, _) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl error::Error for TopiaryError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::Lib(error) => error.source(),
+            Self::Bin(_, CLIError::IOError(error)) => error.source(),
+            Self::Bin(_, CLIError::Generic(error)) => error.source(),
+        }
+    }
+}
+
+impl From<FormatterError> for TopiaryError {
+    fn from(e: FormatterError) -> Self {
+        Self::Lib(e)
+    }
+}
+
+impl From<io::Error> for TopiaryError {
+    fn from(e: io::Error) -> Self {
+        match e.kind() {
+            io::ErrorKind::NotFound => Self::Bin("File not found".into(), CLIError::IOError(e)),
+
+            _ => Self::Bin(
+                "Cound not read or write to file".into(),
+                CLIError::IOError(e),
+            ),
+        }
+    }
+}
+
+impl From<tempfile::PersistError> for TopiaryError {
+    fn from(e: tempfile::PersistError) -> Self {
+        Self::Bin(
+            "Could not persist output to disk".into(),
+            CLIError::IOError(e.error),
+        )
+    }
+}
+
+// We only have to deal with io::BufWriter<crate::output::OutputFile>,
+// but the genericised code is clearer
+impl<W> From<io::IntoInnerError<W>> for TopiaryError
+where
+    W: io::Write + fmt::Debug + Send + 'static,
+{
+    fn from(e: io::IntoInnerError<W>) -> Self {
+        Self::Bin(
+            "Cannot flush internal buffer".into(),
+            CLIError::Generic(Box::new(e)),
+        )
+    }
+}

--- a/src/bin/topiary/main.rs
+++ b/src/bin/topiary/main.rs
@@ -1,7 +1,8 @@
+mod error;
 mod output;
 mod supported;
 
-use crate::{output::OutputFile, supported::SupportedLanguage};
+use crate::{error::CLIResult, output::OutputFile, supported::SupportedLanguage};
 use clap::{ArgGroup, Parser};
 use std::{
     error::Error,
@@ -9,7 +10,7 @@ use std::{
     io::{stdin, BufReader, BufWriter},
     path::PathBuf,
 };
-use topiary::{formatter, FormatterResult, Language};
+use topiary::{formatter, Language};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -50,7 +51,7 @@ fn main() {
     }
 }
 
-fn run() -> FormatterResult<()> {
+fn run() -> CLIResult<()> {
     env_logger::init();
     let args = Args::parse();
 

--- a/src/bin/topiary/output.rs
+++ b/src/bin/topiary/output.rs
@@ -1,9 +1,9 @@
+use crate::error::CLIResult;
 use std::{
     ffi::OsString,
     io::{stdout, Write},
 };
 use tempfile::NamedTempFile;
-use topiary::FormatterResult;
 
 #[derive(Debug)]
 pub enum OutputFile {
@@ -17,7 +17,7 @@ pub enum OutputFile {
 }
 
 impl OutputFile {
-    pub fn new(path: Option<&str>) -> FormatterResult<Self> {
+    pub fn new(path: Option<&str>) -> CLIResult<Self> {
         match path {
             Some("-") | None => Ok(Self::Stdout),
             Some(file) => Ok(Self::Disk {
@@ -28,7 +28,7 @@ impl OutputFile {
     }
 
     // This function must be called to persist the output to disk
-    pub fn persist(self) -> FormatterResult<()> {
+    pub fn persist(self) -> CLIResult<()> {
         if let Self::Disk { staged, output } = self {
             staged.persist(output)?;
         }


### PR DESCRIPTION
This is the beginnings of #303, as a piecemeal migration to separated codebases.

Notes:
* This is just a surface-level separation. There are still functions of the library that should be handled by the CLI, whose error handling code needs to remain before these functions are extracted. (Marked with comments.)
* The piecemeal nature of the migration means there is a certain amount of redundant/duplicated code. This is a crutch, to ensure a clean build, until the migration is complete.