### PR TITLE
Bump prettydiff version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,8 +895,9 @@ dependencies = [
 
 [[package]]
 name = "prettydiff"
-version = "0.6.3"
-source = "git+https://github.com/nbacquey/prettydiff?branch=format_with_context#02dcef5d2e61f8b8062f46fb8f9d9bed4a76e536"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ff1fec61082821f8236cf6c0c14e8172b62ce8a72a0eedc30d3b247bb68dc11"
 dependencies = [
  "ansi_term",
  "pad",

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 itertools = "0.10"
 log = "0.4"
 pretty_assertions = "1.3"
-prettydiff = { git = "https://github.com/nbacquey/prettydiff", branch = "format_with_context"}
+prettydiff = "0.6.4"
 regex = "1.7.1"
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Following the merge of my fix in `master` in https://github.com/romankoblov/prettydiff, we no longer need to tag it explicitly.