### PR TITLE
Fix premature draining of query buffer

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -12,13 +12,12 @@ async fn format() {
     let grammars = configuration.language.grammars().await.unwrap();
 
     let mut input = input.as_bytes();
-    let mut query = query.as_bytes();
     let mut output = io::BufWriter::new(Vec::new());
 
     formatter(
         &mut input,
         &mut output,
-        &mut query,
+        &query,
         &configuration,
         &grammars,
         Operation::Format {

--- a/src/bin/topiary/error.rs
+++ b/src/bin/topiary/error.rs
@@ -33,7 +33,7 @@ impl error::Error for TopiaryError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::Lib(error) => error.source(),
-            Self::Bin(_, Some(CLIError::IOError(error))) => error.source(),
+            Self::Bin(_, Some(CLIError::IOError(error))) => Some(error),
             Self::Bin(_, Some(CLIError::Generic(error))) => error.source(),
             Self::Bin(_, None) => None,
         }

--- a/src/bin/topiary/main.rs
+++ b/src/bin/topiary/main.rs
@@ -113,13 +113,14 @@ async fn run() -> CLIResult<()> {
         unreachable!();
     };
 
-    let mut query_reader = BufReader::new(File::open(query_path)?);
+    let query = {
+        let mut reader = BufReader::new(File::open(&query_path)?);
+        let mut contents = String::new();
+        reader.read_to_string(&mut contents)?;
 
-    // It's not very nice that formatter wants an io::Read and
-    // Configuration::parse wants a &str. Should we just let formatter take
-    // &str as well?
-    let mut query = String::new();
-    query_reader.read_to_string(&mut query)?;
+        contents
+    };
+
     let mut configuration = Configuration::parse(&query)?;
 
     // Replace the language deduced from the query file by the one from the CLI, if any
@@ -142,7 +143,7 @@ async fn run() -> CLIResult<()> {
     formatter(
         &mut input,
         &mut output,
-        &mut query_reader,
+        &query,
         &configuration,
         &grammars,
         operation,

--- a/src/bin/topiary/main.rs
+++ b/src/bin/topiary/main.rs
@@ -13,7 +13,10 @@ use std::{
 use clap::{ArgGroup, Parser};
 
 use crate::{
-    error::CLIResult, output::OutputFile, supported::SupportedLanguage, visualise::Visualisation,
+    error::{CLIError, CLIResult, TopiaryError},
+    output::OutputFile,
+    supported::SupportedLanguage,
+    visualise::Visualisation,
 };
 use topiary::{formatter, Configuration, Language, Operation};
 
@@ -113,13 +116,19 @@ async fn run() -> CLIResult<()> {
         unreachable!();
     };
 
-    let query = {
+    let query = (|| {
         let mut reader = BufReader::new(File::open(&query_path)?);
         let mut contents = String::new();
         reader.read_to_string(&mut contents)?;
 
-        contents
-    };
+        Ok(contents)
+    })()
+    .map_err(|e| {
+        TopiaryError::Bin(
+            "Could not open query file".into(),
+            Some(CLIError::IOError(e)),
+        )
+    })?;
 
     let mut configuration = Configuration::parse(&query)?;
 

--- a/tests/sample-tester.rs
+++ b/tests/sample-tester.rs
@@ -30,7 +30,7 @@ async fn input_output_tester() {
         formatter(
             &mut input,
             &mut output,
-            &mut query.as_bytes(),
+            &query,
             &configuration,
             &grammars,
             Operation::Format {
@@ -69,7 +69,7 @@ async fn formatted_query_tester() {
         formatter(
             &mut input,
             &mut output,
-            &mut query.as_bytes(),
+            &query,
             &configuration,
             &grammars,
             Operation::Format {

--- a/web-playground/src/lib.rs
+++ b/web-playground/src/lib.rs
@@ -32,7 +32,7 @@ pub async fn format(input: &str, query: &str) -> String {
     match formatter(
         &mut input.as_bytes(),
         &mut output,
-        &mut query.as_bytes(),
+        query,
         &configuration,
         &grammars,
         Operation::Format {


### PR DESCRIPTION
Change the `formatter` API such that it takes the query as a `&str`, rather than `io::Read`. Previously, the `BufReader` was getting drained in `src/bin/topiary/main.rs` to parse the configuration, leaving the formatter with an empty query buffer.