### PR TITLE
Nickel: Fix line breaking in container values which include a comment

### DIFF
--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -404,5 +404,6 @@
     ","
     ";"
   ] @append_spaced_scoped_softline
+  .
   (comment)? @do_nothing
 )

--- a/topiary-playground/languages_export.ts
+++ b/topiary-playground/languages_export.ts
@@ -1240,6 +1240,7 @@ export xyzzy=$(
     ","
     ";"
   ] @append_spaced_scoped_softline
+  .
   (comment)? @do_nothing
 )
 `,
@@ -1280,7 +1281,15 @@ export xyzzy=$(
         fn
           arg # After function arguments
           arg
-    }
+    },
+
+    # Container containing a comment
+    [
+      1,
+      2,
+      # Comment
+      3
+    ]
   ],
 
   # Nickel standard library as of af0d5ee

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -35,7 +35,15 @@
         fn
           arg # After function arguments
           arg
-    }
+    },
+
+    # Container containing a comment
+    [
+      1,
+      2,
+      # Comment
+      3
+    ]
   ],
 
   # Nickel standard library as of af0d5ee

--- a/topiary/tests/samples/input/nickel.ncl
+++ b/topiary/tests/samples/input/nickel.ncl
@@ -35,7 +35,15 @@
         fn
           arg # After function arguments
           arg
-    }
+    },
+
+    # Container containing a comment
+    [
+      1,
+      2,
+      # Comment
+      3
+    ]
   ],
 
   # Nickel standard library as of af0d5ee


### PR DESCRIPTION
The comment exceptions from #431 were not quite right. This PR fixes the problem.

Resolves #439