### PR TITLE
Introduce conditional predicates to reduce number of directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,24 +557,6 @@ Remove the matched node from the output.
 )
 ```
 
-### `@singleline_delete`
-
-Remove the matched node from the output, online if the context is single-line.
-
-#### Example
-
-```scheme
-; Delete the optional "|" before the first match case
-; if the context is single-line
-(
-  (match_case)? @do_nothing
-  .
-  "|" @singleline_delete
-  .
-  (match_case)
-)
-```
-
 ### `@do_nothing`
 
 If any of the captures in a query match are `@do_nothing`, then the
@@ -860,42 +842,62 @@ This Tree-sitter query:
 
 ...while the single-lined `(1, 2, 3)` is kept as is.
 
-### `@singleline_scoped_delete`
+### Testing context with predicates
 
-Remove the matched node from the output, only if the associated custom scope is single-line. The scope must be specified with the predicate `#scope_id!`.
+Sometimes, similarly to what happens with softlines, we want a query to match only if the context is single-line, or multi-line. Topiary has several predicates that achieve this result.
+
+### `#single_line_only!` / `#multi_line_only!`
+
+These predicates allow the query to trigger only if the matched nodes are in a single-line (resp. multi-line) context.
 
 #### Example
 
 ```scheme
-; Delete the optional "|" before the first match case
-; if the context is single-line
-(function_expression
-  (match_case)? @do_nothing
+; Allow (and enforce) the optional "|" before the first match case
+; in OCaml if and only if the context is multi-line
+(
+  "with"
   .
-  "|" @singleline_scoped_delete
+  "|" @delete
   .
   (match_case)
-  (#scope_id! "function_definition")
+  (#single_line_only!)
+)
+
+(
+  "with"
+  .
+  "|"? @do_nothing
+  .
+  (match_case) @prepend_delimiter
+  (#delimiter! "| ")
+  (#multi_line_only!)
 )
 ```
 
-### `@append_multiline_delimiter` / `@prepend_multiline_delimiter`
+### `#single_line_scope_only!` / `#multi_line_scope_only!`
 
