### PR TITLE
Simplify workspace building

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ echo '{"foo":"bar"}' | topiary --language json
 if you have those installed:
 
 ```bash
-echo '{"foo":"bar"}' | cargo run -p topiary-cli -- --language json
+echo '{"foo":"bar"}' | cargo run -- --language json
 echo '{"foo":"bar"}' | nix run . -- --language json
 ```
 

--- a/default.nix
+++ b/default.nix
@@ -45,14 +45,9 @@ let
   craneLibWasm = craneLib.overrideToolchain rustWithWasmTarget;
 in
 {
-  clippy-topiary = craneLib.cargoClippy (commonArgs // {
+  clippy = craneLib.cargoClippy (commonArgs // {
     inherit cargoArtifacts;
-    cargoClippyExtraArgs = "-p topiary -- --deny warnings";
-  });
-
-  clippy-cli = craneLib.cargoClippy (commonArgs // {
-    inherit cargoArtifacts;
-    cargoClippyExtraArgs = "-p topiary-cli -- --deny warnings";
+    cargoClippyExtraArgs = "-- --deny warnings";
   });
 
   clippy-wasm = craneLibWasm.cargoClippy (commonArgs // {
@@ -68,14 +63,7 @@ in
 
   benchmark = craneLib.buildPackage (commonArgs // {
     inherit cargoArtifacts;
-    cargoExtraArgs = "-p topiary";
     cargoTestCommand = "cargo bench --profile release";
-  });
-
-  topiary = craneLib.buildPackage (commonArgs // {
-    inherit cargoArtifacts;
-    pname = "topiary";
-    cargoExtraArgs = "-p topiary";
   });
 
   topiary-cli = craneLib.buildPackage (commonArgs // {

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
           default = topiary-cli;
         };
         checks = with code; {
-          inherit clippy-topiary clippy-cli clippy-wasm fmt topiary topiary-cli topiary-playground audit benchmark;
+          inherit clippy clippy-wasm fmt topiary-cli topiary-playground audit benchmark;
         };
 
         ## For easy use in https://github.com/cachix/pre-commit-hooks.nix

