### PR TITLE
Compile Wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build and test executable
         run: 'echo \{ \"foo\": \"bar\" \} | nix run . -- -l json'
 
+      - name: Compile Wasm
+        run: nix build .#wasm
+
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v1.0.7
         if: github.ref == 'refs/heads/main'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,10 +371,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+
+[[package]]
+name = "futures-task"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-util"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "half"
@@ -582,6 +665,12 @@ name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
@@ -813,6 +902,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +1039,7 @@ dependencies = [
  "clap 4.1.8",
  "criterion",
  "env_logger",
+ "futures",
  "itertools",
  "log",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +104,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cast"
@@ -332,6 +371,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +576,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "plotters"
@@ -834,10 +885,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "pin-project-lite",
+ "tokio-macros",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "topiary"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "async-recursion",
  "clap 4.1.8",
  "criterion",
  "env_logger",
@@ -849,6 +949,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-log",
+ "tokio",
+ "tokio-test",
  "tree-sitter-bash",
  "tree-sitter-facade",
  "tree-sitter-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,17 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,7 +1025,6 @@ name = "topiary"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
- "async-recursion",
  "clap 4.1.8",
  "criterion",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.23",
  "criterion-plot",
+ "futures",
  "itertools",
  "lazy_static",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-recursion = "1.0.2"
 # For now we just load the tree-sitter language parsers statically.
 # Eventually we will want to dynamically load them, like Helix does.
 clap = { version = "4.1", features = ["derive"] }
@@ -17,6 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.4.0"
 test-log = "0.2"
+tokio = { version = "^1.26.0", features = ["rt-multi-thread", "macros"] }
 tree-sitter-facade = { git = "https://github.com/tweag/tree-sitter-facade" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies] 
@@ -35,6 +37,7 @@ web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", packag
 [dev-dependencies]
 assert_cmd = "2.0"
 criterion = "0.4"
+tokio-test = "0.4.2"
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", packag
 
 [dev-dependencies]
 assert_cmd = "2.0"
-criterion = "0.4"
+criterion = { version = "0.4", features=["async_futures"] }
 tokio-test = "0.4.2"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,19 @@ description = "Formats input source code in a style defined for that language."
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+crate-type = [
+    "cdylib", # for Wasm 
+    "rlib" # for native
+]
+
 [dependencies]
 async-recursion = "1.0.2"
 # For now we just load the tree-sitter language parsers statically.
 # Eventually we will want to dynamically load them, like Helix does.
 clap = { version = "4.1", features = ["derive"] }
 env_logger = "0.10"
+futures = "0.3.26"
 itertools = "0.10"
 log = "0.4"
 pretty_assertions = "1.3"
@@ -18,10 +25,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.4.0"
 test-log = "0.2"
-tokio = { version = "^1.26.0", features = ["rt-multi-thread", "macros"] }
 tree-sitter-facade = { git = "https://github.com/tweag/tree-sitter-facade" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies] 
+tokio = { version = "^1.26.0", features = ["rt-multi-thread", "macros"] }
 tree-sitter-json = "0.19"
 tree-sitter-rust = "0.20.3"
 tree-sitter-toml = "0.20.0"
@@ -32,6 +39,7 @@ tree-sitter-query = { git = "https://github.com/nvim-treesitter/tree-sitter-quer
 tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "^1.26.0", features = ["rt", "macros"] }
 web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", package = "web-tree-sitter-sys", default-features = false, features = ["web"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,10 @@ crate-type = [
 ]
 
 [dependencies]
-async-recursion = "1.0.2"
 # For now we just load the tree-sitter language parsers statically.
 # Eventually we will want to dynamically load them, like Helix does.
 clap = { version = "4.1", features = ["derive"] }
 env_logger = "0.10"
-futures = "0.3.26"
 itertools = "0.10"
 log = "0.4"
 pretty_assertions = "1.3"
