### PR TITLE
Fix "definiton" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ Remove the matched node from the output, only if the associated custom scope is 
   "|" @singleline_scoped_delete
   .
   (match_case)
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 ```
 
@@ -854,7 +854,7 @@ The delimiter must be specified using the predicate `#delimiter!`. The scope mus
   "|"? @do_nothing
   .
   (match_case) @prepend_scoped_multiline_delimiter
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
   (#delimiter! "| ")
 )
 ```

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -762,7 +762,7 @@
   (fun_expression
     "->" @append_spaced_scoped_softline
   ) @end_scope
-  (#scope_id! "fun_definiton")
+  (#scope_id! "fun_definition")
 )
 
 ; The same as above holds for single-line `function`.
@@ -786,13 +786,13 @@
   (function_expression
     "function" @append_spaced_scoped_softline
   ) @end_scope
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (parenthesized_expression
   (function_expression
     "function" @append_spaced_scoped_softline
   ) @begin_scope @end_scope
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (function_expression
   (match_case)? @do_nothing
@@ -800,20 +800,20 @@
   "|" @singleline_scoped_delete
   .
   (match_case)
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (function_expression
   "|"? @do_nothing
   .
   (match_case) @prepend_scoped_multiline_delimiter
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
   (#delimiter! "| ") ; sic
 )
 (function_expression
   "|" @prepend_spaced_scoped_softline
   .
   (match_case)
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 
 (value_definition

--- a/tests/samples/expected/tree-sitter-query.scm
+++ b/tests/samples/expected/tree-sitter-query.scm
@@ -744,7 +744,7 @@
   (fun_expression
     "->" @append_spaced_scoped_softline
   ) @end_scope
-  (#scope_id! "fun_definiton")
+  (#scope_id! "fun_definition")
 )
 
 ; The same as above holds for single-line `function`.
@@ -768,23 +768,23 @@
   (function_expression
     "function" @append_spaced_scoped_softline
   ) @end_scope
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (parenthesized_expression
   (function_expression) @begin_scope @end_scope
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (function_expression
   "|"* @do_nothing
   .
   (match_case) @prepend_spaced_scoped_softline
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (function_expression
   "|"* @prepend_spaced_scoped_softline
   .
   (match_case)
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 
 (value_definition

--- a/tests/samples/input/tree-sitter-query.scm
+++ b/tests/samples/input/tree-sitter-query.scm
@@ -745,7 +745,7 @@
   (fun_expression
     "->" @append_spaced_scoped_softline
   ) @end_scope
-  (#scope_id! "fun_definiton")
+  (#scope_id! "fun_definition")
 )
 
 ; The same as above holds for single-line `function`.
@@ -769,23 +769,23 @@
   (function_expression
     "function" @append_spaced_scoped_softline
   ) @end_scope
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (parenthesized_expression
   (function_expression) @begin_scope @end_scope
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (function_expression
   "|"* @do_nothing
   .
   (match_case) @prepend_spaced_scoped_softline
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 (function_expression
   "|"* @prepend_spaced_scoped_softline
   .
   (match_case)
-  (#scope_id! "function_definiton")
+  (#scope_id! "function_definition")
 )
 
 (value_definition


### PR DESCRIPTION
Replace occurrences of `definiton` with `definition`