### PR TITLE
Use Rc<Atom>

### DIFF
--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
-    ops::Deref,
     rc::Rc,
 };
 
@@ -12,7 +11,6 @@ use crate::{Atom, FormatterError, FormatterResult, ScopeCondition};
 #[derive(Debug)]
 pub struct AtomCollection {
     atoms: Vec<Rc<Atom>>,
-    post_processed: Vec<Rc<Atom>>,
     prepend: HashMap<usize, Vec<Rc<Atom>>>,
     append: HashMap<usize, Vec<Rc<Atom>>>,
     specified_leaf_nodes: HashSet<usize>,
@@ -45,7 +43,6 @@ impl<'a> AtomCollection {
 
         let mut atoms = AtomCollection {
             atoms: Vec::new(),
-            post_processed: Vec::new(),
             prepend: HashMap::new(),
             append: HashMap::new(),
             specified_leaf_nodes,
@@ -83,7 +80,7 @@ impl<'a> AtomCollection {
                 atom,
             })
         } else {
-            atom.clone()
+            atom
         }
     }
 
@@ -452,7 +449,7 @@ impl<'a> AtomCollection {
                 None
             }
         } else {
-            Some(atom.clone())
+            Some(atom)
         }
     }
 
@@ -616,7 +613,7 @@ impl<'a> AtomCollection {
         let mut new_vec: Vec<Rc<Atom>> = Vec::new();
         for next in &self.atoms {
             if let Some(prev) = new_vec.last().cloned() {
-                post_process_internal(&mut new_vec, prev.clone(), next.clone());
+                post_process_internal(&mut new_vec, prev, next.clone());
             } else {
                 // If the new vector is still empty,
                 // we skip all the spaces and newlines

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -29,7 +29,7 @@ pub struct AtomCollection {
     counter: usize,
 }
 
-impl<'a> AtomCollection {
+impl AtomCollection {
     /// Use this to create an initial AtomCollection
     pub fn collect_leafs(
         root: &Node,

--- a/topiary/src/error.rs
+++ b/topiary/src/error.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt, io, path::PathBuf, str, string};
+use std::{error::Error, fmt, io, ops::Deref, path::PathBuf, str, string};
 
 /// The various errors the formatter may return.
 #[derive(Debug)]
@@ -101,7 +101,7 @@ impl Error for FormatterError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             Self::Idempotence => None,
-            Self::Internal(_, source) => source.as_ref().map(|e| &**e),
+            Self::Internal(_, source) => source.as_ref().map(|e| e.deref()),
             Self::Parsing { .. } => None,
             Self::Query(_, source) => source.as_ref().map(|e| e as &dyn Error),
             Self::LanguageDetection(_, _) => None,

--- a/topiary/src/lib.rs
+++ b/topiary/src/lib.rs
@@ -12,7 +12,7 @@
 
 use itertools::Itertools;
 use pretty_assertions::StrComparison;
-use std::io;
+use std::{io, rc::Rc};
 
 pub use crate::{
     configuration::Configuration,
@@ -91,7 +91,7 @@ pub enum Atom {
         id: usize,
         scope_id: String,
         condition: ScopeCondition,
-        atom: Box<Atom>,
+        atom: Rc<Atom>,
     },
 }
 

--- a/topiary/src/pretty.rs
+++ b/topiary/src/pretty.rs
@@ -1,13 +1,13 @@
-use std::fmt::Write;
+use std::{borrow::Cow, fmt::Write, ops::Deref, rc::Rc};
 
 use crate::{Atom, FormatterError, FormatterResult};
 
-pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
+pub fn render<'a>(atoms: &[Rc<Atom>], indent: &str) -> FormatterResult<String> {
     let mut buffer = String::new();
     let mut indent_level: usize = 0;
 
     for atom in atoms {
-        match atom {
+        match atom.deref() {
             Atom::Blankline => write!(buffer, "\n\n{}", indent.repeat(indent_level))?,
 
             Atom::Empty => (),

--- a/topiary/src/pretty.rs
+++ b/topiary/src/pretty.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Write, ops::Deref, rc::Rc};
+use std::{fmt::Write, ops::Deref, rc::Rc};
 
 use crate::{Atom, FormatterError, FormatterResult};
 

--- a/topiary/src/pretty.rs
+++ b/topiary/src/pretty.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write, ops::Deref, rc::Rc};
 
 use crate::{Atom, FormatterError, FormatterResult};
 
-pub fn render<'a>(atoms: &[Rc<Atom>], indent: &str) -> FormatterResult<String> {
+pub fn render(atoms: &[Rc<Atom>], indent: &str) -> FormatterResult<String> {
     let mut buffer = String::new();
     let mut indent_level: usize = 0;
 

--- a/topiary/src/tree_sitter.rs
+++ b/topiary/src/tree_sitter.rs
@@ -80,7 +80,7 @@ struct LocalQueryMatch<'a> {
     captures: Vec<QueryCapture<'a>>,
 }
 
-pub fn apply_query(
+pub fn apply_query<'a>(
     input_content: &str,
     query_content: &str,
     grammars: &[tree_sitter_facade::Language],

--- a/topiary/src/tree_sitter.rs
+++ b/topiary/src/tree_sitter.rs
@@ -80,7 +80,7 @@ struct LocalQueryMatch<'a> {
     captures: Vec<QueryCapture<'a>>,
 }
 
-pub fn apply_query<'a>(
+pub fn apply_query(
     input_content: &str,
     query_content: &str,
     grammars: &[tree_sitter_facade::Language],


### PR DESCRIPTION
This PR changes `Vec<Atom>` to `Vec<Rc<Atom>>`. Why?

We were operating with atoms directly. Since they cannot be moved out of their atom collection, this meant they sometimes had to be cloned. We should be operating with references instead. But this introduces lifetime issues. Atoms reference themselves (through `ScopedConditional`), and needed a lifetime same as that of the atom collection, which is essentially static. The post-processing function tries to create a new vector of atoms, and then assign that to be the new atom collection. But that doesn't work, because the new vector elements are references to the old vector.

We could have introduced a new set of atoms, solely for the ownership, and then let all atom collections during processing reference that. But that would leak memory slightly (not a big problem in our scenario, admittedly) unless we added some manual memory management. To fix that we could have a set of `Rc<Atom>` instead. But if we do that, we don't really need the new set. We can just let our current atom collection hold `Rc<Atom>`.

So that's what this PR is doing.

The ergonomics of this solution are very nice. No lifetime issues to ponder. Almost felt like cheating!

What about performance?

It is essentially unchanged. Actually, just slightly improved.