-The matched nodes will have a multi-line-only delimiter appended to
-them. It will be printed if the associated custom scope is multi-line, and omitted otherwise.
-The delimiter must be specified using the predicate `#delimiter!`. The scope must be specified with the predicate `#scope_id!`.
+These predicates allow the query to trigger only if the associated custom scope containing the matched nodes are is single-line (resp. multi-line).
 
 #### Example
 
 ```scheme
-; Add the optional "|" before the first match case
-; only if the context is multi-line
+; Allow (and enforce) the optional "|" before the first match case
+; in function expressions in OCaml if and only if the scope is multi-line
+(function_expression
+  (match_case)? @do_nothing
+  .
+  "|" @delete
+  .
+  (match_case)
+  (#single_line_scope_only! "function_definition")
+)
 (function_expression
   "|"? @do_nothing
   .
-  (match_case) @prepend_scoped_multiline_delimiter
-  (#scope_id! "function_definition")
-  (#delimiter! "| ")
+  (match_case) @prepend_delimiter
+  (#multi_line_scope_only! "function_definition")
+  (#delimiter! "| ") ; sic
 )
 ```
 

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -799,16 +799,16 @@
 (function_expression
   (match_case)? @do_nothing
   .
-  "|" @singleline_scoped_delete
+  "|" @delete
   .
   (match_case)
-  (#scope_id! "function_definition")
+  (#single_line_scope_only! "function_definition")
 )
 (function_expression
   "|"? @do_nothing
   .
-  (match_case) @prepend_scoped_multiline_delimiter
-  (#scope_id! "function_definition")
+  (match_case) @prepend_delimiter
+  (#multi_line_scope_only! "function_definition")
   (#delimiter! "| ") ; sic
 )
 (function_expression

--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -690,9 +690,10 @@
 (
   "with"
   .
-  "|" @singleline_delete
+  "|" @delete
   .
   (match_case)
+  (#single_line_only! )
 )
 
 (
@@ -700,8 +701,9 @@
   .
   "|"? @do_nothing
   .
-  (match_case) @prepend_multiline_delimiter
+  (match_case) @prepend_delimiter
   (#delimiter! "| ") ; sic
+  (#multi_line_only! )
 )
 
 ; Multi-line definitions must have a linebreak after "=" and before "in":

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -145,24 +145,6 @@ impl AtomCollection {
 
                 self.append(space, node, predicates);
             }
-            "append_multiline_delimiter" => self.append(
-                Atom::MultilineOnlyLiteral(requires_delimiter()?.to_string()),
-                node,
-                predicates,
-            ),
-            "append_scoped_multiline_delimiter" => {
-                let id = self.next_id();
-                self.append(
-                    Atom::ScopedConditional {
-                        id,
-                        condition: ScopeCondition::MultiLineOnly,
-                        atom: Box::new(Atom::Literal(requires_delimiter()?.to_string())),
-                        scope_id: requires_scope_id()?.to_string(),
-                    },
-                    node,
-                    predicates,
-                )
-            }
             "append_space" => self.append(Atom::Space, node, predicates),
             "append_antispace" => self.append(Atom::Antispace, node, predicates),
             "append_spaced_softline" => {
@@ -188,24 +170,6 @@ impl AtomCollection {
 
                 self.prepend(space, node, predicates);
             }
-            "prepend_multiline_delimiter" => self.prepend(
-                Atom::MultilineOnlyLiteral(requires_delimiter()?.to_string()),
-                node,
-                predicates,
-            ),
-            "prepend_scoped_multiline_delimiter" => {
-                let id = self.next_id();
-                self.prepend(
-                    Atom::ScopedConditional {
-                        id,
-                        condition: ScopeCondition::MultiLineOnly,
-                        atom: Box::new(Atom::Literal(requires_delimiter()?.to_string())),
-                        scope_id: requires_scope_id()?.to_string(),
-                    },
-                    node,
-                    predicates,
-                )
-            }
             "prepend_space" => self.prepend(Atom::Space, node, predicates),
             "prepend_antispace" => self.prepend(Atom::Antispace, node, predicates),
             "prepend_spaced_softline" => {
@@ -217,34 +181,6 @@ impl AtomCollection {
             "delete" => {
                 self.prepend(Atom::DeleteBegin, node, predicates);
                 self.append(Atom::DeleteEnd, node, predicates)
-            }
-            "singleline_delete" => {
-                self.prepend(Atom::SingleLineDeleteBegin, node, predicates);
-                self.append(Atom::SingleLineDeleteEnd, node, predicates)
-            }
-            "singleline_scoped_delete" => {
-                let id = self.next_id();
-                self.prepend(
-                    Atom::ScopedConditional {
-                        id,
-                        condition: ScopeCondition::SingleLineOnly,
-                        atom: Box::new(Atom::DeleteBegin),
-                        scope_id: requires_scope_id()?.to_string(),
-                    },
-                    node,
-                    predicates,
-                );
-                let id = self.next_id();
-                self.append(
-                    Atom::ScopedConditional {
-                        id,
-                        condition: ScopeCondition::SingleLineOnly,
-                        atom: Box::new(Atom::DeleteEnd),
-                        scope_id: requires_scope_id()?.to_string(),
-                    },
-                    node,
-                    predicates,
-                )
             }
             // Scope manipulation
             "begin_scope" => self.begin_scope_before(node, requires_scope_id()?),
@@ -505,61 +441,6 @@ impl AtomCollection {
                         parent
                     );
                     Some(Atom::Space)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else if let Atom::MultilineOnlyLiteral(literal) = atom {
-            if let Some(parent) = node.parent() {
-                let parent_id = parent.id();
-
-                if self.multi_line_nodes.contains(&parent_id) {
-                    log::debug!(
-                        "Expanding multiline literal {:?} in node {:?} with parent {}: {:?}",
-                        literal,
-                        node,
-                        parent_id,
-                        parent
-                    );
-                    Some(Atom::Literal(literal))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else if let Atom::SingleLineDeleteBegin = atom {
-            if let Some(parent) = node.parent() {
-                let parent_id = parent.id();
-
-                if !self.multi_line_nodes.contains(&parent_id) {
-                    log::debug!(
-                        "Expanding single-line delete begin in node {:?} with parent {}: {:?}",
-                        node,
-                        parent_id,
-                        parent
-                    );
-                    Some(Atom::DeleteBegin)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else if let Atom::SingleLineDeleteEnd = atom {
-            if let Some(parent) = node.parent() {
-                let parent_id = parent.id();
-
-                if !self.multi_line_nodes.contains(&parent_id) {
-                    log::debug!(
-                        "Expanding single-line delete end in node {:?} with parent {}: {:?}",
-                        node,
-                        parent_id,
-                        parent
-                    );
-                    Some(Atom::DeleteEnd)
                 } else {
                     None
                 }

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -65,18 +65,17 @@ impl AtomCollection {
         &mut self,
         name: &str,
         node: &Node,
-        delimiter: Option<&str>,
-        scope_id: Option<&str>,
+        predicates: &QueryPredicates,
     ) -> FormatterResult<()> {
         log::debug!("Resolving {name}");
 
         let requires_delimiter = || {
-            delimiter.ok_or_else(|| {
+            predicates.delimiter.as_deref().ok_or_else(|| {
                 FormatterError::Query(format!("@{name} requires a #delimiter! predicate"), None)
             })
         };
         let requires_scope_id = || {
-            scope_id.ok_or_else(|| {
+            predicates.scope_id.as_deref().ok_or_else(|| {
                 FormatterError::Query(format!("@{name} requires a #scope_id! predicate"), None)
             })
         };
@@ -746,6 +745,13 @@ impl AtomCollection {
         self.counter += 1;
         self.counter
     }
+}
+
+#[derive(Clone, Debug, Default)]
+// A struct to store query predicates that are relevant to Topiary
+pub struct QueryPredicates {
+    pub delimiter: Option<String>,
+    pub scope_id: Option<String>,
 }
 
 fn post_process_internal(new_vec: &mut Vec<Atom>, prev: Atom, next: Atom) {

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -80,6 +80,22 @@ impl AtomCollection {
             })
         };
 
+        let mut is_multi_line = false;
+        if let Some(parent) = node.parent() {
+            let parent_id = parent.id();
+            if self.multi_line_nodes.contains(&parent_id) {
+                is_multi_line = true
+            }
+        }
+        if is_multi_line && predicates.single_line_only {
+            log::debug!("Aborting because context is multi-line and #single_line_only! is set");
+            return Ok(())
+        }
+        if !is_multi_line && predicates.multi_line_only {
+            log::debug!("Aborting because context is single-line and #multi_line_only! is set");
+            return Ok(())
+        }
+
         match name {
             "allow_blank_line_before" => {
                 if self.blank_lines_before.contains(&node.id()) {
@@ -752,6 +768,8 @@ impl AtomCollection {
 pub struct QueryPredicates {
     pub delimiter: Option<String>,
     pub scope_id: Option<String>,
+    pub single_line_only: bool,
+    pub multi_line_only: bool,
 }
 
 fn post_process_internal(new_vec: &mut Vec<Atom>, prev: Atom, next: Atom) {

--- a/topiary/src/lib.rs
+++ b/topiary/src/lib.rs
@@ -61,13 +61,6 @@ pub enum Atom {
     /// Represents a literal string, such as a semicolon. It will be printed only
     /// in multi-line nodes.
     MultilineOnlyLiteral(String),
-    /// Represents a literal string, such as a semicolon. It will be printed only
-    /// if the associated scope is multi-line
-    ScopedMultilineOnlyLiteral {
-        id: usize,
-        literal: String,
-        scope_id: String,
-    },
     /// Represents a softline. It will be turned into a hardline for multi-line
     /// constructs, and either a space or nothing for single-line constructs.
     Softline {
@@ -86,15 +79,6 @@ pub enum Atom {
     /// Represents a segment to be deleted, only if the context is single-line
     SingleLineDeleteBegin,
     SingleLineDeleteEnd,
-    /// Represents a segment to be deleted, only if the associated scope is single-line
-    SingleLineScopedDeleteBegin {
-        id: usize,
-        scope_id: String,
-    },
-    SingleLineScopedDeleteEnd {
-        id: usize,
-        scope_id: String,
-    },
     /// Scoped commands
     // ScopedSoftline works together with the @open_scope and @end_scope query tags.
     // To decide if a scoped softline must be expanded into a hardline, we look at

--- a/topiary/src/lib.rs
+++ b/topiary/src/lib.rs
@@ -107,6 +107,20 @@ pub enum Atom {
         scope_id: String,
         spaced: bool,
     },
+    // Represents an atom that must only be output if the associated scope meets the condition
+    // (single-line or multi-line)
+    ScopedConditional {
+        id: usize,
+        scope_id: String,
+        condition: ScopeCondition,
+        atom: Box<Atom>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ScopeCondition {
+    SingleLineOnly,
+    MultiLineOnly,
 }
 
 /// A convenience wrapper around `std::result::Result<T, FormatterError>`.

--- a/topiary/src/lib.rs
+++ b/topiary/src/lib.rs
@@ -58,9 +58,6 @@ pub enum Atom {
     },
     /// Represents a literal string, such as a semicolon.
     Literal(String),
-    /// Represents a literal string, such as a semicolon. It will be printed only
-    /// in multi-line nodes.
-    MultilineOnlyLiteral(String),
     /// Represents a softline. It will be turned into a hardline for multi-line
     /// constructs, and either a space or nothing for single-line constructs.
     Softline {
@@ -76,11 +73,8 @@ pub enum Atom {
     // it might happen that it contains several leaves.
     DeleteBegin,
     DeleteEnd,
-    /// Represents a segment to be deleted, only if the context is single-line
-    SingleLineDeleteBegin,
-    SingleLineDeleteEnd,
     /// Scoped commands
-    // ScopedSoftline works together with the @open_scope and @end_scope query tags.
+    // ScopedSoftline works together with the @begin_scope and @end_scope query tags.
     // To decide if a scoped softline must be expanded into a hardline, we look at
     // the innermost scope having the corresponding `scope_id`, that encompasses it.
     // We expand the softline if that scope is multi-line.

--- a/topiary/src/tree_sitter.rs
+++ b/topiary/src/tree_sitter.rs
@@ -131,6 +131,9 @@ pub fn apply_query(
         for p in query.general_predicates(m.pattern_index) {
             predicates = handle_predicate(&p, &predicates)?;
         }
+        if predicates.single_line_only && predicates.multi_line_only {
+            log::warn!("Both predicates #single_line_only! and #multi_line_only! have been set: this query won't do anything")
+        }
 
         // If any capture is a do_nothing, then do nothing.
         if m.captures
@@ -244,6 +247,16 @@ fn handle_predicate(
             })?;
         Ok(QueryPredicates {
             scope_id: Some(arg),
+            ..predicates.clone()
+        })
+    } else if let "single_line_only!" = operator {
+        Ok(QueryPredicates {
+            single_line_only: true,
+            ..predicates.clone()
+        })
+    } else if let "multi_line_only!" = operator {
+        Ok(QueryPredicates {
+            multi_line_only: true,
             ..predicates.clone()
         })
     } else {


### PR DESCRIPTION
### Testing context with predicates

Sometimes, similarly to what happens with softlines, we want a query to match only if the context is single-line, or multi-line. This PR introduces several predicates that achieve this result.

### `#single_line_only!` / `#multi_line_only!`

These predicates allow the query to trigger only if the matched nodes are in a single-line (resp. multi-line) context.

#### Example

```scheme
; Allow (and enforce) the optional "|" before the first match case
; in OCaml if and only if the context is multi-line
(
  "with"
  .
  "|" @delete
  .
  (match_case)
  (#single_line_only!)
)

(
  "with"
  .
  "|"? @do_nothing
  .
  (match_case) @prepend_delimiter
  (#delimiter! "| ")
  (#multi_line_only!)
)
```

### `#single_line_scope_only!` / `#multi_line_scope_only!`

These predicates allow the query to trigger only if the associated custom scope containing the matched nodes are is single-line (resp. multi-line).

#### Example

```scheme
; Allow (and enforce) the optional "|" before the first match case
; in function expressions in OCaml if and only if the scope is multi-line
(function_expression
  (match_case)? @do_nothing
  .
  "|" @delete
  .
  (match_case)
  (#single_line_scope_only! "function_definition")
)
(function_expression
  "|"? @do_nothing
  .
  (match_case) @prepend_delimiter
  (#multi_line_scope_only! "function_definition")
  (#delimiter! "| ") ; sic
)
```

This PR uses those new predicates to reduce the number of verbose formatting directives in `ocaml.scm`, and removes deprecated atoms and formatting directives.

Closes #337