### PR TITLE
Refactor Language interface

### DIFF
--- a/src/bin/topiary/main.rs
+++ b/src/bin/topiary/main.rs
@@ -75,7 +75,7 @@ fn run() -> CLIResult<()> {
     let language: Option<Language> = if let Some(language) = args.language {
         Some(language.into())
     } else if let Some(filename) = args.input_file.as_deref() {
-        Some(PathBuf::from(filename).try_into()?)
+        Some(Language::detect(filename)?)
     } else {
         // At this point, Clap ensures that args.query must be present.
         // We will read the language from the query file later.
@@ -86,7 +86,7 @@ fn run() -> CLIResult<()> {
         query
     } else if let Some(language) = language {
         // Deduce the query file from the language, if the argument is missing
-        language.try_into()?
+        language.query_file()?
     } else {
         // Clap ensures we won't get here
         unreachable!();

--- a/src/bin/topiary/main.rs
+++ b/src/bin/topiary/main.rs
@@ -75,7 +75,7 @@ fn run() -> CLIResult<()> {
     let language: Option<Language> = if let Some(language) = args.language {
         Some(language.into())
     } else if let Some(filename) = args.input_file.as_deref() {
-        Some(Language::detect(filename)?)
+        Some(PathBuf::from(filename).try_into()?)
     } else {
         // At this point, Clap ensures that args.query must be present.
         // We will read the language from the query file later.
@@ -86,7 +86,7 @@ fn run() -> CLIResult<()> {
         query
     } else if let Some(language) = language {
         // Deduce the query file from the language, if the argument is missing
-        Language::query_path(language)?
+        language.try_into()?
     } else {
         // Clap ensures we won't get here
         unreachable!();

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -173,7 +173,7 @@ impl FromStr for Configuration {
                             log::warn!("The #language! pragma has already been set");
                         }
 
-                        language = Some(value.try_into()?);
+                        language = Some(Language::new(value)?);
                     } else {
                         return Err(FormatterError::Query(
                             "The #language! pragma must have a parameter".into(),

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -173,7 +173,7 @@ impl FromStr for Configuration {
                             log::warn!("The #language! pragma has already been set");
                         }
 
-                        language = Some(Language::new(value)?);
+                        language = Some(value.try_into()?);
                     } else {
                         return Err(FormatterError::Query(
                             "The #language! pragma must have a parameter".into(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, ffi, fmt, io, str, string};
+use std::{error::Error, fmt, io, path::PathBuf, str, string};
 
 /// The various errors the formatter may return.
 #[derive(Debug)]
@@ -29,7 +29,7 @@ pub enum FormatterError {
     Query(String, Option<tree_sitter::QueryError>),
 
     /// Could not detect the input language from the (filename, Option<extension>)
-    LanguageDetection(String, Option<ffi::OsString>),
+    LanguageDetection(PathBuf, Option<String>),
 
     /// I/O-related errors
     Io(IoError),
@@ -65,15 +65,14 @@ impl fmt::Display for FormatterError {
             }
 
             Self::LanguageDetection(filename, extension) => {
-                let file: String = match filename.as_str() {
+                let file: String = match filename.to_str().unwrap() {
                     "-" => "from standard input".into(),
-                    _ => format!("of file '{filename}'"),
+                    _ => format!("of file '{}'", filename.to_string_lossy()),
                 };
 
                 match extension {
                     Some(extension) => write!(f,
-                        "Cannot detect language {file} due to unknown extension '.{}'. Try specifying language explicitly.",
-                        extension.to_string_lossy()
+                        "Cannot detect language {file} due to unknown extension '.{extension}'. Try specifying language explicitly.",
                     ),
                     None => write!(f,
                         "Cannot detect language {file}. Try specifying language explicitly."

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::{FormatterError, FormatterResult, IoError};
 
@@ -47,6 +47,28 @@ const EXTENSIONS: &[(Language, &[&str])] = &[
     (Language::Toml, &["toml"]),
     (Language::TreeSitterQuery, &["scm"]),
 ];
+
+impl Language {
+    /// Convenience alias to create a Language from "magic strings".
+    pub fn new(s: &str) -> FormatterResult<Self> {
+        s.try_into()
+    }
+
+    /// Convenience alias to detect the Language from a Path-like value's extension.
+    pub fn detect<P: AsRef<Path>>(path: P) -> FormatterResult<Self> {
+        path.as_ref().to_path_buf().try_into()
+    }
+
+    /// Convenience alias to return the query file path for the Language.
+    pub fn query_file(&self) -> FormatterResult<PathBuf> {
+        self.to_owned().try_into()
+    }
+
+    /// Convenience alias to return the Tree-sitter grammars for the Language.
+    pub fn grammars(&self) -> Vec<tree_sitter::Language> {
+        self.to_owned().into()
+    }
+}
 
 /// Convert a string into a Language, if possible.
 impl TryFrom<&str> for Language {

--- a/src/language.rs
+++ b/src/language.rs
@@ -61,12 +61,12 @@ impl Language {
 
     /// Convenience alias to return the query file path for the Language.
     pub fn query_file(&self) -> FormatterResult<PathBuf> {
-        (*self).try_into()
+        self.try_into()
     }
 
     /// Convenience alias to return the Tree-sitter grammars for the Language.
     pub fn grammars(&self) -> Vec<tree_sitter::Language> {
-        (*self).into()
+        self.into()
     }
 }
 
@@ -108,10 +108,10 @@ impl TryFrom<&str> for Language {
 ///
 /// Note that different languages may map to the same query file, because their grammars produce
 /// similar trees, which can be formatted with the same queries.
-impl TryFrom<Language> for PathBuf {
+impl TryFrom<&Language> for PathBuf {
     type Error = FormatterError;
 
-    fn try_from(language: Language) -> FormatterResult<Self> {
+    fn try_from(language: &Language) -> FormatterResult<Self> {
         let basename = Self::from(match language {
             Language::Bash => "bash",
             Language::Json => "json",
@@ -177,8 +177,8 @@ impl TryFrom<PathBuf> for Language {
 ///
 /// Note that, currently, all grammars are statically linked. This will change once dynamic linking
 /// is implemented (see Issue #4).
-impl From<Language> for Vec<tree_sitter::Language> {
-    fn from(language: Language) -> Self {
+impl From<&Language> for Vec<tree_sitter::Language> {
+    fn from(language: &Language) -> Self {
         match language {
             Language::Bash => vec![tree_sitter_bash::language()],
             Language::Json => vec![tree_sitter_json::language()],

--- a/src/language.rs
+++ b/src/language.rs
@@ -61,12 +61,12 @@ impl Language {
 
     /// Convenience alias to return the query file path for the Language.
     pub fn query_file(&self) -> FormatterResult<PathBuf> {
-        self.to_owned().try_into()
+        (*self).try_into()
     }
 
     /// Convenience alias to return the Tree-sitter grammars for the Language.
     pub fn grammars(&self) -> Vec<tree_sitter::Language> {
-        self.to_owned().into()
+        (*self).into()
     }
 }
 
@@ -156,9 +156,7 @@ impl TryFrom<PathBuf> for Language {
     fn try_from(path: PathBuf) -> FormatterResult<Self> {
         let extension = path.extension().map(|ext| ext.to_string_lossy());
 
-        if extension.is_some() {
-            let extension = extension.as_deref().unwrap();
-
+        if let Some(extension) = &extension {
             // NOTE This extension search is influenced by Wilfred Hughes' Difftastic
             // https://github.com/Wilfred/difftastic/blob/master/src/parse/guess_language.rs
             for (language, extensions) in EXTENSIONS {

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -21,7 +21,7 @@ pub fn apply_query(
     query_content: &str,
     language: Language,
 ) -> FormatterResult<AtomCollection> {
-    let (tree, grammar) = parse(input_content, language.into())?;
+    let (tree, grammar) = parse(input_content, language.grammars())?;
     let root = tree.root_node();
     let source = input_content.as_bytes();
     let query = Query::new(grammar, query_content)

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -21,8 +21,7 @@ pub fn apply_query(
     query_content: &str,
     language: Language,
 ) -> FormatterResult<AtomCollection> {
-    let grammars = Language::grammars(language);
-    let (tree, grammar) = parse(input_content, grammars)?;
+    let (tree, grammar) = parse(input_content, language.into())?;
     let root = tree.root_node();
     let source = input_content.as_bytes();
     let query = Query::new(grammar, query_content)

--- a/tests/sample-tester.rs
+++ b/tests/sample-tester.rs
@@ -1,7 +1,7 @@
 use pretty_assertions::assert_eq;
 use std::fs;
 use std::io::BufReader;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use test_log::test;
 use topiary::{formatter, Language};
 
@@ -14,17 +14,14 @@ fn input_output_tester() {
         let file = file.unwrap();
 
         let input_path = file.path();
-        let language =
-            Language::detect(input_path.to_str().unwrap()).unwrap_or_else(|err| panic!("{err}"));
+        let language: Language = input_path.try_into().unwrap();
 
         let expected_path = expected_dir.join(file.file_name());
         let expected = fs::read_to_string(expected_path).unwrap();
 
         let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
         let mut output = Vec::new();
-        let query_path_base = Language::query_file_base_name(language);
-        let query_path = str::to_lowercase(format!("languages/{query_path_base}.scm").as_str());
-        let query = fs::read_to_string(query_path).unwrap();
+        let query = fs::read_to_string(PathBuf::try_from(language).unwrap()).unwrap();
         let mut query = query.as_bytes();
 
         formatter(&mut input, &mut output, &mut query, Some(language), true).unwrap();
@@ -48,9 +45,7 @@ fn formatted_query_tester() {
 
         let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
         let mut output = Vec::new();
-        let query_path_base = Language::query_file_base_name(language);
-        let query_path = str::to_lowercase(format!("languages/{query_path_base}.scm").as_str());
-        let query = fs::read_to_string(query_path).unwrap();
+        let query = fs::read_to_string(PathBuf::try_from(language).unwrap()).unwrap();
         let mut query = query.as_bytes();
 
         formatter(&mut input, &mut output, &mut query, Some(language), true).unwrap();

--- a/tests/sample-tester.rs
+++ b/tests/sample-tester.rs
@@ -1,8 +1,10 @@
-use pretty_assertions::assert_eq;
 use std::fs;
 use std::io::BufReader;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+use pretty_assertions::assert_eq;
 use test_log::test;
+
 use topiary::{formatter, Language};
 
 #[test]
@@ -12,16 +14,14 @@ fn input_output_tester() {
 
     for file in input_dir {
         let file = file.unwrap();
-
-        let input_path = file.path();
-        let language: Language = input_path.try_into().unwrap();
+        let language = Language::detect(file.path()).unwrap();
 
         let expected_path = expected_dir.join(file.file_name());
         let expected = fs::read_to_string(expected_path).unwrap();
 
         let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
         let mut output = Vec::new();
-        let query = fs::read_to_string(PathBuf::try_from(language).unwrap()).unwrap();
+        let query = fs::read_to_string(language.query_file().unwrap()).unwrap();
         let mut query = query.as_bytes();
 
         formatter(&mut input, &mut output, &mut query, Some(language), true).unwrap();
@@ -45,7 +45,7 @@ fn formatted_query_tester() {
 
         let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
         let mut output = Vec::new();
-        let query = fs::read_to_string(PathBuf::try_from(language).unwrap()).unwrap();
+        let query = fs::read_to_string(language.query_file().unwrap()).unwrap();
         let mut query = query.as_bytes();
 
         formatter(&mut input, &mut output, &mut query, Some(language), true).unwrap();


### PR DESCRIPTION
The original purpose of this PR was to expose extension points to Tree-sitter's parser, at the library level, such that the binary could emit a serialised form of the parsed tree (i.e., to satisfy #11). After much thought, however, it is my opinion that it is _not_ the library's job to provide this and is only offered by the binary as a "nice-to-have". Specifically:

* Walking the syntax tree in Tree-sitter is relatively straightforward. Serialising the output is a harder task, but has nothing to do with formatting.
* Exposing Tree-sitter is no different from using Tree-sitter directly.
* As such, if the exposure was to provide an interface -- presuming, for the sake of argument, it's the library's responsibility -- then we'd have the job of reimplementing or wrapping Tree-sitter's functionality. Due to orphan rules, these _may_ then need to be wrapped again in the binary.
* That's a lot of wasted effort, when we could just have the binary also depend on Tree-sitter. (Currently, this requires zero effort, as the library and binary are still conjoined; see #295.)
* What _is_ needed, however, is Topiary's library's machinery to deal with various languages (including #4, once implemented), such that it can be passed to Tree-sitter without additional fuss.

This PR is therefore just a refactoring of the `Language` type: Rather than explicit methods, we use conversion traits instead, plus there's more documentation. It's not strictly necessary, but ought to make the subsequent code for the binary slightly more idiomatic.

* [x] Based on #317