### PR TITLE
Expand on TOPIARY_LANGUAGE_DIR in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,18 @@ This won't work if you are running Topiary from another directory than this
 repository. In order to use Topiary without restriction, **you must set the
 environment variable `TOPIARY_LANGUAGE_DIR` to point to the directory where
 Topiary's language query files (`.scm`) are located**. By default, you should
-set it to `<local path of the topiary repository>/languages`:
+set it to `<local path of the topiary repository>/languages`, for example:
 
 ```console
 export TOPIARY_LANGUAGE_DIR=/home/me/tools/topiary/languages
 topiary -i -f ./projects/helloworld/hello.ml
 ```
+
+`TOPIARY_LANGUAGE_DIR` can alternatively be set at build time. Topiary will pick
+the correspond path up and embed it into the `topiary` binary. In that case, you
+don't have to worry about making `TOPIARY_LANGUAGE_DIR` available at run-time
+anymore. When `TOPIARY_LANGUAGE_DIR` has been set at build time and is set at
+run-time as well, the run-time value takes precedence.
 
 See [`CONTRIBUTING.md`][contributing] for details on setting up a
 development environment.

--- a/README.md
+++ b/README.md
@@ -114,10 +114,20 @@ directory:
 cargo install --path topiary-cli
 ```
 
-The `TOPIARY_LANGUAGE_DIR` variable can be set either at build time or
-runtime. It should point to the directory where Topiary's language query
-files (`.scm`) are located. Otherwise, Topiary will fall back to the
-`languages` directory in the current working directory.
+Topiary needs to find the language query files (`.scm`) to function properly. By
+default, `topiary` looks for a `languages` directory in the current working
+directory.
+
+This won't work if you are running Topiary from another directory than this
+repository. In order to use Topiary without restriction, **you must set the
+environment variable `TOPIARY_LANGUAGE_DIR` to point to the directory where
+Topiary's language query files (`.scm`) are located**. By default, you should
+set it to `<local path of the topiary repository>/languages`:
+
+```console
+export TOPIARY_LANGUAGE_DIR=/home/me/tools/topiary/languages
+topiary -i -f ./projects/helloworld/hello.ml
+```
 
 See [`CONTRIBUTING.md`][contributing] for details on setting up a
 development environment.


### PR DESCRIPTION
While installing Topiary, I found the explanation around `TOPIARY_LANGUAGE_DIR` in the README to a be a bit lacking (while it's an important point of the setup in order to make topiary correctly work with e.g. the Nickel language server)

- What this environment variable is and why we need it isn't completely covered. In particular, is it compulsory, and what happens if we don't set it.
- The text doesn't provide a sensible default/an example.
- The README says that `TOPIARY_LANGUAGE_DIR` can be set at build time as well, but I'm not sure what it means. I couldn't find (by grepping) and build script or build-time computation referring to this environment variable. My first understanding of this information would be that if you set it a build time, the topiary build somehow picks it up and hardcodes the corresponding path into the binary. But that doesn't seem to be the case? What does the sentence mean, then?

This PR tries to clarify this aspect of the installation by explaining what this environment variable is, why we need it, what value should you use by default, and remove the part about build time (but feel free to re-introduce it if I didn't understand that correctly, which is very probable).