### PR TITLE
Nickel: Annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+
+[[package]]
 name = "bstr"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,7 +164,7 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap",
  "textwrap",
@@ -166,11 +172,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.10"
+version = "4.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce38afc168d8665cfc75c7b1dd9672e50716a137f433f070991619744a67342a"
+checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.2",
  "clap_derive",
  "clap_lex 0.3.3",
  "is-terminal",
@@ -525,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e86b86ae312accbf05ade23ce76b625e0e47a255712b7414037385a1c05380"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -536,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -645,9 +651,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "output_vt100"
@@ -808,7 +814,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -836,11 +842,11 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.36.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "2fe885c3a125aa45213b68cc1472a49880cb5923dc23f522ad2791b882228778"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -871,22 +877,22 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.157"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707de5fcf5df2b5788fca98dd7eab490bc2fd9b7ef1404defc462833b83f25ca"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.157"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78997f4555c22a7971214540c4a661291970619afd56de19f77e0de86296e1e5"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.0",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -928,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.0"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cff13bb1732bccfe3b246f3fdb09edfd51c01d6f5299b7ccd9457c2e4e37774"
+checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1059,7 +1065,7 @@ name = "topiary-cli"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
- "clap 4.1.10",
+ "clap 4.1.11",
  "env_logger",
  "log",
  "tempfile",
@@ -1122,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-nickel"
 version = "0.0.1"
-source = "git+https://github.com/nickel-lang/tree-sitter-nickel#d6c7eeb751038f934b5b1aa7ff236376d0235c56"
+source = "git+https://github.com/nickel-lang/tree-sitter-nickel?rev=fc0c53e#fc0c53ec2fda2f259079a1caea4a1ffe99a0d227"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ stated design goals. They are exposed, in Topiary, through a command
 line flag.
 
 * [OCaml] (both implementations and interfaces)
+* [Nickel]
 * [JSON]
 * [TOML]
 
@@ -97,7 +98,6 @@ specifying the path to their query files.
 
 * [Rust]
 * [Bash]
-* [Nickel]
 * [Tree Sitter Queries][tree-sitter-query]
 
 ## Getting Started
@@ -146,8 +146,8 @@ pre-commit-check = nix-pre-commit-hooks.run {
 Options:
 
 * `-l`, `--language <LANGUAGE>`\
-  Which language to parse and format [possible values: `json`, `toml`,
-  `ocaml`, `ocaml-implementation`, `ocaml-interface`].
+  Which language to parse and format [possible values: `json`, `nickel`,
+  `ocaml`, `ocaml-implementation`, `ocaml-interface`, `toml`].
 
 * `-f`, `--input-file <INPUT_FILE>`\
   Path to an input file. If omitted, or equal to "-", read from standard

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -8,6 +8,7 @@
   (static_string)
   (str_chunks_single)
   (str_chunks_multi)
+  (builtin)
 ] @leaf
 
 ; Allow blank line before

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -140,6 +140,42 @@
   ] @prepend_spaced_scoped_softline
 )
 
+; Start a let binding's RHS on a new line, in a multi-line context.
+(let_in_block
+  (#scope_id! "let_term")
+  "=" @begin_scope
+  .
+  (term) @end_scope
+)
+
+(let_in_block
+  (#scope_id! "let_term")
+  (term) @prepend_spaced_scoped_softline
+)
+
+;; Functions
+
+; Start a function's definition on a new line, in a multi-line context.
+; This also defines an indentation block.
+(fun_expr
+  (#scope_id! "function_definition")
+  "=>" @begin_scope @append_indent_start
+) @append_indent_end @end_scope
+
+(fun_expr
+  (#scope_id! "function_definition")
+  (term) @prepend_spaced_scoped_softline
+)
+
+(fun_expr
+  (pattern) @append_space
+)
+
+; Application operator is space, so we put it between identifiers.
+(applicative
+  t1: (applicative) @append_space
+)
+
 ;; TIDY FROM HERE ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (let_expr
@@ -147,19 +183,9 @@
 )
 
 (let_in_block
-  "=" @append_input_softline @append_indent_start
+  "=" @append_indent_start
   .
   t1: (_) @append_indent_end @append_spaced_softline
-)
-
-(fun_expr
-  "=>" @append_spaced_softline @append_indent_start
-  (_) @append_indent_end
-  .
-)
-
-(fun_expr
-  (pattern) @append_space
 )
 
 (match_expr
@@ -178,11 +204,9 @@
   t2: (term) @append_indent_end
 )
 
-(
-  (infix_b_op_6
-    "&"
-  ) @prepend_spaced_softline
-)
+(infix_b_op_6
+  "&"
+) @prepend_spaced_softline
 
 (forall
   "." @append_spaced_softline @append_indent_start
@@ -254,9 +278,4 @@
     ","
     ";"
   ] @append_spaced_softline
-)
-
-; Application operator is space, so we put it between identifiers.
-(applicative
-  t1: (applicative) @append_space
 )

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -116,13 +116,27 @@
   "=" @end_scope
 )
 
-; Put each component of the signature on a new line,
-; in a multi-line context
+; Put each annotation and the equals sign on a new line, in a multi-line
+; context. Type annotations do not get a new line; this is because they
+; can be nested and it's not(?) possible to deduce the depth with
+; queries alone. For example:
+;
+;   {
+;     foo : { foo : String, bar : Number } = ...
+;   }
+;
+;   {
+;     foo : {
+;       foo : String,
+;       bar : Number
+;     }
+;     = ...
+;   }
 (
   (#scope_id! "signature")
 
   [
-    (annot_atom)
+    (annot_atom "|")
     "="
   ] @prepend_spaced_scoped_softline
 )

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -18,14 +18,6 @@
   (record_last_field)
 ] @allow_blank_line_before
 
-(comment) @prepend_input_softline
-
-(
-  (comment) @append_input_softline
-  .
-  ["," ";"]* @do_nothing
-)
-
 ; Surround spaces
 ; A space is put after, and before keywords.
 ; It is also put before and after "|", ":" and "?" separating annotation from the annotated object.
@@ -84,6 +76,12 @@
     "||"
   ] @prepend_space @append_space
 )
