### PR TITLE
Convert error types into productive exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,22 @@ Language selection is based on precedence, in the following order:
 * Detected from the input file's extension
 * A specified query file
 
+#### Exit Codes
+
+The Topiary process will exit with a zero exit code upon successful
+formatting. Otherwise, the following exit codes are defined:
+
+| Reason                       | Code |
+| :--------------------------- | ---- |
+| Unspecified error            |    1 |
+| CLI argument parsing error   |    2 |
+| I/O error                    |    3 |
+| Topiary query error          |    4 |
+| Source parsing error         |    5 |
+| Language detection error     |    6 |
+| Idempotency error            |    7 |
+| Unspecified formatting error |    8 |
+
 #### Example
 
 Once built, the program can be run like this:

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
                     else
                       EXIT=$?
                       if (( EXIT == 6 )); then
+                        # Skip over language detection errors
                         continue
                       else
                         exit $EXIT

--- a/src/bin/topiary/error.rs
+++ b/src/bin/topiary/error.rs
@@ -63,7 +63,7 @@ impl From<TopiaryError> for ExitCode {
             TopiaryError::Bin(_, Some(CLIError::IOError(_))) => 3,
 
             // Bad arguments: Exit 2
-            // (Handled by clap)
+            // (Handled by clap: https://github.com/clap-rs/clap/issues/3426)
 
             // Anything else: Exit 1
             _ => 1,

--- a/src/bin/topiary/error.rs
+++ b/src/bin/topiary/error.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt, io, result};
+use std::{error, fmt, io, process::ExitCode, result};
 use topiary::FormatterError;
 
 /// A convenience wrapper around `std::result::Result<T, TopiaryError>`.
@@ -37,6 +37,39 @@ impl error::Error for TopiaryError {
             Self::Bin(_, Some(CLIError::Generic(error))) => error.source(),
             Self::Bin(_, None) => None,
         }
+    }
+}
+
+impl From<TopiaryError> for ExitCode {
+    fn from(e: TopiaryError) -> Self {
+        let exit_code = match e {
+            // Formatting errors: Exit 8
+            TopiaryError::Lib(FormatterError::Formatting(_)) => 8,
+
+            // Idempotency errors: Exit 7
+            TopiaryError::Lib(FormatterError::Idempotence) => 7,
+
+            // Language detection errors: Exit 6
+            TopiaryError::Lib(FormatterError::LanguageDetection(_, _)) => 6,
+
+            // Parsing errors: Exit 5
+            TopiaryError::Lib(FormatterError::Parsing { .. }) => 5,
+
+            // Query errors: Exit 4
+            TopiaryError::Lib(FormatterError::Query(_, _)) => 4,
+
+            // I/O errors: Exit 3
+            TopiaryError::Lib(FormatterError::Io(_)) => 3,
+            TopiaryError::Bin(_, Some(CLIError::IOError(_))) => 3,
+
+            // Bad arguments: Exit 2
+            // (Handled by clap)
+
+            // Anything else: Exit 1
+            _ => 1,
+        };
+
+        ExitCode::from(exit_code)
     }
 }
 

--- a/src/bin/topiary/main.rs
+++ b/src/bin/topiary/main.rs
@@ -8,7 +8,7 @@ use std::{
     fs::File,
     io::{stdin, BufReader, BufWriter, Read},
     path::PathBuf,
-    process::ExitCode
+    process::ExitCode,
 };
 
 use clap::{ArgGroup, Parser};

--- a/src/bin/topiary/main.rs
+++ b/src/bin/topiary/main.rs
@@ -8,6 +8,7 @@ use std::{
     fs::File,
     io::{stdin, BufReader, BufWriter, Read},
     path::PathBuf,
+    process::ExitCode
 };
 
 use clap::{ArgGroup, Parser};
@@ -68,11 +69,13 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
     if let Err(e) = run().await {
         print_error(&e);
-        std::process::exit(1);
+        return e.into();
     }
+
+    ExitCode::SUCCESS
 }
 
 async fn run() -> CLIResult<()> {


### PR DESCRIPTION
This PR distinguishes exit code by error type, documented in the `README`. Largely motivated by the need, raised by @Niols, to skip over language detection errors in the precommit hook script (which has also been updated, accordingly).