--- a/playground.sh
+++ b/playground.sh
@@ -49,7 +49,7 @@ format() {
     topiary_args+=(--skip-idempotence)
   fi
 
-  cargo run -p topiary-cli --quiet -- "${topiary_args[@]}"
+  cargo run --quiet -- "${topiary_args[@]}"
 }
 
 idempotency() {

--- a/topiary-playground/Cargo.toml
+++ b/topiary-playground/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cfg-if = "1.0.0"
-topiary = { path = "../topiary", default-features = false, features = ["wasm"] }
+topiary = { path = "../topiary" }
 tree-sitter-facade = { git = "https://github.com/tweag/tree-sitter-facade" }
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"

--- a/topiary-playground/src/lib.rs
+++ b/topiary-playground/src/lib.rs
@@ -1,7 +1,11 @@
+#[cfg(target_arch = "wasm32")]
 use topiary::{formatter, Configuration, FormatterResult, Operation};
+#[cfg(target_arch = "wasm32")]
 use tree_sitter_facade::TreeSitter;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
+#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen(js_name = topiaryInit)]
 pub async fn topiary_init() -> Result<(), JsError> {
     cfg_if::cfg_if! {
@@ -13,6 +17,7 @@ pub async fn topiary_init() -> Result<(), JsError> {
     TreeSitter::init().await
 }
 
+#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub async fn format(input: &str, query: &str) -> Result<String, JsError> {
     format_inner(input, query)
@@ -20,11 +25,12 @@ pub async fn format(input: &str, query: &str) -> Result<String, JsError> {
         .map_err(|e| format_error(&e))
 }
 
+#[cfg(target_arch = "wasm32")]
 async fn format_inner(input: &str, query: &str) -> FormatterResult<String> {
     let mut output = Vec::new();
 
     let configuration = Configuration::parse(query)?;
-    let grammars = configuration.language.grammars().await?;
+    let grammars = configuration.language.grammars_wasm().await?;
 
     formatter(
         &mut input.as_bytes(),
@@ -40,6 +46,7 @@ async fn format_inner(input: &str, query: &str) -> FormatterResult<String> {
     Ok(String::from_utf8(output)?)
 }
 
+#[cfg(target_arch = "wasm32")]
 fn format_error(e: &dyn std::error::Error) -> JsError {
     let mut message: String = format!("{e}");
     let mut inner: &dyn std::error::Error = e;

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -4,32 +4,32 @@ description = "Formats input source code in a style defined for that language."
 version = "0.1.0"
 edition = "2021"
 
-[features]
-default = ["tree-sitter"]
-tree-sitter = ["tree-sitter-json", "tree-sitter-rust", "tree-sitter-toml", "tree-sitter-bash", "tree-sitter-nickel", "tree-sitter-query", "tree-sitter-ocaml", ]
-wasm = ["futures", "tokio/rt", "web-tree-sitter"]
-
 [dependencies]
 # For now we just load the tree-sitter language parsers statically.
 # Eventually we will want to dynamically load them, like Helix does.
-futures = { version = "0.3.27", optional = true }
 itertools = "0.10"
 log = "0.4"
 pretty_assertions = "1.3"
 regex = "1.7.1"
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "^1.26.0", features = ["macros"] }
 tree-sitter-facade = { git = "https://github.com/tweag/tree-sitter-facade" }
-tree-sitter-json = { version = "0.19", optional = true }
-tree-sitter-rust = { version = "0.20.3", optional = true }
-tree-sitter-toml = { version = "0.20.0", optional = true }
-tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", optional = true }
-tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "fc0c53e", optional = true }
-tree-sitter-query = { git = "https://github.com/nvim-treesitter/tree-sitter-query", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies] 
+tokio = "^1.26.0"
+tree-sitter-json = "0.19"
+tree-sitter-rust = "0.20.3"
+tree-sitter-toml = "0.20.0"
+tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash" }
+tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "fc0c53e" }
+tree-sitter-query = { git = "https://github.com/nvim-treesitter/tree-sitter-query" }
 # Needs a version > 0.19
-tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml", optional = true }
-web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", package = "web-tree-sitter-sys", default-features = false, features = ["web"], optional = true }
+tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+futures = { version = "0.3.27" }
+tokio = { version = "^1.26.0", features = ["macros", "rt"] }
+web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", package = "web-tree-sitter-sys", default-features = false, features = ["web"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features=["async_futures"] }

--- a/topiary/src/language.rs
+++ b/topiary/src/language.rs
@@ -68,7 +68,7 @@ impl Language {
     ///
     /// Note that, currently, all grammars are statically linked. This will change once dynamic linking
     /// is implemented (see Issue #4).
-    #[cfg(feature = "tree-sitter")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub async fn grammars(&self) -> FormatterResult<Vec<tree_sitter_facade::Language>> {
         Ok(match self {
             Language::Bash => vec![tree_sitter_bash::language()],
@@ -89,8 +89,8 @@ impl Language {
         .collect())
     }
 
-    #[cfg(feature = "wasm")]
-    pub async fn grammars(&self) -> FormatterResult<Vec<tree_sitter_facade::Language>> {
+    #[cfg(target_arch = "wasm32")]
+    pub async fn grammars_wasm(&self) -> FormatterResult<Vec<tree_sitter_facade::Language>> {
         use futures::future::join_all;
 
         let language_names = match self {


### PR DESCRIPTION
No longer fails on `cargo build` and `cargo run`. And the latter can now be used to run the CLI, like before.

Simplified the Nix build a little because of this.

Going back to using target_arch rather than features for conditional compilation, in order to be compatible with tree-sitter-facade.
