### PR TITLE
Add new formatting directives to solve OCaml idempotency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,45 @@ This Tree-sitter query:
 
 ...while the single-lined `(1, 2, 3)` is kept as is.
 
+### `@singleline_scoped_delete`
+
+Remove the matched node from the output, only if the associated custom scope is single-line. The scope must be specified with the predicate `#scope_id!`.
+
+#### Example
+
+```scheme
+; Delete the optional "|" before the first match case
+; if the context is single-line
+(function_expression
+  (match_case)? @do_nothing
+  .
+  "|" @singleline_scoped_delete
+  .
+  (match_case)
+  (#scope_id! "function_definiton")
+)
+```
+
+### `@append_multiline_delimiter` / `@prepend_multiline_delimiter`
+
+The matched nodes will have a multi-line-only delimiter appended to
+them. It will be printed if the associated custom scope is multi-line, and omitted otherwise.
+The delimiter must be specified using the predicate `#delimiter!`. The scope must be specified with the predicate `#scope_id!`.
+
+#### Example
+
+```scheme
+; Add the optional "|" before the first match case
+; only if the context is multi-line
+(function_expression
+  "|"? @do_nothing
+  .
+  (match_case) @prepend_scoped_multiline_delimiter
+  (#scope_id! "function_definiton")
+  (#delimiter! "| ")
+)
+```
+
 ## Suggested workflow
 
 In order to work productively on query files, the following is one

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -679,7 +679,7 @@
 ;   Const_int _ -> instance Predef.type_int
 ;   | Const_char _ -> instance Predef.type_char
 ;
-(
+(match_expression
   "|"* @do_nothing
   .
   (match_case) @prepend_spaced_softline
@@ -688,7 +688,7 @@
 ; Allow (and enforce) the optional "|" before the first match case
 ; if and only if the context is multi-line
 (
-  (match_case)? @do_nothing
+  "with"
   .
   "|" @singleline_delete
   .
@@ -696,7 +696,7 @@
 )
 
 (
-  (match_case)? @do_nothing
+  "with"
   .
   "|"? @do_nothing
   .
@@ -776,7 +776,7 @@
 ; into
 ;
 ; let foo = function
-;   true -> false
+;   | true -> false
 ;   | false -> true
 ; in
 ; bar
@@ -789,17 +789,28 @@
   (#scope_id! "function_definiton")
 )
 (parenthesized_expression
-  (function_expression) @begin_scope @end_scope
+  (function_expression
+    "function" @append_spaced_scoped_softline
+  ) @begin_scope @end_scope
   (#scope_id! "function_definiton")
 )
 (function_expression
-  "|"* @do_nothing
+  (match_case)? @do_nothing
   .
-  (match_case) @prepend_spaced_scoped_softline
+  "|" @singleline_scoped_delete
+  .
+  (match_case)
   (#scope_id! "function_definiton")
 )
 (function_expression
-  "|"* @prepend_spaced_scoped_softline
+  "|"? @do_nothing
+  .
+  (match_case) @prepend_scoped_multiline_delimiter
+  (#scope_id! "function_definiton")
+  (#delimiter! "| ") ; sic
+)
+(function_expression
+  "|" @prepend_spaced_scoped_softline
   .
   (match_case)
   (#scope_id! "function_definiton")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,15 @@ pub enum Atom {
     /// Represents a segment to be deleted, only if the context is single-line
     SingleLineDeleteBegin,
     SingleLineDeleteEnd,
+    /// Represents a segment to be deleted, only if the associated scope is single-line
+    SingleLineScopedDeleteBegin {
+        id: usize,
+        scope_id: String,
+    },
+    SingleLineScopedDeleteEnd {
+        id: usize,
+        scope_id: String,
+    },
     /// Scoped commands
     // ScopedSoftline works together with the @open_scope and @end_scope query tags.
     // To decide if a scoped softline must be expanded into a hardline, we look at

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,15 @@ pub enum Atom {
     /// Represents a literal string, such as a semicolon.
     Literal(String),
     /// Represents a literal string, such as a semicolon. It will be printed only
-    // in multi-line constructs
+    // in multi-line nodes.
     MultilineOnlyLiteral(String),
+    /// Represents a literal string, such as a semicolon. It will be printed only
+    // if the associated scope is multi-line
+    ScopedMultilineOnlyLiteral {
+        id: usize,
+        literal: String,
+        scope_id: String,
+    },
     /// Represents a softline. It will be turned into a hardline for multi-line
     /// constructs, and either a space or nothing for single-line constructs.
     Softline {

--- a/tests/samples/expected/ocaml.ml
+++ b/tests/samples/expected/ocaml.ml
@@ -605,7 +605,7 @@ let _ =
 
 let _ =
   let foo = function
-    true -> false
+    | true -> false
     | false -> true
   in
   foo
@@ -1000,6 +1000,10 @@ let not x =
   match x with
   | false -> true
   | true -> false
+
+let not = function
+  | true -> false
+  | false -> true
 
 let not = function true -> false | false -> true
 

--- a/tests/samples/input/ocaml.ml
+++ b/tests/samples/input/ocaml.ml
@@ -949,6 +949,9 @@ let not x = match x with
   | false -> true
   | true -> false
 
+let not =
+  function | true -> false | false -> true
+
 let not = function true -> false | false -> true
 
 let not x = match x with | true -> false | false -> true


### PR DESCRIPTION
This PR introduces two new formatting directives, which use custom scopes:
- `@append_scoped_multiline_delimiter` / `@prepend_scoped_multiline_delimiter`, which are the equivalent of `@*pend_multiline_delimiter`, but check if a custom scope is multi-line instead of the parent node.
- `@singleline_scoped_delete`, which is the equivalent of `@singleline_delete`, but checks if a custom scope is multi-line instead of the parent node.

These directives are used to fix the OCaml query file, which can now format
```ocaml
let not =
  function true -> false | false -> true
```
into
```ocaml
let not = function
  | true -> false
  | false -> true
```
in a single pass, instead of two previously.

Closes the OCaml part of #334:
```
cargo run -- -f tests/samples/input/ocaml.ml
```