### PR TITLE
Nickel spacing tweaks

### DIFF
--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -1,7 +1,7 @@
 ; Configuration
 (#language! nickel)
 
-;; General
+;; General Spacing
 
 ; The following nodes in our source text should not be formatted
 [
@@ -43,8 +43,6 @@
     "?"
     "="
     "rec"
-    "{"
-    "}"
     "Array"
     "Dyn"
     "Num"
@@ -74,6 +72,17 @@
     "||"
   ] @prepend_space @append_space
 )
+
+; Don't insert spaces before the following delimiters
+[
+  ","
+  ";"
+  "."
+] @prepend_antispace
+
+; Don't insert spaces immediately inside parentheses
+"(" @append_antispace
+")" @prepend_antispace
 
 ;; Comments
 
@@ -176,6 +185,26 @@
   t1: (applicative) @append_space
 )
 
+;; Records
+
+; We don't want to add spaces/newlines in empty records, so the
+; following query only matches if a named node exists within the record
+(uni_record
+  .
+  "{" @append_spaced_softline @append_indent_start
+  (_)
+  "}" @prepend_indent_end @prepend_spaced_softline
+  .
+)
+
+(uni_record
+  "," @append_spaced_softline
+)
+
+(uni_record
+  ";" @append_spaced_softline
+)
+
 ;; TIDY FROM HERE ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (let_expr
@@ -218,19 +247,6 @@
   (ident) @append_space
   .
   (ident)
-)
-
-(uni_record
-  "{" @append_spaced_softline @append_indent_start
-  "}" @prepend_indent_end @prepend_spaced_softline
-)
-
-(uni_record
-  "," @append_spaced_softline
-)
-
-(uni_record
-  ";" @append_spaced_softline
 )
 
 ; We want the same rule for arrays as for records,

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -28,8 +28,8 @@
     }
   in
   # Compute `7!`
-  let l = my_array_lib.map ( fun x => x + 1) [ 1, 2, 3, 4, 5, 6 ] in
-  my_array_lib.fold ( fun x acc => x * acc) l 1,
+  let l = my_array_lib.map (fun x => x + 1) [ 1, 2, 3, 4, 5, 6 ] in
+  my_array_lib.fold (fun x acc => x * acc) l 1,
 
   fibonacci_fibonacci = let rec fibonacci =
     fun n =>
@@ -47,21 +47,21 @@
 
   merge_main = let server = import "server.ncl" in
   let security = import "security.ncl" in
-  server & security & { firewall.enabled = false } ,
+  server & security & { firewall.enabled = false },
 
   merge_server = {
     server.host.ip = "182.168.1.1",
     server.host.port = 80,
     server.host.name = "hello-world.net",
-  } ,
+  },
 
   merge_security = {
     server.host.options = "TLS",
 
-    firewall.enabled | default = true ,
+    firewall.enabled | default = true,
     firewall.type = "iptables",
     firewall.open_ports = [ 21, 80, 443 ],
-  } ,
+  },
 
   polymorphism_polymorphism =
   # First projection, statically typed
@@ -69,7 +69,7 @@
   # Evaluation function, statically typed
   let ev : forall a b. (a -> b) -> a -> b = fun f x => f x in
   let id : forall a. a -> a = fun x => x in
-  (ev id (fst 5 10) == 5 : Bool ),
+  (ev id (fst 5 10) == 5 : Bool),
 
   simple-contracts_simple-contract-bool =
   # Example of simple custom contract, parametrized by a first argument.
@@ -91,7 +91,7 @@
   # Try passing `false` to `not`, or to use the identity function (replacing `!x`
   # by `x`) to see contract errors appear.
   let not | AlwaysTrue -> AlwaysFalse = fun x => ! x in
-  not true ,
+  not true,
 
   simple-contracts_simple-contract-div =
   # /!\ THIS EXAMPLE IS EXPECTED TO FAIL


### PR DESCRIPTION
* Don't add spaces before `,`, `;` and `.` delimiters[^1]
* Don't add spaces immediately inside parentheses
* Don't surround record opening/closing tokens with spaces
* Don't add spaces/newlines to empty records

[^1]: I've been liberal, here. I don't know if all these delimiters are attested.