### PR TITLE
Remove ensure_final_hardline from post-processing

### DIFF
--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -738,7 +738,6 @@ impl AtomCollection {
             }
         }
         collapse_antispace(&mut new_vec);
-        ensure_final_hardline(&mut new_vec);
         self.atoms = new_vec;
     }
 
@@ -807,13 +806,6 @@ fn collapse_antispace(v: &mut Vec<Atom>) {
             Atom::Space | Atom::Antispace => v.pop(),
             _ => break,
         };
-    }
-}
-
-fn ensure_final_hardline(v: &mut Vec<Atom>) {
-    if let Some(Atom::Hardline) = v.last() {
-    } else {
-        v.push(Atom::Hardline);
     }
 }
 


### PR DESCRIPTION
This PR removes `topiary::atom_collection::ensure_final_hardline`, as it is redundant. The whitespace trimmer (`topiary::lib::trim_whitespace`) -- which happens after post-processing -- will strip the `\n` added by `ensure_final_hardline` and then reinstates it.

https://github.com/tweag/topiary/blob/d9e0a72a60be911cfa5de98d3207a0833fb9b15a/topiary/src/lib.rs#L214-L219