### PR TITLE
Use info logging, instead of warn, for zero-width nodes

### DIFF
--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -328,7 +328,7 @@ impl AtomCollection {
         );
 
         if node.end_byte() == node.start_byte() {
-            log::warn!("Skipping zero-byte node: {node:?}");
+            log::info!("Skipping zero-byte node: {node:?}");
         } else if node.child_count() == 0 || self.specified_leaf_nodes.contains(&node.id()) {
             self.atoms.push(Atom::Leaf {
                 content: String::from(node.utf8_text(source)?),


### PR DESCRIPTION
Per https://github.com/tweag/topiary/pull/410#pullrequestreview-1369233669