### PR TITLE
Fix pre-commit-hook settings and add a flake check for them

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,10 @@
         checks = {
           inherit (code) clippy clippy-wasm fmt topiary-lib topiary-cli topiary-playground audit benchmark;
 
-          ## Check that the `lib.pre-commit-hook` output builds correctly.
+          ## Check that the `lib.pre-commit-hook` output builds/evaluates
+          ## correctly. `deepSeq e1 e2` evaluates `e1` strictly in depth before
+          ## returning `e2`. We use this trick because checks need to be
+          ## derivations, which `lib.pre-commit-hook` is not.
           pre-commit-hook = builtins.deepSeq self.lib.${system}.pre-commit-hook pkgs.hello;
         };
 
@@ -80,4 +83,3 @@
       }
     );
 }
-

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
                 name = "topiary-inplace";
                 text = ''
                   for FILE; do
-                    if ${code.app}/bin/topiary --in-place --input-file "$FILE"; then
+                    if ${code.topiary-cli}/bin/topiary --in-place --input-file "$FILE"; then
                       continue
                     else
                       EXIT=$?

--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,12 @@
           inherit topiary-playground;
           default = topiary-cli;
         };
-        checks = with code; {
-          inherit clippy clippy-wasm fmt topiary-lib topiary-cli topiary-playground audit benchmark;
+
+        checks = {
+          inherit (code) clippy clippy-wasm fmt topiary-lib topiary-cli topiary-playground audit benchmark;
+
+          ## Check that the `lib.pre-commit-hook` output builds correctly.
+          pre-commit-hook = builtins.deepSeq self.lib.${system}.pre-commit-hook pkgs.hello;
         };
 
         ## For easy use in https://github.com/cachix/pre-commit-hooks.nix


### PR DESCRIPTION
closes https://github.com/tweag/topiary/issues/405

This PR:

- fixes the bug described in #405 
- adds a flake check to avoid future similar breakages.

As an evidence that this works, I will push twice, once without the fix and once with it. The CI should complain about the first commit, and be happy with the second.