### PR TITLE
Rewrite detect_line_breaks_inner

### DIFF
--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -808,27 +808,24 @@ pub fn detect_line_breaks_inner(
     dfs_nodes
         .iter()
         .zip(dfs_nodes[1..].iter())
-        .filter(|(alpha, omega)| {
+        .filter_map(|(alpha, omega)| {
             let last = alpha.end_position().row();
             let next = omega.start_position().row();
 
-            if next < last + minimum_line_breaks {
-                return false;
+            if next >= last + minimum_line_breaks {
+                log::debug!(
+                    "There are at least {} line breaks between {:?} and {:?}",
+                    minimum_line_breaks,
+                    alpha.id(),
+                    omega.id()
+                );
+
+                // We only need the node IDs and, to preserve the API,
+                // flip the output to ("before", "after") sets.
+                return Some((omega.id(), alpha.id()));
             }
 
-            log::debug!(
-                "There are at least {} line breaks between {:?} and {:?}",
-                minimum_line_breaks,
-                alpha.id(),
-                omega.id()
-            );
-
-            true
-        })
-        .map(|(alpha, omega)| {
-            // We only need the node IDs and, to preserve the API,
-            // flip the output to ("before", "after") sets.
-            (omega.id(), alpha.id())
+            None
         })
         .unzip()
 }

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -773,29 +773,29 @@ fn detect_multi_line_nodes(node: &Node) -> HashSet<usize> {
 }
 
 fn detect_blank_lines_before(node: &Node) -> HashSet<usize> {
-    detect_line_breaks_inner(node, 2, None).0
+    detect_line_breaks_inner(node, 2, None, None).0
 }
 
 fn detect_line_break_before_and_after(node: &Node) -> (HashSet<usize>, HashSet<usize>) {
-    let result = detect_line_breaks_inner(node, 1, None);
+    let result = detect_line_breaks_inner(node, 1, None, None);
     (result.0, result.1)
 }
 
 // TODO: This is taking a bit too much time, and would benefit from an
 // optimization.
 // TODO 2: The whole function is a mess now, and should be rewritten.
-fn detect_line_breaks_inner<'tree>(
-    node: &'tree Node<'tree>,
+fn detect_line_breaks_inner(
+    node: &Node,
     minimum_line_breaks: u32,
-    previous_node: Option<&'tree Node<'tree>>,
-) -> (HashSet<usize>, HashSet<usize>, Option<&'tree Node<'tree>>) {
+
+    // TODO: Replace these with just previous_node: Option<&Node>
+    previous_node_id: Option<usize>,
+    previous_end: Option<u32>,
+) -> (HashSet<usize>, HashSet<usize>, Option<usize>, Option<u32>) {
     let mut nodes_with_breaks_before = HashSet::new();
     let mut nodes_with_breaks_after = HashSet::new();
 
-    //if let (Some(previous_node_id), Some(previous_end)) = (previous_node_id, previous_end) {
-    if let Some(previous_node) = previous_node {
-        let previous_node_id = previous_node.id();
-        let previous_end = previous_node.end_position().row();
+    if let (Some(previous_node_id), Some(previous_end)) = (previous_node_id, previous_end) {
         let current_start = node.start_position().row();
 
         if current_start >= previous_end + minimum_line_breaks {
@@ -811,13 +811,15 @@ fn detect_line_breaks_inner<'tree>(
         }
     }
 
-    let mut previous_node = Some(node);
+    let mut previous_node_id = Some(node.id());
+    let mut previous_end = Some(node.end_position().row());
 
     for child in node.children(&mut node.walk()) {
-        let (before, after, previous) =
-            detect_line_breaks_inner(&child, minimum_line_breaks, previous_node);
+        let (before, after, node_id, end) =
+            detect_line_breaks_inner(&child, minimum_line_breaks, previous_node_id, previous_end);
 
-        previous_node = previous;
+        previous_node_id = node_id;
+        previous_end = end;
         nodes_with_breaks_before.extend(before);
         nodes_with_breaks_after.extend(after);
     }
@@ -825,7 +827,8 @@ fn detect_line_breaks_inner<'tree>(
     (
         nodes_with_breaks_before,
         nodes_with_breaks_after,
-        previous_node,
+        previous_node_id,
+        previous_end,
     )
 }
 


### PR DESCRIPTION
Resolves #346

Note: The flattening of the syntax tree can be factored out, to avoid having to do it twice (for single line breaks and blank lines). I will do this refactor in a separate PR.