+
+;; Comments
+
+(comment) @prepend_input_softline @append_hardline
+
+;;
 
 (let_expr
   (let_in_block) @append_spaced_softline

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -14,6 +14,8 @@
 ; Allow blank line before
 [
   (comment)
+  (record_field)
+  (record_last_field)
 ] @allow_blank_line_before
 
 (comment) @prepend_input_softline

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -83,7 +83,8 @@
 ; i.e., Let bindings and record fields
 
 ; Create a scope that covers all annotation atoms, if any,
-; which are children of the (annot) node, *and* the equal sign
+; which are children of the (annot) node, *and* the equal sign. This
+; also defines an indentation block.
 ;
 ; NOTE This query will only match when annotations are present; thus a
 ; "bare" signature, with just an equal sign, will not get a softline,
@@ -108,12 +109,11 @@
 ;   }
 (
   (#scope_id! "signature")
-
   _ @begin_scope
   .
-  (annot)
+  (annot) @prepend_indent_start
   .
-  "=" @end_scope
+  "=" @append_indent_end @end_scope
 )
 
 ; Put each annotation and the equals sign on a new line, in a multi-line
@@ -134,26 +134,11 @@
 ;   }
 (
   (#scope_id! "signature")
-
   [
     (annot_atom "|")
     "="
   ] @prepend_spaced_scoped_softline
 )
-
-; Start an indentation block after the first named child of a
-; definition, up 'til the end of that definition
-(let_in_block
-  .
-  (_) @append_indent_start
-  "in" @prepend_indent_end
-  .
-)
-
-(record_field
-  .
-  (_) @append_indent_start
-) @append_indent_end
 
 ;; TIDY FROM HERE ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -162,7 +147,7 @@
 )
 
 (let_in_block
-  "=" @append_indent_start ; @append_spaced_softline
+  "=" @append_input_softline @append_indent_start
   .
   t1: (_) @append_indent_end @append_spaced_softline
 )

--- a/topiary-cli/src/supported.rs
+++ b/topiary-cli/src/supported.rs
@@ -4,10 +4,11 @@ use topiary::Language;
 #[derive(ValueEnum, Clone, Copy, Debug)]
 pub enum SupportedLanguage {
     Json,
-    Toml,
+    Nickel,
     Ocaml,
     OcamlImplementation,
     OcamlInterface,
+    Toml,
     // Any other entries in crate::Language are experimental and won't be
     // exposed in the CLI. They can be accessed using --query language/foo.scm
     // instead.
@@ -17,10 +18,11 @@ impl From<SupportedLanguage> for Language {
     fn from(language: SupportedLanguage) -> Self {
         match language {
             SupportedLanguage::Json => Language::Json,
-            SupportedLanguage::Toml => Language::Toml,
+            SupportedLanguage::Nickel => Language::Nickel,
             SupportedLanguage::Ocaml => Language::Ocaml,
             SupportedLanguage::OcamlImplementation => Language::OcamlImplementation,
             SupportedLanguage::OcamlInterface => Language::OcamlInterface,
+            SupportedLanguage::Toml => Language::Toml,
         }
     }
 }

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -25,7 +25,7 @@ tree-sitter-json = { version = "0.19", optional = true }
 tree-sitter-rust = { version = "0.20.3", optional = true }
 tree-sitter-toml = { version = "0.20.0", optional = true }
 tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", optional = true }
-tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", optional = true }
+tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "fc0c53e", optional = true }
 tree-sitter-query = { git = "https://github.com/nvim-treesitter/tree-sitter-query", optional = true }
 # Needs a version > 0.19
 tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", optional = true }
@@ -35,6 +35,6 @@ web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", packag
 criterion = { version = "0.4", features=["async_futures"] }
 tokio-test = "0.4.2"
 
