### PR TITLE
Nickel: Correct formatting of trailing comments

### DIFF
--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -295,15 +295,20 @@
   (applicative) @begin_scope
 ) @end_scope
 
-; NOTE Unlike infix chains, applicatives bind to the left. So rather
-; than creating a single indent block for all operands, we have to
-; create one for each operand independently.
 (
   (#scope_id! "applicative_chain")
   (applicative
-    (applicative) @append_spaced_scoped_softline @append_indent_start
-  ) @append_indent_end
+    (applicative) @append_spaced_scoped_softline
+    (comment)? @do_nothing
+  )
 )
+
+; NOTE Unlike infix chains, applicatives bind to the left. So rather
+; than creating a single indent block for all operands, we have to
+; create one for each operand independently.
+(applicative
+  (applicative) @append_indent_start
+) @append_indent_end
 
 ;; Conditionals
 

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -335,7 +335,7 @@
 ; alternative style is to give the "then" token its own line.)
 (ite_expr
   "then" @append_spaced_softline @append_indent_start
-  t1: (term) @append_indent_end @append_spaced_softline
+  "else" @prepend_indent_end @prepend_spaced_softline
 )
 
 (ite_expr

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -389,4 +389,5 @@
     ","
     ";"
   ] @append_spaced_scoped_softline
+  (comment)? @do_nothing
 )

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -211,6 +211,16 @@
   ) @append_indent_end
 )
 
+; If the RHS starts with a comment, which itself is followed by a hard
+; line, then we apply the normal indent block formatting in a multi-line
+; context (i.e., no exceptions)
+(_
+  "=" @append_indent_start
+  .
+  (comment)
+  (term) @append_indent_end
+)
+
 ; A let expression looks like:
 ;
 ;   let [rec] IDENT = EXPR in EXPR

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -13,7 +13,29 @@
     let x = 1 in
     let y = 2 in
 
-    [x, y]
+    [x, y],
+
+    # Trailing comments
+    {
+      a = # In bound expression
+        123,
+
+      b =
+        if something then
+          foo # After the truthy clause
+        else
+          bar,
+
+      c = [
+        foo, # After items in a compound value
+        bar
+      ],
+
+      d =
+        fn
+          arg # After function arguments
+          arg
+    }
   ],
 
   # Nickel standard library as of af0d5ee

--- a/topiary/tests/samples/input/nickel.ncl
+++ b/topiary/tests/samples/input/nickel.ncl
@@ -13,7 +13,29 @@
     let x = 1 in
     let y = 2 in
 
-    [x, y]
+    [x, y],
+
+    # Trailing comments
+    {
+      a = # In bound expression
+        123,
+
+      b =
+        if something then
+          foo # After the truthy clause
+        else
+          bar,
+
+      c = [
+        foo, # After items in a compound value
+        bar
+      ],
+
+      d =
+        fn
+          arg # After function arguments
+          arg
+    }
   ],
 
   # Nickel standard library as of af0d5ee


### PR DESCRIPTION
This PR corrects the formatting of trailing comments when they appear in the following contexts:

* After the truthy clause in an `if..then..else` expression.
* After the equals sign in a bound expression.
* After the delimiter in a compound value (e.g., list, record, etc.)
* After a the function/argument in a multi-line function call site.

There are some other contexts where trailing comments will be reflowed on to the following line. These have not been addressed because the trade-off with query complexity is too high.

Resolves #425