### PR TITLE
Use borrows where possible

### DIFF
--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -36,9 +36,9 @@ impl AtomCollection {
         specified_leaf_nodes: HashSet<usize>,
     ) -> FormatterResult<AtomCollection> {
         // Detect user specified line breaks
-        let multi_line_nodes = detect_multi_line_nodes(&root);
-        let blank_lines_before = detect_blank_lines_before(&root);
-        let (line_break_before, line_break_after) = detect_line_break_before_and_after(&root);
+        let multi_line_nodes = detect_multi_line_nodes(root);
+        let blank_lines_before = detect_blank_lines_before(root);
+        let (line_break_before, line_break_after) = detect_line_break_before_and_after(root);
 
         let mut atoms = AtomCollection {
             atoms: Vec::new(),
@@ -321,7 +321,7 @@ impl AtomCollection {
                 single_line_no_indent: false,
             });
             // Mark all sub-nodes as having this node as a "leaf parent"
-            self.mark_leaf_parent(&node, node.id())
+            self.mark_leaf_parent(node, node.id())
         } else {
             for child in node.children(&mut node.walk()) {
                 self.collect_leafs_inner(&child, source, &parent_ids, level + 1)?;

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -31,7 +31,7 @@ pub struct AtomCollection {
 impl AtomCollection {
     /// Use this to create an initial AtomCollection
     pub fn collect_leafs(
-        root: Node,
+        root: &Node,
         source: &[u8],
         specified_leaf_nodes: HashSet<usize>,
     ) -> FormatterResult<AtomCollection> {
@@ -299,7 +299,7 @@ impl AtomCollection {
 
     fn collect_leafs_inner(
         &mut self,
-        node: Node,
+        node: &Node,
         source: &[u8],
         parent_ids: &[usize],
         level: usize,
@@ -324,7 +324,7 @@ impl AtomCollection {
             self.mark_leaf_parent(&node, node.id())
         } else {
             for child in node.children(&mut node.walk()) {
-                self.collect_leafs_inner(child, source, &parent_ids, level + 1)?;
+                self.collect_leafs_inner(&child, source, &parent_ids, level + 1)?;
             }
         }
 
@@ -668,7 +668,7 @@ fn post_process_internal(new_vec: &mut Vec<Atom>, prev: Atom, next: Atom) {
             match next {
                 // And the next one is also a space/line
                 Atom::Space | Atom::Hardline | Atom::Blankline => {
-                    if is_dominant(next.clone(), prev) {
+                    if is_dominant(&next, &prev) {
                         new_vec.pop();
                         new_vec.push(next);
                     }
@@ -709,11 +709,11 @@ fn collapse_antispace(v: &mut Vec<Atom>) {
 
 // This function is only expected to take spaces and newlines as argument.
 // It defines the order Blankline > Hardline > Space.
-fn is_dominant(next: Atom, prev: Atom) -> bool {
+fn is_dominant(next: &Atom, prev: &Atom) -> bool {
     match next {
         Atom::Space => false,
-        Atom::Hardline => prev == Atom::Space,
-        Atom::Blankline => prev != Atom::Blankline,
+        Atom::Hardline => *prev == Atom::Space,
+        Atom::Blankline => *prev != Atom::Blankline,
         _ => panic!("Unexpected character in is_dominant"),
     }
 }

--- a/topiary/src/tree_sitter.rs
+++ b/topiary/src/tree_sitter.rs
@@ -211,7 +211,7 @@ fn check_for_error_nodes(node: &Node) -> FormatterResult<()> {
     Ok(())
 }
 
-fn collect_leaf_ids(matches: &Vec<LocalQueryMatch>, capture_names: &[String]) -> HashSet<usize> {
+fn collect_leaf_ids(matches: &[LocalQueryMatch], capture_names: &[String]) -> HashSet<usize> {
     let mut ids = HashSet::new();
 
     for m in matches {

--- a/topiary/src/tree_sitter.rs
+++ b/topiary/src/tree_sitter.rs
@@ -110,7 +110,7 @@ pub fn apply_query(
     let specified_leaf_nodes: HashSet<usize> = collect_leaf_ids(&matches, &capture_names);
 
     // The Flattening: collects all terminal nodes of the tree-sitter tree in a Vec
-    let mut atoms = AtomCollection::collect_leafs(root, source, specified_leaf_nodes)?;
+    let mut atoms = AtomCollection::collect_leafs(&root, source, specified_leaf_nodes)?;
 
     log::debug!("List of atoms before formatting: {atoms:?}");
 
@@ -177,7 +177,7 @@ pub fn parse<'a>(
                 .ok_or_else(|| FormatterError::Internal("Could not parse input".into(), None))?;
 
             // Fail parsing if we don't get a complete syntax tree.
-            check_for_error_nodes(tree.root_node())?;
+            check_for_error_nodes(&tree.root_node())?;
 
             Ok((tree, grammar))
         })
@@ -190,7 +190,7 @@ pub fn parse<'a>(
         )
 }
 
-fn check_for_error_nodes(node: Node) -> FormatterResult<()> {
+fn check_for_error_nodes(node: &Node) -> FormatterResult<()> {
     if node.kind() == "ERROR" {
         let start = node.start_position();
         let end = node.end_position();
@@ -205,7 +205,7 @@ fn check_for_error_nodes(node: Node) -> FormatterResult<()> {
     }
 
     for child in node.children(&mut node.walk()) {
-        check_for_error_nodes(child)?;
+        check_for_error_nodes(&child)?;
     }
 
     Ok(())


### PR DESCRIPTION
Using borrows where possible is less restrictive, and allows for less cloning of data.