### PR TITLE
Implemented antispaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,26 @@ with space as delimiter.
 ] @append_space
 ```
 
+### `@append_antispace` / `@prepend_antispace`
+
+It is often the case that tokens need to be juxtaposed with spaces,
+except in a few isolated contexts. Rather than writing complicated rules
+that enumerate every exception, an "antispace" can be inserted with
+`@append_antispace` / `@prepend_antispace`; this will destroy any spaces
+(not newlines) from that node, including those added by other formatting
+rules.
+
+#### Example
+
+```scheme
+[
+  ","
+  ";"
+  ":"
+  "."
+] @prepend_antispace
+```
+
 ### `@append_spaced_softline` / `@prepend_spaced_softline`
 
 The matched nodes will have a spaced softline appended or prepended to

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -119,6 +119,7 @@ impl AtomCollection {
                 )
             }
             "append_space" => self.append(Atom::Space, node),
+            "append_antispace" => self.append(Atom::Antispace, node),
             "append_spaced_softline" => self.append(Atom::Softline { spaced: true }, node),
             "prepend_delimiter" => {
                 self.prepend(Atom::Literal(requires_delimiter()?.to_string()), node)
@@ -152,6 +153,7 @@ impl AtomCollection {
                 )
             }
             "prepend_space" => self.prepend(Atom::Space, node),
+            "prepend_antispace" => self.prepend(Atom::Antispace, node),
             "prepend_spaced_softline" => self.prepend(Atom::Softline { spaced: true }, node),
             // Skip over leafs
             "leaf" => {}

--- a/topiary/src/lib.rs
+++ b/topiary/src/lib.rs
@@ -59,10 +59,10 @@ pub enum Atom {
     /// Represents a literal string, such as a semicolon.
     Literal(String),
     /// Represents a literal string, such as a semicolon. It will be printed only
-    // in multi-line nodes.
+    /// in multi-line nodes.
     MultilineOnlyLiteral(String),
     /// Represents a literal string, such as a semicolon. It will be printed only
-    // if the associated scope is multi-line
+    /// if the associated scope is multi-line
     ScopedMultilineOnlyLiteral {
         id: usize,
         literal: String,
@@ -75,6 +75,9 @@ pub enum Atom {
     },
     /// Represents a space. Consecutive spaces are reduced to one before rendering.
     Space,
+    /// Represents the destruction of errant spaces. Adjacent consecutive spaces are
+    /// reduced to zero before rendering.
+    Antispace,
     /// Represents a segment to be deleted.
     // It is a segment, because if one wants to delete a node,
     // it might happen that it contains several leaves.


### PR DESCRIPTION
The PR introduces the concept of "antispaces", that can be inserted into the formatting stream with the `@append_antispace` and `@prepend_antispace` capture names. When an `Antispace` atom is encountered during post-processing, it and any runs of preceding and/or succeeding `Space` or `Antispace` atoms are removed from the stream. This ultimately allows spacing exception rules to be written more easily.

For example, if we define the JSON formatting rules such that _any_ named node is surrounded by spaces, this upsets the spacing around list and pair delimiters. However, we can now fix that easily with an antispace:

```scheme
(#language! json)

(string) @leaf
(_) @append_space @prepend_space

":" @prepend_antispace
"," @prepend_antispace @append_empty_softline

(object
  .
  "{" @append_spaced_softline @append_indent_start
  (_)
  "}" @prepend_spaced_softline @prepend_indent_end
  .
)

(array
  .
  "[" @append_spaced_softline @append_indent_start
  (_)
  "]" @prepend_spaced_softline @prepend_indent_end
  .
)
```

(:bulb: This is not objectively better than the current JSON formatting rules; it's about the same. It's just an example to illustrate the point.)