### PR TITLE
Skip over zero-byte nodes

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -679,7 +679,7 @@
   "|" @delete
   .
   (match_case)
-  (#single_line_only! )
+  (#single_line_only!)
 )
 
 (
@@ -689,7 +689,7 @@
   .
   (match_case) @prepend_delimiter
   (#delimiter! "| ") ; sic
-  (#multi_line_only! )
+  (#multi_line_only!)
 )
 
 ; Multi-line definitions must have a linebreak after "=" and before "in":

--- a/languages/tree-sitter-query.scm
+++ b/languages/tree-sitter-query.scm
@@ -26,7 +26,6 @@
     (grouping)
     (named_node)
     (parameters)
-    (predicate_type)
     (quantifier)
     ":"
     "."
@@ -41,7 +40,6 @@
     (capture)
     (grouping)
     (named_node)
-    (parameters)
     "."
     "("
     "["
@@ -50,6 +48,13 @@
 )
 (anonymous_node
   (capture) @prepend_space
+)
+
+; The grammar always includes a (parameters) child node under
+; (predicate), even when there are none. Topiary will deal with the
+; zero-byte nodes, so we just need to set the spacing correctly.
+(predicate
+  (parameters) @prepend_space
 )
 
 ; Line breaks and indentation in multi-line lists and nodes

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -327,7 +327,9 @@ impl AtomCollection {
             node.is_named()
         );
 
-        if node.child_count() == 0 || self.specified_leaf_nodes.contains(&node.id()) {
+        if node.end_byte() == node.start_byte() {
+            log::warn!("Skipping zero-byte node: {node:?}");
+        } else if node.child_count() == 0 || self.specified_leaf_nodes.contains(&node.id()) {
             self.atoms.push(Atom::Leaf {
                 content: String::from(node.utf8_text(source)?),
                 id,


### PR DESCRIPTION
This PR checks the byte-width of a node, when constructing the atom collection, to skip zero-width nodes. Along with a slight tweak to the Tree-Sitter Query formatting rules, this allows us to format parameter-less predicates without an undesired space.

(n.b., It would have been nicer to filter out zero-width nodes during the parse, but Tree-Sitter doesn't expose an API to clip nodes from the tree directly.)

Resolves #383