### PR TITLE
Support arbitrary indentation (#105)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "tree-sitter-query",
  "tree-sitter-rust",
  "tree-sitter-toml",
+ "unescape",
  "web-tree-sitter-sys",
 ]
 
@@ -1171,6 +1172,12 @@ dependencies = [
  "cc",
  "tree-sitter",
 ]
+
+[[package]]
+name = "unescape"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicode-ident"

--- a/README.md
+++ b/README.md
@@ -292,17 +292,16 @@ this:
 ```scheme
 ; Configuration
 (#language! rust)
-(#indent-level! 4)
+(#indent! "    ")
 ```
 
 The `#language!` pragma must be included in any query file and dictates
 which language to parse. The queries themselves will refer to node types
 that are specific to this language.
 
-The `#indent-level!` pragma is optional and controls how many spaces to
-indent a block whenever `@append_indent_start` or
-`@prepend_indent_start` is processed. If it is omitted, it defaults to
-two spaces.
+The `#indent!` pragma is optional and controls what indentation to use to
+indent a block whenever `@append_indent_start` or `@prepend_indent_start` is
+processed. If it is omitted, it defaults to two spaces.
 
 ### `@allow_blank_line_before`
 

--- a/languages/rust.scm
+++ b/languages/rust.scm
@@ -1,6 +1,6 @@
 ; Configuration
 (#language! rust)
-(#indent-level! 4)
+(#indent! "    ")
 
 ; Sometimes we want to indicate that certain parts of our source text should
 ; not be formatted, but taken as is. We use the leaf capture name to inform the

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -14,8 +14,9 @@ regex = "1.7.1"
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0"
 tree-sitter-facade = { git = "https://github.com/tweag/tree-sitter-facade" }
+unescape = "0.1"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies] 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = "^1.26.0"
 tree-sitter-json = "0.19"
 tree-sitter-rust = "0.20.3"

--- a/topiary/src/lib.rs
+++ b/topiary/src/lib.rs
@@ -173,7 +173,7 @@ pub fn formatter(
 
             // Pretty-print atoms
             log::info!("Pretty-print output");
-            let rendered = pretty::render(&atoms[..], configuration.indent_level)?;
+            let rendered = pretty::render(&atoms[..], &configuration.indent)?;
             let trimmed = trim_whitespace(&rendered);
 
             if !skip_idempotence {

--- a/topiary/src/pretty.rs
+++ b/topiary/src/pretty.rs
@@ -2,30 +2,30 @@ use std::fmt::Write;
 
 use crate::{Atom, FormatterError, FormatterResult};
 
-pub fn render(atoms: &[Atom], indent_offset: usize) -> FormatterResult<String> {
+pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
     let mut buffer = String::new();
-    let mut indent_level = 0;
+    let mut indent_level: usize = 0;
 
     for atom in atoms {
         match atom {
-            Atom::Blankline => write!(buffer, "\n\n{}", " ".repeat(indent_level))?,
+            Atom::Blankline => write!(buffer, "\n\n{}", indent.repeat(indent_level))?,
 
             Atom::Empty => (),
 
-            Atom::Hardline => write!(buffer, "\n{}", " ".repeat(indent_level))?,
+            Atom::Hardline => write!(buffer, "\n{}", indent.repeat(indent_level))?,
 
             Atom::IndentEnd => {
-                if indent_offset > indent_level {
+                if indent_level == 0 {
                     return Err(FormatterError::Query(
                         "Trying to close an unopened indentation block".into(),
                         None,
                     ));
                 }
 
-                indent_level -= indent_offset;
+                indent_level -= 1;
             }
 
-            Atom::IndentStart => indent_level += indent_offset,
+            Atom::IndentStart => indent_level += 1,
 
             Atom::Leaf {
                 content,


### PR DESCRIPTION
Resolves #105 

I was/am not sure about the regular expressions parsing of the arguments. They used to support multiple arguments, but I've reduced that to 1 because I could not reconcile that easily with "   " string arguments.

Escaping is done by an old crate, but more modern alternatives are all GPL licensed. This isn't an issue to us, but could be a problem to future users of our library.