-[[bench]]   
+[[bench]]
 name = "benchmark"
 harness = false

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -12,6 +12,7 @@
           let head = array.head arr in
           let tail = array.tail arr in
           [ f head ] @ map f tail,
+
       fold : forall a b. (a -> b -> b) -> Array a -> b -> b = fun f arr first =>
         if arr == []
         then
@@ -25,6 +26,7 @@
   # Compute `7!`
   let l = my_array_lib.map ( fun x => x + 1) [ 1, 2, 3, 4, 5, 6 ] in
   my_array_lib.fold ( fun x acc => x * acc) l 1,
+
   fibonacci_fibonacci = let rec fibonacci =
     fun n =>
       if n == 0
@@ -38,20 +40,25 @@
           fibonacci (n - 1) + fibonacci (n - 2)
   in
   fibonacci 10,
+
   merge_main = let server = import "server.ncl" in
   let security = import "security.ncl" in
   server & security & { firewall.enabled = false } ,
+
   merge_server = {
     server.host.ip = "182.168.1.1",
     server.host.port = 80,
     server.host.name = "hello-world.net",
   } ,
+
   merge_security = {
     server.host.options = "TLS",
+
     firewall.enabled | default = true ,
     firewall.type = "iptables",
     firewall.open_ports = [ 21, 80, 443 ],
   } ,
+
   polymorphism_polymorphism =
   # First projection, statically typed
   let fst : forall a b. a -> b -> a = fun x y => x in
@@ -59,6 +66,7 @@
   let ev : forall a b. (a -> b) -> a -> b = fun f x => f x in
   let id : forall a. a -> a = fun x => x in
   (ev id (fst 5 10) == 5 : Bool ),
+
   simple-contracts_simple-contract-bool =
   # Example of simple custom contract, parametrized by a first argument.
   # In practice, for this kind of simple predicate, one should rather use
@@ -80,6 +88,7 @@
   # by `x`) to see contract errors appear.
   let not | AlwaysTrue -> AlwaysFalse = fun x => ! x in
   not true ,
+
   simple-contracts_simple-contract-div =
   # /!\ THIS EXAMPLE IS EXPECTED TO FAIL
   # Illustrates a basic contract violation.

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -4,7 +4,11 @@
 {
   arrays_arrays = let my_array_lib =
     {
-      map : forall a b. (a -> b) -> Array a -> Array b = fun f arr =>
+      map : forall a b. (a -> b) -> Array a -> Array b
+        | doc m%"
+          Here is some documentation
+          "%
+        = fun f arr =>
         if arr == []
         then
           []

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -6,7 +6,7 @@
     {
       map : forall a b. (a -> b) -> Array a -> Array b
         | doc m%"
-          Here is some documentation
+            Here is some documentation
           "%
         = fun f arr =>
         if arr == []

--- a/topiary/tests/samples/input/nickel.ncl
+++ b/topiary/tests/samples/input/nickel.ncl
@@ -7,7 +7,7 @@
     let my_array_lib = {
       map : forall a b. (a -> b) -> Array a -> Array b
         | doc m%"
-          Here is some documentation
+            Here is some documentation
           "%
         = fun f arr =>
           if arr == [] then

--- a/topiary/tests/samples/input/nickel.ncl
+++ b/topiary/tests/samples/input/nickel.ncl
@@ -5,13 +5,17 @@
 {
   arrays_arrays =
     let my_array_lib = {
-      map : forall a b. (a -> b) -> Array a -> Array b = fun f arr =>
-        if arr == [] then
-          []
-        else
-          let head = array.head arr in
-          let tail = array.tail arr in
-          [f head] @ map f tail,
+      map : forall a b. (a -> b) -> Array a -> Array b
+        | doc m%"
+          Here is some documentation
+          "%
+        = fun f arr =>
+          if arr == [] then
+            []
+          else
+            let head = array.head arr in
+            let tail = array.tail arr in
+            [f head] @ map f tail,
 
       fold : forall a b. (a -> b -> b) -> Array a -> b -> b =
           fun f arr first =>


### PR DESCRIPTION
This PR introduces:

* [x] Formatting rules for annotated symbol definitions
* [x] Formatting rules for nested annotations
* [x] Updated Nickel integration tests
* [x] Exposed Nickel as a supported language in the CLI

This will flow `|`-annotations on to new lines, when the annotations as a whole cover multiple lines. It will not reflow type annotations, because they can be nested and this causes idempotency issues (there doesn't appear to be a way of establishing the depth of the nesting from the grammar alone). For example:

```nickel
{
  single-line : type | annot | annot = whatever,

  multi-line : type
    | annot
    | annot
    = whatever
}
```

For let bindings, the RHS will appear indented, on a new line, if it covers multiple lines:

```nickel
let single-line = fun x => x

let multi-line =
  fun x => x
```

Likewise for function definitions:

```nickel
let multi-line-function =
  fun x =>
    x
```

Miscellaneous stuff:
* Allow blank lines between record fields.
* Designate builtins as leaves so their surrounding `%` characters don't get parsed as mod operators.
* Began to tidy up the query file, with comments and explanations of formatting choices.