### PR TITLE
Improve the escaping for GraphViz output

### DIFF
--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -4,7 +4,6 @@ use std::{borrow::Cow, fmt, io};
 
 use crate::{tree_sitter::SyntaxNode, FormatterResult};
 
-// TODO Add tests for this
 /// We double-escape whitespace (\n and \t) so it is
 /// rendered as the escaped value in the GraphViz output
 fn escape(input: &str) -> Cow<str> {
@@ -92,4 +91,22 @@ pub fn write(output: &mut dyn io::Write, root: &SyntaxNode) -> FormatterResult<(
     writeln!(output, "}}")?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::escape;
+
+    #[test]
+    fn double_escape() {
+        // PBT would be handy, here
+        assert_eq!(escape("foo"), "foo");
+        assert_eq!(escape("'"), r#"\'"#);
+        assert_eq!(escape("\n"), r#"\\n"#);
+        assert_eq!(escape("\t"), r#"\\t"#);
+        assert_eq!(
+            escape("Here's something\nlonger"),
+            r#"Here\'s something\\nlonger"#
+        );
+    }
 }

--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -7,25 +7,25 @@ use crate::{tree_sitter::SyntaxNode, FormatterResult};
 /// We double-escape whitespace (\n and \t) so it is
 /// rendered as the escaped value in the GraphViz output
 fn escape(input: &str) -> Cow<str> {
-    let mut buffer: Option<String> = None;
+    // No allocation happens for an empty string
+    let mut buffer = String::new();
 
     let mut start: usize = 0;
     let length = input.len();
 
-    let append = |buffer: &mut Option<String>, from: &mut usize, to: usize, suffix: &str| {
+    let append = |buffer: &mut String, from: &mut usize, to: usize, suffix: &str| {
         // Allocate buffer only when necessary
-        if buffer.is_none() {
+        if buffer.is_empty() {
             // Best case:  length + 1  (i.e., single escaped character in input)
             // Worst case: length * 3  (i.e., every character needs double-escaping)
-            *buffer = Some(String::with_capacity(length * 2));
+            // The input is likely to be short, so no harm in reserving for the worst case
+            buffer.reserve(length * 3);
         }
 
-        if let Some(ref mut buffer) = buffer {
-            // Decant the unescaped chunk from the input,
-            // followed by the escaped suffix provided
-            *buffer += &input[*from..to];
-            *buffer += suffix;
-        }
+        // Decant the unescaped chunk from the input,
+        // followed by the escaped suffix provided
+        *buffer += &input[*from..to];
+        *buffer += suffix;
 
         // Fast-forward the tracking cursor to the next character
         *from = to + 1;
@@ -53,12 +53,12 @@ fn escape(input: &str) -> Cow<str> {
         }
     }
 
-    if let Some(mut buffer) = buffer {
+    if buffer.is_empty() {
+        input.into()
+    } else {
         // Decant whatever's left of the input into the buffer
         buffer += &input[start..length];
         buffer.into()
-    } else {
-        input.into()
     }
 }
 
@@ -96,10 +96,11 @@ pub fn write(output: &mut dyn io::Write, root: &SyntaxNode) -> FormatterResult<(
 #[cfg(test)]
 mod test {
     use super::escape;
+    use std::borrow::Cow;
 
     #[test]
     fn double_escape() {
-        // PBT would be handy, here
+        // Property-based testing would be handy, here...
         assert_eq!(escape("foo"), "foo");
         assert_eq!(escape("'"), r#"\'"#);
         assert_eq!(escape("\n"), r#"\\n"#);
@@ -108,5 +109,21 @@ mod test {
             escape("Here's something\nlonger"),
             r#"Here\'s something\\nlonger"#
         );
+    }
+
+    #[test]
+    fn escape_borrowed() {
+        match escape("foo") {
+            Cow::Borrowed("foo") => (),
+            _ => panic!("Expected a borrowed, unmodified str"),
+        }
+    }
+
+    #[test]
+    fn escape_owned() {
+        match escape("'") {
+            Cow::Owned(s) => assert_eq!(s, r#"\'"#),
+            _ => panic!("Expected an owned, escaped string"),
+        }
     }
 }

--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -1,8 +1,71 @@
 /// GraphViz visualisation for our SyntaxTree representation
 /// Named syntax nodes are elliptical; anonymous are rectangular
-use std::{fmt, io};
+use std::{borrow::Cow, fmt, io};
 
 use crate::{tree_sitter::SyntaxNode, FormatterResult};
+
+// TODO Factor out the repetition here
+// TODO Add tests for this
+fn escape(input: &str) -> Cow<str> {
+    // We double-escape whitespace (\n and \t) so it is
+    // rendered as the escaped value in the GraphViz output
+    let mut is_escaped = false;
+    let mut buffer: String = String::new();
+    let mut start: usize = 0;
+    let length = input.len();
+
+    for (upto, c) in input.chars().enumerate() {
+        match c {
+            '\n' => {
+                if !is_escaped {
+                    // Best case scenario: length + 1
+                    // Worst case scenario: length * 3
+                    buffer.reserve(length * 2);
+                    is_escaped = true;
+                }
+
+                buffer += &input[start..upto];
+                buffer += r#"\\n"#;
+
+                start = upto + 1;
+            }
+
+            '\t' => {
+                if !is_escaped {
+                    buffer.reserve(length * 2);
+                    is_escaped = true;
+                }
+
+                buffer += &input[start..upto];
+                buffer += r#"\\t"#;
+
+                start = upto + 1;
+            }
+
+            otherwise => {
+                let mut escaped = otherwise.escape_default().peekable();
+                if escaped.peek() == Some(&'\\') {
+                    if !is_escaped {
+                        buffer.reserve(length * 2);
+                        is_escaped = true;
+                    }
+
+                    buffer += &input[start..upto];
+                    buffer += &otherwise.escape_default().to_string();
+
+                    start = upto + 1;
+                }
+            }
+        }
+    }
+
+    if is_escaped {
+        buffer += &input[start..length];
+        buffer.into()
+    } else {
+        input.into()
+    }
+}
 
 impl fmt::Display for SyntaxNode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -15,7 +78,7 @@ impl fmt::Display for SyntaxNode {
             f,
             "  {} [label=\"{}\", shape={shape}];",
             self.id,
-            self.kind.escape_default()
+            escape(&self.kind)
         )?;
 
         for child in &self.children {


### PR DESCRIPTION
The node kind was escaped in the original GraphViz output. However, for anonymous nodes that contained escapable whitespace characters (e.g., `\n`), these ended up getting reinterpreted by GraphViz as their corresponding whitespace. That wasn't very helpful in the output, so now these characters are double-escaped, so they can be scrutinised.