### PR TITLE
Nickel: Open an indent block between multi-line parentheses

### DIFF
--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -86,11 +86,22 @@
   ";"
 ] @prepend_antispace
 
+; Create a scope between parentheses such that, if their contents are
+; multi-line, we start an indentation block on a new line
+(
+  (#scope_id! "parens")
+  "(" @begin_scope
+  ")" @end_scope
+)
+
 ; Don't insert spaces immediately inside parentheses
 ; WARNING Using parentheses in string interpolation will manifest the
 ; bug documented in Issue #395
-"(" @append_antispace
-")" @prepend_antispace
+(
+  (#scope_id! "parens")
+  "(" @append_empty_scoped_softline @append_indent_start @append_antispace
+  ")" @prepend_antispace @prepend_indent_end @prepend_empty_scoped_softline
+)
 
 ; Don't insert spaces between infix operators and their operand
 (infix_expr

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -86,21 +86,15 @@
   ";"
 ] @prepend_antispace
 
-; Create a scope between parentheses such that, if their contents are
-; multi-line, we start an indentation block on a new line
-(
-  (#scope_id! "parens")
-  "(" @begin_scope
-  ")" @end_scope
-)
-
-; Don't insert spaces immediately inside parentheses
+; Don't insert spaces immediately inside parentheses. In a multi-line
+; context, start an indentation block
 ; WARNING Using parentheses in string interpolation will manifest the
 ; bug documented in Issue #395
-(
-  (#scope_id! "parens")
-  "(" @append_empty_scoped_softline @append_indent_start @append_antispace
-  ")" @prepend_antispace @prepend_indent_end @prepend_empty_scoped_softline
+(atom
+  .
+  "(" @append_empty_softline @append_indent_start @append_antispace
+  ")" @prepend_antispace @prepend_indent_end @prepend_empty_softline
+  .
 )
 
 ; Don't insert spaces between infix operators and their operand

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -1374,25 +1374,29 @@
       # preserved.
       let field_diff =
         fun left right =>
-          array.fold_left (fun acc field =>
-            if %has_field% field right then
-              acc
-            else
-              %record_insert% field acc (left."%{field}")) (%record_empty_with_tail% left) (%fields% left)
+          array.fold_left (
+            fun acc field =>
+              if %has_field% field right then
+                acc
+              else
+                %record_insert% field acc (left."%{field}")
+          ) (%record_empty_with_tail% left) (%fields% left)
       in
       let contracts_not_in_value = field_diff field_contracts value in
       let missing_fields = %fields% contracts_not_in_value in
       if %length% missing_fields == 0 then
         let tail_fields = field_diff value field_contracts in
         let fields_with_contracts =
-          array.fold_left (fun acc field =>
-            if %has_field% field field_contracts then
-              let contract = field_contracts."%{field}" in
-              let label = %go_field% field label in
-              let val = value."%{field}" in
-              %record_insert% field acc (%assume% contract label val)
-            else
-              acc) {} (%fields% value)
+          array.fold_left (
+            fun acc field =>
+              if %has_field% field field_contracts then
+                let contract = field_contracts."%{field}" in
+                let label = %go_field% field label in
+                let val = value."%{field}" in
+                %record_insert% field acc (%assume% contract label val)
+              else
+                acc
+          ) {} (%fields% value)
         in
         tail_contract fields_with_contracts label tail_fields
       else
@@ -1975,13 +1979,15 @@
           error
       ```
       "%
-      = contract.from_predicate (fun value =>
-        let type = builtin.typeof value in
-        value == null
-        || type == `Number
-        || type == `Bool
-        || type == `String
-        || type == `Enum),
+      = contract.from_predicate (
+        fun value =>
+          let type = builtin.typeof value in
+          value == null
+          || type == `Number
+          || type == `Bool
+          || type == `String
+          || type == `Enum
+      ),
 
     NonEmpty
       | doc m%"


### PR DESCRIPTION
This PR makes a small tweak to the formatting of parentheses. Namely, if their contents are multi-line, then that starts an indentation block on a new-line.