@@ -39,6 +37,7 @@ tree-sitter-query = { git = "https://github.com/nvim-treesitter/tree-sitter-quer
 tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+futures = "0.3.26"
 tokio = { version = "^1.26.0", features = ["rt", "macros"] }
 web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", package = "web-tree-sitter-sys", default-features = false, features = ["web"] }
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,40 +1,37 @@
+use criterion::async_executor::FuturesExecutor;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs;
 use std::io;
 use topiary::Configuration;
 use topiary::{formatter, Operation};
 
-fn criterion_benchmark(c: &mut Criterion) {
-    tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async {
-            let input = fs::read_to_string("tests/samples/input/ocaml.ml").unwrap();
-            let query = fs::read_to_string("languages/ocaml.scm").unwrap();
-            c.bench_function("format ocaml", |b| {
-                b.iter(|| async {
-                    let configuration = Configuration::parse(&query).unwrap();
-                    let grammars = configuration.language.grammars().await.unwrap();
+async fn format() {
+    let input = fs::read_to_string("tests/samples/input/ocaml.ml").unwrap();
+    let query = fs::read_to_string("languages/ocaml.scm").unwrap();
+    let configuration = Configuration::parse(&query).unwrap();
+    let grammars = configuration.language.grammars().await.unwrap();
 
-                    let mut input = input.as_bytes();
-                    let mut query = query.as_bytes();
-                    let mut output = io::BufWriter::new(Vec::new());
+    let mut input = input.as_bytes();
+    let mut query = query.as_bytes();
+    let mut output = io::BufWriter::new(Vec::new());
 
-                    formatter(
-                        &mut input,
-                        &mut output,
-                        &mut query,
-                        &grammars,
-                        &configuration,
-                        Operation::Format {
-                            skip_idempotence: false,
-                        },
-                    )
-                })
-            });
-        });
+    formatter(
+        &mut input,
+        &mut output,
+        &mut query,
+        &grammars,
+        &configuration,
+        Operation::Format {
+            skip_idempotence: true,
+        },
+    )
+    .unwrap()
 }
 
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("format_ocaml", |b| {
+        b.to_async(FuturesExecutor).iter(format);
+    });
+}
 criterion_group!(benches, criterion_benchmark);
 criterion_main!(benches);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,30 +1,39 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs;
 use std::io;
+use topiary::Configuration;
 use topiary::{formatter, Operation};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let input = fs::read_to_string("tests/samples/input/ocaml.ml").unwrap();
-    let query = fs::read_to_string("languages/ocaml.scm").unwrap();
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            let input = fs::read_to_string("tests/samples/input/ocaml.ml").unwrap();
+            let query = fs::read_to_string("languages/ocaml.scm").unwrap();
+            c.bench_function("format ocaml", |b| {
+                b.iter(|| async {
+                    let configuration = Configuration::parse(&query).unwrap();
+                    let grammars = configuration.language.grammars().await.unwrap();
 
-    c.bench_function("format ocaml", |b| {
-        b.iter(|| async {
-            let mut input = input.as_bytes();
-            let mut query = query.as_bytes();
-            let mut output = io::BufWriter::new(Vec::new());
+                    let mut input = input.as_bytes();
+                    let mut query = query.as_bytes();
+                    let mut output = io::BufWriter::new(Vec::new());
 
-            formatter(
-                &mut input,
-                &mut output,
-                &mut query,
-                None,
-                Operation::Format {
-                    skip_idempotence: false,
-                },
-            )
-            .await
-        })
-    });
+                    formatter(
+                        &mut input,
+                        &mut output,
+                        &mut query,
+                        &grammars,
+                        &configuration,
+                        Operation::Format {
+                            skip_idempotence: false,
+                        },
+                    )
+                })
+            });
+        });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -19,8 +19,8 @@ async fn format() {
         &mut input,
         &mut output,
         &mut query,
-        &grammars,
         &configuration,
+        &grammars,
         Operation::Format {
             skip_idempotence: true,
         },

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -8,7 +8,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let query = fs::read_to_string("languages/ocaml.scm").unwrap();
 
     c.bench_function("format ocaml", |b| {
-        b.iter(|| {
+        b.iter(|| async {
             let mut input = input.as_bytes();
             let mut query = query.as_bytes();
             let mut output = io::BufWriter::new(Vec::new());
@@ -22,6 +22,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     skip_idempotence: false,
                 },
             )
+            .await
         })
     });
 }

