### PR TITLE
GraphViz visualisation support

### DIFF
--- a/src/bin/topiary/visualise.rs
+++ b/src/bin/topiary/visualise.rs
@@ -5,12 +5,14 @@ use clap::ValueEnum;
 
 #[derive(ValueEnum, Clone, Copy, Debug)]
 pub enum Visualisation {
+    Dot,
     Json,
 }
 
 impl From<Visualisation> for topiary::Visualisation {
     fn from(visualisation: Visualisation) -> Self {
         match visualisation {
+            Visualisation::Dot => Self::GraphViz,
             Visualisation::Json => Self::Json,
         }
     }

--- a/src/bin/topiary/visualise.rs
+++ b/src/bin/topiary/visualise.rs
@@ -5,8 +5,13 @@ use clap::ValueEnum;
 
 #[derive(ValueEnum, Clone, Copy, Debug)]
 pub enum Visualisation {
-    Dot,
+    // JSON is first as it's the default and
+    // we want it displayed first in the help
     Json,
+
+    // All other output formats should be listed
+    // in alphabetical order
+    Dot,
 }
 
 impl From<Visualisation> for topiary::Visualisation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,11 +245,17 @@ fn idempotence_check(
 }
 
 // GraphViz output for our syntax tree
+// Named syntax nodes are elliptical; anonymous are rectangular
 impl fmt::Display for SyntaxNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let shape = match self.is_named {
+            true => "ellipse",
+            false => "box",
+        };
+
         writeln!(
             f,
-            "  {} [label=\"{}\"];",
+            "  {} [label=\"{}\", shape={shape}];",
             self.id,
             self.kind.escape_default()
         )?;

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -40,7 +40,7 @@ pub struct SyntaxNode {
     pub id: usize,
 
     pub kind: String,
-    is_named: bool,
+    pub is_named: bool,
     is_extra: bool,
     is_error: bool,
     is_missing: bool,

--- a/src/tree_sitter.rs
+++ b/src/tree_sitter.rs
@@ -13,6 +13,7 @@ use crate::{
 /// Supported visualisation formats
 #[derive(Clone, Copy, Debug)]
 pub enum Visualisation {
+    GraphViz,
     Json,
 }
 
@@ -35,7 +36,10 @@ impl From<Point> for Position {
 // Simplified syntactic node struct, for the sake of serialisation.
 #[derive(Serialize)]
 pub struct SyntaxNode {
-    kind: String,
+    #[serde(skip_serializing)]
+    pub id: usize,
+
+    pub kind: String,
     is_named: bool,
     is_extra: bool,
     is_error: bool,
@@ -43,7 +47,7 @@ pub struct SyntaxNode {
     start: Position,
     end: Position,
 
-    children: Vec<SyntaxNode>,
+    pub children: Vec<SyntaxNode>,
 }
 
 impl From<Node<'_>> for SyntaxNode {
@@ -52,7 +56,7 @@ impl From<Node<'_>> for SyntaxNode {
         let children = node.children(&mut walker).map(SyntaxNode::from).collect();
 
         Self {
-            children,
+            id: node.id(),
 
             kind: node.kind().into(),
             is_named: node.is_named(),
@@ -61,6 +65,8 @@ impl From<Node<'_>> for SyntaxNode {
             is_missing: node.is_missing(),
             start: node.start_position().into(),
             end: node.end_position().into(),
+
+            children,
         }
     }
 }


### PR DESCRIPTION
This PR introduces basic GraphViz visualisation support, with the node shape depending on its type: elliptical for named nodes; rectangular for anonymous.

For example:

```
cargo run -- -vdot -ljson <<< '{"test":123}' \
| dot -Tsvg
```

Renders:

![test](https://user-images.githubusercontent.com/384987/223405275-9588361e-08f4-4c50-bd2b-2df8c4eaf2ec.svg)

There's scope for improvement, but these are perhaps best addressed in separate PRs:
* Use a GraphViz-specific abstraction, rather than `fmt::Display`.
* Use, e.g., colour to indicate a node's status (e.g., red for error nodes, etc.).
* Embed other metadata (e.g., position) into the node.