### PR TITLE
Enforce opinion about optional `|` before first match case

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,24 @@ Remove the matched node from the output.
 )
 ```
 
+### `@singleline_delete`
+
+Remove the matched node from the output, online if the context is single-line.
+
+#### Example
+
+```scheme
+; Delete the optional "|" before the first match case
+; if the context is single-line
+(
+  (match_case)? @do_nothing
+  .
+  "|" @singleline_delete
+  .
+  (match_case)
+)
+```
+
 ### `@do_nothing`
 
 If any of the captures in a query match are `@do_nothing`, then the

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -685,6 +685,25 @@
   (match_case) @prepend_spaced_softline
 )
 
+; Allow (and enforce) the optional "|" before the first match case
+; if and only if the context is multi-line
+(
+  (match_case)? @do_nothing
+  .
+  "|" @singleline_delete
+  .
+  (match_case)
+)
+
+(
+  (match_case)? @do_nothing
+  .
+  "|"? @do_nothing
+  .
+  (match_case) @prepend_multiline_delimiter
+  (#delimiter! "| ") ; sic
+)
+
 ; Multi-line definitions must have a linebreak after "=" and before "in":
 ;
 ; let a =

--- a/src/atom_collection.rs
+++ b/src/atom_collection.rs
@@ -135,6 +135,10 @@ impl AtomCollection {
                 self.prepend(Atom::DeleteBegin, node);
                 self.append(Atom::DeleteEnd, node)
             }
+            "singleline_delete" => {
+                self.prepend(Atom::SingleLineDeleteBegin, node);
+                self.append(Atom::SingleLineDeleteEnd, node)
+            }
             // Scope manipulation
             "begin_scope" => self.begin_scope_before(node, requires_scope_id()?),
             "end_scope" => self.end_scope_after(node, requires_scope_id()?),
@@ -402,6 +406,42 @@ impl AtomCollection {
                         parent
                     );
                     Some(Atom::Literal(literal))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else if let Atom::SingleLineDeleteBegin = atom {
+            if let Some(parent) = node.parent() {
+                let parent_id = parent.id();
+
+                if !self.multi_line_nodes.contains(&parent_id) {
+                    log::debug!(
+                        "Expanding single-line delete begin in node {:?} with parent {}: {:?}",
+                        node,
+                        parent_id,
+                        parent
+                    );
+                    Some(Atom::DeleteBegin)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else if let Atom::SingleLineDeleteEnd = atom {
+            if let Some(parent) = node.parent() {
+                let parent_id = parent.id();
+
+                if !self.multi_line_nodes.contains(&parent_id) {
+                    log::debug!(
+                        "Expanding single-line delete end in node {:?} with parent {}: {:?}",
+                        node,
+                        parent_id,
+                        parent
+                    );
+                    Some(Atom::DeleteEnd)
                 } else {
                     None
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,9 @@ pub enum Atom {
     // it might happen that it contains several leaves.
     DeleteBegin,
     DeleteEnd,
+    /// Represents a segment to be deleted, only if the context is single-line
+    SingleLineDeleteBegin,
+    SingleLineDeleteEnd,
     /// Scoped commands
     // ScopedSoftline works together with the @open_scope and @end_scope query tags.
     // To decide if a scoped softline must be expanded into a hardline, we look at

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -439,7 +439,7 @@ let topological_sort deps =
         try
           List.assoc node graph
         with
-          Not_found ->
+          | Not_found ->
             if !ignore then []
             else
               raise
@@ -990,3 +990,17 @@ let _ =
       bar
     else
       baz
+
+(* various test cases for "|" rules *)
+let not = function
+  | true -> false
+  | false -> true
+
+let not x =
+  match x with
+  | false -> true
+  | true -> false
+
+let not = function true -> false | false -> true
+
+let not x = match x with true -> false | false -> true

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -939,3 +939,16 @@ let _ =
       bar
     else
       baz
+
+(* various test cases for "|" rules *)
+let not = function
+  true -> false
+  | false -> true
+
+let not x = match x with
+  | false -> true
+  | true -> false
+
+let not = function true -> false | false -> true
+
+let not x = match x with | true -> false | false -> true


### PR DESCRIPTION
This PR introduces a new formatting predicate, `singleline_delete`, which deletes a node only if the context is single-line. It also uses this new predicate, along with `prepend_multiline_delimiter`, to enforce the following rule in OCaml:
**The optional `|` before the first match case must be present if and only if the context is multi-line.**

Formats
```ocaml
let not = function
  true -> false
  | false -> true

let not = function | true -> false | false -> true
```
as
```ocaml
let not = function
  | true -> false
  | false -> true

let not = function true -> false | false -> true
```

TODO:
- [X] Edit OCaml queries to delete first `|` in match cases
- [X] Add code to test the feature in OCaml samples

Closes #281 