--- a/flake.lock
+++ b/flake.lock
@@ -85,6 +85,21 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nix-filter": {
       "locked": {
         "lastModified": 1678109515,
@@ -116,13 +131,30 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1665296151,
+        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "advisory-db": "advisory-db",
         "crane": "crane",
         "flake-utils": "flake-utils_2",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay_2"
       }
     },
     "rust-overlay": {
@@ -142,6 +174,25 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1678674283,
+        "narHash": "sha256-MnFqHP7AwvjK3VLRmDnzbJWSL8lbDrmYESjQDaRmAVo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f25d4bc2f6a0a3f9a2f15d3b9e3edb0ee5099a3d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    rust-overlay.url = "github:oxalica/rust-overlay";
+
     advisory-db = {
       url = "github:rustsec/advisory-db";
       flake = false;
@@ -31,9 +33,12 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        code = pkgs.callPackage ./. { inherit advisory-db crane nix-filter; };
+        code = pkgs.callPackage ./. { inherit nixpkgs system advisory-db crane rust-overlay nix-filter; };
       in {
-        packages.default = code.app;
+        packages = with code; {
+          inherit wasm;
+          default = app;
+        };
         checks = with code; {
           inherit app clippy fmt audit benchmark;
         };

--- a/src/bin/topiary/main.rs
+++ b/src/bin/topiary/main.rs
@@ -143,8 +143,8 @@ async fn run() -> CLIResult<()> {
         &mut input,
         &mut output,
         &mut query_reader,
-        &grammars,
         &configuration,
+        &grammars,
         operation,
     )?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -176,6 +176,15 @@ impl From<serde_json::Error> for FormatterError {
     }
 }
 
+impl From<tree_sitter_facade::LanguageError> for FormatterError {
+    fn from(e: tree_sitter_facade::LanguageError) -> Self {
+        Self::Internal(
+            "Error while loading language grammar".into(),
+            Some(Box::new(e)),
+        )
+    }
+}
+
 impl From<tree_sitter_facade::ParserError> for FormatterError {
     fn from(e: tree_sitter_facade::ParserError) -> Self {
         Self::Internal("Error while parsing".into(), Some(Box::new(e)))

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -70,7 +69,7 @@ impl Language {
     /// Note that, currently, all grammars are statically linked. This will change once dynamic linking
     /// is implemented (see Issue #4).
     #[cfg(not(target_arch = "wasm32"))]
-    pub async fn grammars(&self) -> Result<Vec<tree_sitter_facade::Language>, Box<dyn Error>> {
+    pub async fn grammars(&self) -> FormatterResult<Vec<tree_sitter_facade::Language>> {
         Ok(match self {
             Language::Bash => vec![tree_sitter_bash::language()],
             Language::Json => vec![tree_sitter_json::language()],
@@ -91,7 +90,7 @@ impl Language {
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub async fn grammars(&self) -> Result<Vec<tree_sitter_facade::Language>, Box<dyn Error>> {
+    pub async fn grammars(&self) -> FormatterResult<Vec<tree_sitter_facade::Language>> {
         use futures::future::join_all;
 
         let language_names = match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub enum Operation {
 ///     .await
 ///     .expect("grammars");
 ///
-/// match formatter(&mut input, &mut output, &mut query_file, &grammars, &configuration, Operation::Format{ skip_idempotence: false }) {
+/// match formatter(&mut input, &mut output, &mut query_file, &configuration, &grammars, Operation::Format{ skip_idempotence: false }) {
 ///   Ok(()) => {
 ///     let formatted = String::from_utf8(output).expect("valid utf-8");
 ///   }
@@ -140,8 +140,8 @@ pub fn formatter(
     input: &mut impl io::Read,
     output: &mut impl io::Write,
     query: &mut impl io::Read,
-    grammars: &[tree_sitter_facade::Language],
     configuration: &Configuration,
+    grammars: &[tree_sitter_facade::Language],
     operation: Operation,
 ) -> FormatterResult<()> {
     let content = read_input(input).map_err(|e| {
@@ -172,7 +172,7 @@ pub fn formatter(
             let trimmed = trim_whitespace(&rendered);
 
             if !skip_idempotence {
-                idempotence_check(&trimmed, &query, grammars, configuration)?
+                idempotence_check(&trimmed, &query, configuration, grammars)?
             }
 
             write!(output, "{trimmed}")?;
@@ -208,8 +208,8 @@ fn trim_whitespace(s: &str) -> String {
 fn idempotence_check(
     content: &str,
     query: &str,
-    grammars: &[tree_sitter_facade::Language],
     configuration: &Configuration,
+    grammars: &[tree_sitter_facade::Language],
 ) -> FormatterResult<()> {
     log::info!("Checking for idempotence ...");
 
@@ -221,8 +221,8 @@ fn idempotence_check(
         &mut input,
         &mut output,
         &mut query,
-        grammars,
         configuration,
+        grammars,
         Operation::Format {
             skip_idempotence: true,
         },
@@ -263,8 +263,8 @@ async fn parse_error_fails_formatting() {
         &mut input,
         &mut output,
         &mut query.as_bytes(),
-        &grammars,
         &configuration,
+        &grammars,
         Operation::Format {
             skip_idempotence: true,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,7 @@ pub enum Operation {
 ///     .language
 ///     .grammars()
 ///     .await
-///     // TODO: Let grammars return this error.
-///     .map_err(|e| FormatterError::Internal("Could not load grammars".into(), Some(e))).expect("grammars");
+///     .expect("grammars");
 ///
 /// match formatter(&mut input, &mut output, &mut query_file, &grammars, &configuration, Operation::Format{ skip_idempotence: false }) {
 ///   Ok(()) => {
@@ -138,9 +137,9 @@ pub enum Operation {
 /// # }) // end tokio_test
 /// ```
 pub fn formatter(
-    input: &mut (impl io::Read + Send),
-    output: &mut (impl io::Write + Send),
-    query: &mut (impl io::Read + Send),
+    input: &mut impl io::Read,
+    output: &mut impl io::Write,
+    query: &mut impl io::Read,
     grammars: &[tree_sitter_facade::Language],
     configuration: &Configuration,
     operation: Operation,

--- a/tests/sample-tester.rs
+++ b/tests/sample-tester.rs
@@ -3,12 +3,11 @@ use std::io::BufReader;
 use std::path::Path;
 
 use pretty_assertions::assert_eq;
-use test_log::test;
 
 use topiary::{formatter, Language, Operation};
 
-#[test]
-fn input_output_tester() {
+#[tokio::test]
+async fn input_output_tester() {
     let input_dir = fs::read_dir("tests/samples/input").unwrap();
     let expected_dir = Path::new("tests/samples/expected");
 
@@ -33,6 +32,7 @@ fn input_output_tester() {
                 skip_idempotence: true,
             },
         )
+        .await
         .unwrap();
 
         let formatted = String::from_utf8(output).unwrap();
@@ -43,8 +43,8 @@ fn input_output_tester() {
 }
 
 // Test that our query files are properly formatted
-#[test]
-fn formatted_query_tester() {
+#[tokio::test]
+async fn formatted_query_tester() {
     let language_dir = fs::read_dir("languages").unwrap();
 
     for file in language_dir {
@@ -67,6 +67,7 @@ fn formatted_query_tester() {
                 skip_idempotence: true,
             },
         )
+        .await
         .unwrap();
 
         let formatted = String::from_utf8(output).unwrap();

--- a/tests/sample-tester.rs
+++ b/tests/sample-tester.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use pretty_assertions::assert_eq;
 
-use topiary::{formatter, Language, Operation};
+use topiary::{formatter, Configuration, Language, Operation};
 
 #[tokio::test]
 async fn input_output_tester() {
@@ -21,18 +21,22 @@ async fn input_output_tester() {
         let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
         let mut output = Vec::new();
         let query = fs::read_to_string(language.query_file().unwrap()).unwrap();
-        let mut query = query.as_bytes();
+
+        let mut configuration = Configuration::parse(&query).unwrap();
+        configuration.language = language;
+
+        let grammars = configuration.language.grammars().await.unwrap();
 
         formatter(
             &mut input,
             &mut output,
-            &mut query,
-            Some(language),
+            &mut query.as_bytes(),
+            &grammars,
+            &configuration,
             Operation::Format {
                 skip_idempotence: true,
             },
         )
-        .await
         .unwrap();
 
         let formatted = String::from_utf8(output).unwrap();
@@ -56,18 +60,22 @@ async fn formatted_query_tester() {
         let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
         let mut output = Vec::new();
         let query = fs::read_to_string(language.query_file().unwrap()).unwrap();
-        let mut query = query.as_bytes();
+
+        let mut configuration = Configuration::parse(&query).unwrap();
+        configuration.language = language;
+
+        let grammars = configuration.language.grammars().await.unwrap();
 
         formatter(
             &mut input,
             &mut output,
-            &mut query,
-            Some(language),
+            &mut query.as_bytes(),
+            &grammars,
+            &configuration,
             Operation::Format {
                 skip_idempotence: true,
             },
         )
-        .await
         .unwrap();
 
         let formatted = String::from_utf8(output).unwrap();

--- a/tests/sample-tester.rs
+++ b/tests/sample-tester.rs
@@ -31,8 +31,8 @@ async fn input_output_tester() {
             &mut input,
             &mut output,
             &mut query.as_bytes(),
-            &grammars,
             &configuration,
+            &grammars,
             Operation::Format {
                 skip_idempotence: true,
             },
@@ -70,8 +70,8 @@ async fn formatted_query_tester() {
             &mut input,
             &mut output,
             &mut query.as_bytes(),
-            &grammars,
             &configuration,
+            &grammars,
             Operation::Format {
                 skip_idempotence: true,
             },


### PR DESCRIPTION
Related to #171 .

`web_tree_sitter::Language::load_path()` is async, so now Topiary is as well. It's not entirely straightforward to make `formatter()` async, and it may be nice to keep the async stuff out of it anyway, so the API has changed so that grammars are loaded outside of it, then passed in to `formatter()`.

Also added Wasm building to Nix, and running that from CI.