### PR TITLE
Update tree-sitter-nickel to new unstable branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-nickel"
 version = "0.0.1"
-source = "git+https://github.com/nickel-lang/tree-sitter-nickel?rev=fc0c53e#fc0c53ec2fda2f259079a1caea4a1ffe99a0d227"
+source = "git+https://github.com/nickel-lang/tree-sitter-nickel?rev=d2ebf1e58971d3afc7858c3199815d0cc9a9a1fc#d2ebf1e58971d3afc7858c3199815d0cc9a9a1fc"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/languages/nickel.scm
+++ b/languages/nickel.scm
@@ -52,9 +52,9 @@
     "rec"
     "Array"
     "Dyn"
-    "Num"
+    "Number"
     "Bool"
-    "Str"
+    "String"
     "->"
     "=>"
     ; Infix operators

--- a/topiary-playground/languages_export.ts
+++ b/topiary-playground/languages_export.ts
@@ -888,9 +888,9 @@ export xyzzy=$(
     "rec"
     "Array"
     "Dyn"
-    "Num"
+    "Number"
     "Bool"
-    "Str"
+    "String"
     "->"
     "=>"
     ; Infix operators
@@ -1308,7 +1308,7 @@ export xyzzy=$(
         \`\`\`
         "%
       = fun label value =>
-        if %typeof% value == \`Array then
+        if %typeof% value == 'Array then
           if %length% value != 0 then
             value
           else
@@ -1683,13 +1683,13 @@ export xyzzy=$(
       = fun f n => %generate% n f,
 
     sort
-      | forall a. (a -> a -> [| \`Lesser, \`Equal, \`Greater |]) -> Array a -> Array a
+      | forall a. (a -> a -> [| 'Lesser, 'Equal, 'Greater |]) -> Array a -> Array a
       | doc m%"
         Sorts the given arrays based on the provided comparison operator.
 
         For example:
         \`\`\`nickel
-          sort (fun x y => if x < y then \`Lesser else if (x == y) then \`Equal else \`Greater) [ 4, 5, 1, 2 ] =>
+          sort (fun x y => if x < y then 'Lesser else if (x == y) then 'Equal else 'Greater) [ 4, 5, 1, 2 ] =>
             [ 1, 2, 4, 5 ]
         \`\`\`
         "%
@@ -1698,7 +1698,7 @@ export xyzzy=$(
         let length = %length% array in
         let first = %elem_at% array 0 in
         let rest = %array_slice% 1 length array in
-        let parts = partition (fun x => (cmp x first == \`Lesser)) rest in
+        let parts = partition (fun x => (cmp x first == 'Lesser)) rest in
         if length <= 1 then
           array
         else
@@ -1945,7 +1945,7 @@ export xyzzy=$(
           false
       \`\`\`
       "%
-      = fun x => %typeof% x == \`Number,
+      = fun x => %typeof% x == 'Number,
 
     is_bool
       : Dyn -> Bool
@@ -1960,7 +1960,7 @@ export xyzzy=$(
           false
       \`\`\`
       "%
-      = fun x => %typeof% x == \`Bool,
+      = fun x => %typeof% x == 'Bool,
 
     is_string
       : Dyn -> Bool
@@ -1975,7 +1975,7 @@ export xyzzy=$(
           true
       \`\`\`
       "%
-      = fun x => %typeof% x == \`String,
+      = fun x => %typeof% x == 'String,
 
     is_enum
       : Dyn -> Bool
@@ -1986,11 +1986,11 @@ export xyzzy=$(
       \`\`\`nickel
         is_enum true =>
           false
-        is_enum \`false =>
+        is_enum 'false =>
           true
       \`\`\`
       "%
-      = fun x => %typeof% x == \`Enum,
+      = fun x => %typeof% x == 'Enum,
 
     is_function
       : Dyn -> Bool
@@ -2005,7 +2005,7 @@ export xyzzy=$(
           false
       \`\`\`
       "%
-      = fun x => %typeof% x == \`Function,
+      = fun x => %typeof% x == 'Function,
 
     is_array
       : Dyn -> Bool
@@ -2020,7 +2020,7 @@ export xyzzy=$(
           false
       \`\`\`
       "%
-      = fun x => %typeof% x == \`Array,
+      = fun x => %typeof% x == 'Array,
 
     is_record
       : Dyn -> Bool
@@ -2035,19 +2035,19 @@ export xyzzy=$(
           true
       \`\`\`
       "%
-      = fun x => %typeof% x == \`Record,
+      = fun x => %typeof% x == 'Record,
 
     typeof
       : Dyn -> [|
-        \`Number,
-        \`Bool,
-        \`String,
-        \`Enum,
-        \`Label,
-        \`Function,
-        \`Array,
-        \`Record,
-        \`Other
+        'Number,
+        'Bool,
+        'String,
+        'Enum,
+        'Label,
+        'Function,
+        'Array,
+        'Record,
+        'Other
       |]
       | doc m%"
       Results in a value representing the type of the typed value.
@@ -2055,9 +2055,9 @@ export xyzzy=$(
       For example:
       \`\`\`nickel
         typeof [ 1, 2 ] =>
-          \`Array
+          'Array
         typeof (fun x => x) =>
-          \`Function
+          'Function
       \`\`\`
       "%
       = fun x => %typeof% x,
@@ -2097,26 +2097,26 @@ export xyzzy=$(
       = fun x y => %deep_seq% x y,
 
     hash
-      : [| \`Md5, \`Sha1, \`Sha256, \`Sha512 |] -> String -> String
+      : [| 'Md5, 'Sha1, 'Sha256, 'Sha512 |] -> String -> String
       | doc m%"
       Hashes the given string provided the desired hash algorithm.
 
       For example:
       \`\`\`nickel
-        hash \`Md5 "hunter2" =>
+        hash 'Md5 "hunter2" =>
           "2ab96390c7dbe3439de74d0c9b0b1767"
       \`\`\`
       "%
       = fun type s => %hash% type s,
 
     serialize
-      : [| \`Json, \`Toml, \`Yaml |] -> Dyn -> String
+      : [| 'Json, 'Toml, 'Yaml |] -> Dyn -> String
       | doc m%"
       Serializes the given value to the desired representation.
 
       For example:
       \`\`\`nickel
-        serialize \`Json { hello = "Hello", world = "World" } =>
+        serialize 'Json { hello = "Hello", world = "World" } =>
           "{
             "hello": "Hello",
             "world": "World"
@@ -2126,13 +2126,13 @@ export xyzzy=$(
       = fun format x => %serialize% format (%force% x),
 
     deserialize
-      : [| \`Json, \`Toml, \`Yaml |] -> String -> Dyn
+      : [| 'Json, 'Toml, 'Yaml |] -> String -> Dyn
       | doc m%"
       Deserializes the given string to a nickel value given the encoding of the string.
 
       For example:
       \`\`\`nickel
-        deserialize \`Json "{ \\"hello\\": \\"Hello\\", \\"world\\": \\"World\\" }"
+        deserialize 'Json "{ \\"hello\\": \\"Hello\\", \\"world\\": \\"World\\" }"
           { hello = "Hello", world = "World" }
       \`\`\`
       "%
@@ -2148,7 +2148,7 @@ export xyzzy=$(
       \`\`\`nickel
       from 42 =>
         "42"
-      from \`Foo =>
+      from 'Foo =>
         "Foo"
       from null =>
         "null"
@@ -2466,10 +2466,10 @@ export xyzzy=$(
           # Examples
 
           \`\`\`nickel
-            (\`foo | Tag) =>
-              \`foo
-            (\`FooBar | Tag) =>
-              \`FooBar
+            ('foo | Tag) =>
+              'foo
+            ('FooBar | Tag) =>
+              'FooBar
             ("tag" | Tag) =>
               error
           \`\`\`
@@ -2491,18 +2491,18 @@ export xyzzy=$(
             let Schema = {
               protocol
                 | enum.TagOrString
-                | [| \`http, \`ftp |],
+                | [| 'http, 'ftp |],
               port
                 | Number,
               method
                 | enum.TagOrString
-                | [| \`GET, \`POST |]
+                | [| 'GET, 'POST |]
             } in
             let serialized =
               m%"
                 {"protocol": "http", "port": 80, "method": "GET"}
               "%
-              |> builtin.deserialize \`Json
+              |> builtin.deserialize 'Json
             in
 
             serialized | Schema
@@ -2511,8 +2511,8 @@ export xyzzy=$(
       = fun label value =>
         %typeof% value
         |> match {
-          \`String => %enum_from_str% value,
-          \`Enum => value,
+          'String => %enum_from_str% value,
+          'Enum => value,
           _ =>
             contract.blame_with_message "expected either a string or an enum tag" label,
         },
@@ -2592,7 +2592,7 @@ export xyzzy=$(
       \`\`\`nickel
       pipe 2 [ (+) 2, (+) 3 ]
         => 7
-      pipe \`World [ string.from, fun s => "Hello, %{s}!" ]
+      pipe 'World [ string.from, fun s => "Hello, %{s}!" ]
         => "Hello, World!"
       \`\`\`
     "%%
@@ -2605,22 +2605,22 @@ export xyzzy=$(
   # Contract implementations
   "$dyn" = fun _label value => value,
 
-  "$num" = fun label value => if %typeof% value == \`Number then value else %blame% label,
+  "$num" = fun label value => if %typeof% value == 'Number then value else %blame% label,
 
-  "$bool" = fun label value => if %typeof% value == \`Bool then value else %blame% label,
+  "$bool" = fun label value => if %typeof% value == 'Bool then value else %blame% label,
 
-  "$string" = fun label value => if %typeof% value == \`String then value else %blame% label,
+  "$string" = fun label value => if %typeof% value == 'String then value else %blame% label,
 
   "$fail" = fun label _value => %blame% label,
 
   "$array" = fun element_contract label value =>
-    if %typeof% value == \`Array then
+    if %typeof% value == 'Array then
       %array_lazy_assume% (%go_array% label) value element_contract
     else
       %blame% label,
 
   "$func" = fun domain codomain label value =>
-    if %typeof% value == \`Function then
+    if %typeof% value == 'Function then
       (fun x => %assume% codomain (%go_codom% label) (value (%assume% domain (%chng_pol% (%go_dom% label)) x)))
     else
       %blame% label,
@@ -2641,7 +2641,7 @@ export xyzzy=$(
     contract (%insert_type_variable% sealing_key polarity label) value,
 
   "$enums" = fun case label value =>
-    if %typeof% value == \`Enum then
+    if %typeof% value == 'Enum then
       %assume% case label value
     else
       %blame% (%label_with_message% "not an enum tag" label),
@@ -2650,7 +2650,7 @@ export xyzzy=$(
     %blame% (%label_with_message% "tag not included in the enum type" label),
 
   "$record" = fun field_contracts tail_contract label value =>
-    if %typeof% value == \`Record then
+    if %typeof% value == 'Record then
       # Returns the sub-record of \`l\` containing only those fields which are not
       # present in \`r\`. If \`l\` has a sealed polymorphic tail then it will be
       # preserved.
@@ -2684,7 +2684,7 @@ export xyzzy=$(
       %blame% (%label_with_message% "not a record" label),
 
   "$dyn_record" = fun contract label value =>
-    if %typeof% value == \`Record then
+    if %typeof% value == 'Record then
       %dictionary_assume% (%go_dict% label) value contract
     else
       %blame% (%label_with_message% "not a record" label),
@@ -2738,7 +2738,7 @@ export xyzzy=$(
       \`\`\`
       "%
       = fun label value =>
-        if %typeof% value == \`Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 then
             value
           else
@@ -2761,7 +2761,7 @@ export xyzzy=$(
       \`\`\`
       "%
       = fun label value =>
-        if %typeof% value == \`Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 && value >= 0 then
             value
           else
@@ -2784,7 +2784,7 @@ export xyzzy=$(
       \`\`\`
       "%
       = fun label value =>
-        if %typeof% value == \`Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 && value > 0 then
             value
           else
@@ -2805,7 +2805,7 @@ export xyzzy=$(
       \`\`\`
       "%
       = fun label value =>
-        if %typeof% value == \`Number then
+        if %typeof% value == 'Number then
           if value != 0 then
             value
           else
@@ -3173,7 +3173,7 @@ export xyzzy=$(
       \`\`\`
       "%
       = fun l s =>
-        if %typeof% s == \`String then
+        if %typeof% s == 'String then
           if s == "true" || s == "True" then
             "true"
           else
@@ -3201,7 +3201,7 @@ export xyzzy=$(
       = let pattern = m%"^[+-]?(\\d+(\\.\\d*)?(e[+-]?\\d+)?|\\.\\d+(e[+-]?\\d+)?)$"% in
       let is_num_literal = %str_is_match% pattern in
       fun l s =>
-        if %typeof% s == \`String then
+        if %typeof% s == 'String then
           if is_num_literal s then
             s
           else
@@ -3226,7 +3226,7 @@ export xyzzy=$(
       \`\`\`
       "%
       = fun l s =>
-        if %typeof% s == \`String then
+        if %typeof% s == 'String then
           if length s == 1 then
             s
           else
@@ -3247,8 +3247,8 @@ export xyzzy=$(
 
       For example:
       \`\`\`nickel
-        (\`Foo | Stringable) =>
-          \`Foo
+        ('Foo | Stringable) =>
+          'Foo
         (false | Stringable) =>
           false
         ("bar" ++ "foo" | Stringable) =>
@@ -3260,10 +3260,10 @@ export xyzzy=$(
       = contract.from_predicate (fun value =>
         let type = builtin.typeof value in
         value == null
-        || type == \`Number
-        || type == \`Bool
-        || type == \`String
-        || type == \`Enum),
+        || type == 'Number
+        || type == 'Bool
+        || type == 'String
+        || type == 'Enum),
 
     NonEmpty
       | doc m%"
@@ -3280,7 +3280,7 @@ export xyzzy=$(
       \`\`\`
       "%
       = fun l s =>
-        if %typeof% s == \`String then
+        if %typeof% s == 'String then
           if %str_length% s > 0 then
             s
           else
@@ -3578,7 +3578,7 @@ export xyzzy=$(
       \`\`\`nickel
       from 42 =>
         "42"
-      from \`Foo =>
+      from 'Foo =>
         "Foo"
       from null =>
         "null"
@@ -3606,7 +3606,7 @@ export xyzzy=$(
 
       For example:
       \`\`\`nickel
-      from_enum \`MyEnum =>
+      from_enum 'MyEnum =>
         "MyEnum"
       \`\`\`
       "%

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -23,7 +23,7 @@ tree-sitter-json = "0.19"
 tree-sitter-rust = "0.20.3"
 tree-sitter-toml = "0.20.0"
 tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash" }
-tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "fc0c53e" }
+tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "d2ebf1e58971d3afc7858c3199815d0cc9a9a1fc" }
 tree-sitter-query = { git = "https://github.com/nvim-treesitter/tree-sitter-query" }
 # Needs a version > 0.19
 tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml" }

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -62,7 +62,7 @@
         ```
         "%
       = fun label value =>
-        if %typeof% value == `Array then
+        if %typeof% value == 'Array then
           if %length% value != 0 then
             value
           else
@@ -434,13 +434,13 @@
       = fun f n => %generate% n f,
 
     sort
-      | forall a. (a -> a -> [| `Lesser, `Equal, `Greater |]) -> Array a -> Array a
+      | forall a. (a -> a -> [| 'Lesser, 'Equal, 'Greater |]) -> Array a -> Array a
       | doc m%"
         Sorts the given arrays based on the provided comparison operator.
 
         For example:
         ```nickel
-          sort (fun x y => if x < y then `Lesser else if (x == y) then `Equal else `Greater) [ 4, 5, 1, 2 ] =>
+          sort (fun x y => if x < y then 'Lesser else if (x == y) then 'Equal else 'Greater) [ 4, 5, 1, 2 ] =>
             [ 1, 2, 4, 5 ]
         ```
         "%
@@ -696,7 +696,7 @@
           false
       ```
       "%
-      = fun x => %typeof% x == `Number,
+      = fun x => %typeof% x == 'Number,
 
     is_bool
       : Dyn -> Bool
@@ -711,7 +711,7 @@
           false
       ```
       "%
-      = fun x => %typeof% x == `Bool,
+      = fun x => %typeof% x == 'Bool,
 
     is_string
       : Dyn -> Bool
@@ -726,7 +726,7 @@
           true
       ```
       "%
-      = fun x => %typeof% x == `String,
+      = fun x => %typeof% x == 'String,
 
     is_enum
       : Dyn -> Bool
@@ -741,7 +741,7 @@
           true
       ```
       "%
-      = fun x => %typeof% x == `Enum,
+      = fun x => %typeof% x == 'Enum,
 
     is_function
       : Dyn -> Bool
@@ -756,7 +756,7 @@
           false
       ```
       "%
-      = fun x => %typeof% x == `Function,
+      = fun x => %typeof% x == 'Function,
 
     is_array
       : Dyn -> Bool
@@ -771,7 +771,7 @@
           false
       ```
       "%
-      = fun x => %typeof% x == `Array,
+      = fun x => %typeof% x == 'Array,
 
     is_record
       : Dyn -> Bool
@@ -786,19 +786,19 @@
           true
       ```
       "%
-      = fun x => %typeof% x == `Record,
+      = fun x => %typeof% x == 'Record,
 
     typeof
       : Dyn -> [|
-        `Number,
-        `Bool,
-        `String,
-        `Enum,
-        `Label,
-        `Function,
-        `Array,
-        `Record,
-        `Other
+        'Number,
+        'Bool,
+        'String,
+        'Enum,
+        'Label,
+        'Function,
+        'Array,
+        'Record,
+        'Other
       |]
       | doc m%"
       Results in a value representing the type of the typed value.
@@ -806,9 +806,9 @@
       For example:
       ```nickel
         typeof [ 1, 2 ] =>
-          `Array
+          'Array
         typeof (fun x => x) =>
-          `Function
+          'Function
       ```
       "%
       = fun x => %typeof% x,
@@ -848,26 +848,26 @@
       = fun x y => %deep_seq% x y,
 
     hash
-      : [| `Md5, `Sha1, `Sha256, `Sha512 |] -> String -> String
+      : [| 'Md5, 'Sha1, 'Sha256, 'Sha512 |] -> String -> String
       | doc m%"
       Hashes the given string provided the desired hash algorithm.
 
       For example:
       ```nickel
-        hash `Md5 "hunter2" =>
+        hash 'Md5 "hunter2" =>
           "2ab96390c7dbe3439de74d0c9b0b1767"
       ```
       "%
       = fun type s => %hash% type s,
 
     serialize
-      : [| `Json, `Toml, `Yaml |] -> Dyn -> String
+      : [| 'Json, 'Toml, 'Yaml |] -> Dyn -> String
       | doc m%"
       Serializes the given value to the desired representation.
 
       For example:
       ```nickel
-        serialize `Json { hello = "Hello", world = "World" } =>
+        serialize 'Json { hello = "Hello", world = "World" } =>
           "{
             "hello": "Hello",
             "world": "World"
@@ -877,13 +877,13 @@
       = fun format x => %serialize% format (%force% x),
 
     deserialize
-      : [| `Json, `Toml, `Yaml |] -> String -> Dyn
+      : [| 'Json, 'Toml, 'Yaml |] -> String -> Dyn
       | doc m%"
       Deserializes the given string to a nickel value given the encoding of the string.
 
       For example:
       ```nickel
-        deserialize `Json "{ \"hello\": \"Hello\", \"world\": \"World\" }"
+        deserialize 'Json "{ \"hello\": \"Hello\", \"world\": \"World\" }"
           { hello = "Hello", world = "World" }
       ```
       "%
@@ -899,7 +899,7 @@
       ```nickel
       from 42 =>
         "42"
-      from `Foo =>
+      from 'Foo =>
         "Foo"
       from null =>
         "null"
@@ -1217,10 +1217,10 @@
           # Examples
 
           ```nickel
-            (`foo | Tag) =>
-              `foo
-            (`FooBar | Tag) =>
-              `FooBar
+            ('foo | Tag) =>
+              'foo
+            ('FooBar | Tag) =>
+              'FooBar
             ("tag" | Tag) =>
               error
           ```
@@ -1242,18 +1242,18 @@
             let Schema = {
               protocol
                 | enum.TagOrString
-                | [| `http, `ftp |],
+                | [| 'http, 'ftp |],
               port
                 | Number,
               method
                 | enum.TagOrString
-                | [| `GET, `POST |]
+                | [| 'GET, 'POST |]
             } in
             let serialized =
               m%"
                 {"protocol": "http", "port": 80, "method": "GET"}
               "%
-              |> builtin.deserialize `Json
+              |> builtin.deserialize 'Json
             in
 
             serialized | Schema
@@ -1262,8 +1262,8 @@
       = fun label value =>
         %typeof% value
         |> match {
-          `String => %enum_from_str% value,
-          `Enum => value,
+          'String => %enum_from_str% value,
+          'Enum => value,
           _ =>
             contract.blame_with_message "expected either a string or an enum tag" label,
         },
@@ -1343,7 +1343,7 @@
       ```nickel
       pipe 2 [ (+) 2, (+) 3 ]
         => 7
-      pipe `World [ string.from, fun s => "Hello, %{s}!" ]
+      pipe 'World [ string.from, fun s => "Hello, %{s}!" ]
         => "Hello, World!"
       ```
     "%%
@@ -1356,22 +1356,22 @@
   # Contract implementations
   "$dyn" = fun _label value => value,
 
-  "$num" = fun label value => if %typeof% value == `Number then value else %blame% label,
+  "$num" = fun label value => if %typeof% value == 'Number then value else %blame% label,
 
-  "$bool" = fun label value => if %typeof% value == `Bool then value else %blame% label,
+  "$bool" = fun label value => if %typeof% value == 'Bool then value else %blame% label,
 
-  "$string" = fun label value => if %typeof% value == `String then value else %blame% label,
+  "$string" = fun label value => if %typeof% value == 'String then value else %blame% label,
 
   "$fail" = fun label _value => %blame% label,
 
   "$array" = fun element_contract label value =>
-    if %typeof% value == `Array then
+    if %typeof% value == 'Array then
       %array_lazy_assume% (%go_array% label) value element_contract
     else
       %blame% label,
 
   "$func" = fun domain codomain label value =>
-    if %typeof% value == `Function then
+    if %typeof% value == 'Function then
       (fun x => %assume% codomain (%go_codom% label) (value (%assume% domain (%chng_pol% (%go_dom% label)) x)))
     else
       %blame% label,
@@ -1392,7 +1392,7 @@
     contract (%insert_type_variable% sealing_key polarity label) value,
 
   "$enums" = fun case label value =>
-    if %typeof% value == `Enum then
+    if %typeof% value == 'Enum then
       %assume% case label value
     else
       %blame% (%label_with_message% "not an enum tag" label),
@@ -1401,7 +1401,7 @@
     %blame% (%label_with_message% "tag not included in the enum type" label),
 
   "$record" = fun field_contracts tail_contract label value =>
-    if %typeof% value == `Record then
+    if %typeof% value == 'Record then
       # Returns the sub-record of `l` containing only those fields which are not
       # present in `r`. If `l` has a sealed polymorphic tail then it will be
       # preserved.
@@ -1444,7 +1444,7 @@
       %blame% (%label_with_message% "not a record" label),
 
   "$dyn_record" = fun contract label value =>
-    if %typeof% value == `Record then
+    if %typeof% value == 'Record then
       %dictionary_assume% (%go_dict% label) value contract
     else
       %blame% (%label_with_message% "not a record" label),
@@ -1498,7 +1498,7 @@
       ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 then
             value
           else
@@ -1521,7 +1521,7 @@
       ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 && value >= 0 then
             value
           else
@@ -1544,7 +1544,7 @@
       ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 && value > 0 then
             value
           else
@@ -1565,7 +1565,7 @@
       ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value != 0 then
             value
           else
@@ -1933,7 +1933,7 @@
       ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if s == "true" || s == "True" then
             "true"
           else if s == "false" || s == "False" then
@@ -1961,7 +1961,7 @@
         let pattern = m%"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"% in
         let is_num_literal = %str_is_match% pattern in
         fun l s =>
-          if %typeof% s == `String then
+          if %typeof% s == 'String then
             if is_num_literal s then
               s
             else
@@ -1986,7 +1986,7 @@
       ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if length s == 1 then
             s
           else
@@ -2007,8 +2007,8 @@
 
       For example:
       ```nickel
-        (`Foo | Stringable) =>
-          `Foo
+        ('Foo | Stringable) =>
+          'Foo
         (false | Stringable) =>
           false
         ("bar" ++ "foo" | Stringable) =>
@@ -2023,10 +2023,10 @@
             fun value =>
               let type = builtin.typeof value in
               value == null
-              || type == `Number
-              || type == `Bool
-              || type == `String
-              || type == `Enum
+              || type == 'Number
+              || type == 'Bool
+              || type == 'String
+              || type == 'Enum
           ),
 
     NonEmpty
@@ -2044,7 +2044,7 @@
       ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if %str_length% s > 0 then
             s
           else
@@ -2370,7 +2370,7 @@
 
       For example:
       ```nickel
-      from_enum `MyEnum =>
+      from_enum 'MyEnum =>
         "MyEnum"
       ```
       "%

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -449,7 +449,7 @@
         let length = %length% array in
         let first = %elem_at% array 0 in
         let rest = %array_slice% 1 length array in
-        let parts = partition (fun x => (cmp x first == `Lesser)) rest in
+        let parts = partition (fun x => (cmp x first == 'Lesser)) rest in
         if length <= 1 then
           array
         else
@@ -737,7 +737,7 @@
       ```nickel
         is_enum true =>
           false
-        is_enum `false =>
+        is_enum 'false =>
           true
       ```
       "%
@@ -2342,7 +2342,7 @@
       ```nickel
       from 42 =>
         "42"
-      from `Foo =>
+      from 'Foo =>
         "Foo"
       from null =>
         "null"

--- a/topiary/tests/samples/input/nickel.ncl
+++ b/topiary/tests/samples/input/nickel.ncl
@@ -62,7 +62,7 @@
         ```
         "%
       = fun label value =>
-        if %typeof% value == `Array then
+        if %typeof% value == 'Array then
           if %length% value != 0 then
             value
           else
@@ -437,13 +437,13 @@
       = fun f n => %generate% n f,
 
     sort
-      | forall a. (a -> a -> [| `Lesser, `Equal, `Greater |]) -> Array a -> Array a
+      | forall a. (a -> a -> [| 'Lesser, 'Equal, 'Greater |]) -> Array a -> Array a
       | doc m%"
         Sorts the given arrays based on the provided comparison operator.
 
         For example:
         ```nickel
-          sort (fun x y => if x < y then `Lesser else if (x == y) then `Equal else `Greater) [ 4, 5, 1, 2 ] =>
+          sort (fun x y => if x < y then 'Lesser else if (x == y) then 'Equal else 'Greater) [ 4, 5, 1, 2 ] =>
             [ 1, 2, 4, 5 ]
         ```
         "%
@@ -452,7 +452,7 @@
         let length = %length% array in
         let first = %elem_at% array 0 in
         let rest = %array_slice% 1 length array in
-        let parts = partition (fun x => (cmp x first == `Lesser)) rest in
+        let parts = partition (fun x => (cmp x first == 'Lesser)) rest in
         if length <= 1 then
           array
         else
@@ -699,7 +699,7 @@
           false
       ```
       "%
-      = fun x => %typeof% x == `Number,
+      = fun x => %typeof% x == 'Number,
 
     is_bool
       : Dyn -> Bool
@@ -714,7 +714,7 @@
           false
       ```
       "%
-      = fun x => %typeof% x == `Bool,
+      = fun x => %typeof% x == 'Bool,
 
     is_string
       : Dyn -> Bool
@@ -729,7 +729,7 @@
           true
       ```
       "%
-      = fun x => %typeof% x == `String,
+      = fun x => %typeof% x == 'String,
 
     is_enum
       : Dyn -> Bool
@@ -740,11 +740,11 @@
       ```nickel
         is_enum true =>
           false
-        is_enum `false =>
+        is_enum 'false =>
           true
       ```
       "%
-      = fun x => %typeof% x == `Enum,
+      = fun x => %typeof% x == 'Enum,
 
     is_function
       : Dyn -> Bool
@@ -759,7 +759,7 @@
           false
       ```
       "%
-      = fun x => %typeof% x == `Function,
+      = fun x => %typeof% x == 'Function,
 
     is_array
       : Dyn -> Bool
@@ -774,7 +774,7 @@
           false
       ```
       "%
-      = fun x => %typeof% x == `Array,
+      = fun x => %typeof% x == 'Array,
 
     is_record
       : Dyn -> Bool
@@ -789,19 +789,19 @@
           true
       ```
       "%
-      = fun x => %typeof% x == `Record,
+      = fun x => %typeof% x == 'Record,
 
     typeof
       : Dyn -> [|
-        `Number,
-        `Bool,
-        `String,
-        `Enum,
-        `Label,
-        `Function,
-        `Array,
-        `Record,
-        `Other
+        'Number,
+        'Bool,
+        'String,
+        'Enum,
+        'Label,
+        'Function,
+        'Array,
+        'Record,
+        'Other
       |]
       | doc m%"
       Results in a value representing the type of the typed value.
@@ -809,9 +809,9 @@
       For example:
       ```nickel
         typeof [ 1, 2 ] =>
-          `Array
+          'Array
         typeof (fun x => x) =>
-          `Function
+          'Function
       ```
       "%
       = fun x => %typeof% x,
@@ -851,26 +851,26 @@
       = fun x y => %deep_seq% x y,
 
     hash
-      : [| `Md5, `Sha1, `Sha256, `Sha512 |] -> String -> String
+      : [| 'Md5, 'Sha1, 'Sha256, 'Sha512 |] -> String -> String
       | doc m%"
       Hashes the given string provided the desired hash algorithm.
 
       For example:
       ```nickel
-        hash `Md5 "hunter2" =>
+        hash 'Md5 "hunter2" =>
           "2ab96390c7dbe3439de74d0c9b0b1767"
       ```
       "%
       = fun type s => %hash% type s,
 
     serialize
-      : [| `Json, `Toml, `Yaml |] -> Dyn -> String
+      : [| 'Json, 'Toml, 'Yaml |] -> Dyn -> String
       | doc m%"
       Serializes the given value to the desired representation.
 
       For example:
       ```nickel
-        serialize `Json { hello = "Hello", world = "World" } =>
+        serialize 'Json { hello = "Hello", world = "World" } =>
           "{
             "hello": "Hello",
             "world": "World"
@@ -880,13 +880,13 @@
       = fun format x => %serialize% format (%force% x),
 
     deserialize
-      : [| `Json, `Toml, `Yaml |] -> String -> Dyn
+      : [| 'Json, 'Toml, 'Yaml |] -> String -> Dyn
       | doc m%"
       Deserializes the given string to a nickel value given the encoding of the string.
 
       For example:
       ```nickel
-        deserialize `Json "{ \"hello\": \"Hello\", \"world\": \"World\" }"
+        deserialize 'Json "{ \"hello\": \"Hello\", \"world\": \"World\" }"
           { hello = "Hello", world = "World" }
       ```
       "%
@@ -902,7 +902,7 @@
       ```nickel
       from 42 =>
         "42"
-      from `Foo =>
+      from 'Foo =>
         "Foo"
       from null =>
         "null"
@@ -1220,10 +1220,10 @@
           # Examples
 
           ```nickel
-            (`foo | Tag) =>
-              `foo
-            (`FooBar | Tag) =>
-              `FooBar
+            ('foo | Tag) =>
+              'foo
+            ('FooBar | Tag) =>
+              'FooBar
             ("tag" | Tag) =>
               error
           ```
@@ -1245,18 +1245,18 @@
             let Schema = {
               protocol
                 | enum.TagOrString
-                | [| `http, `ftp |],
+                | [| 'http, 'ftp |],
               port
                 | Number,
               method
                 | enum.TagOrString
-                | [| `GET, `POST |]
+                | [| 'GET, 'POST |]
             } in
             let serialized =
               m%"
                 {"protocol": "http", "port": 80, "method": "GET"}
               "%
-              |> builtin.deserialize `Json
+              |> builtin.deserialize 'Json
             in
 
             serialized | Schema
@@ -1265,8 +1265,8 @@
       = fun label value =>
         %typeof% value
         |> match {
-          `String => %enum_from_str% value,
-          `Enum => value,
+          'String => %enum_from_str% value,
+          'Enum => value,
           _ =>
             contract.blame_with_message "expected either a string or an enum tag" label,
         },
@@ -1346,7 +1346,7 @@
       ```nickel
       pipe 2 [ (+) 2, (+) 3 ]
         => 7
-      pipe `World [ string.from, fun s => "Hello, %{s}!" ]
+      pipe 'World [ string.from, fun s => "Hello, %{s}!" ]
         => "Hello, World!"
       ```
     "%%
@@ -1359,22 +1359,22 @@
   # Contract implementations
   "$dyn" = fun _label value => value,
 
-  "$num" = fun label value => if %typeof% value == `Number then value else %blame% label,
+  "$num" = fun label value => if %typeof% value == 'Number then value else %blame% label,
 
-  "$bool" = fun label value => if %typeof% value == `Bool then value else %blame% label,
+  "$bool" = fun label value => if %typeof% value == 'Bool then value else %blame% label,
 
-  "$string" = fun label value => if %typeof% value == `String then value else %blame% label,
+  "$string" = fun label value => if %typeof% value == 'String then value else %blame% label,
 
   "$fail" = fun label _value => %blame% label,
 
   "$array" = fun element_contract label value =>
-    if %typeof% value == `Array then
+    if %typeof% value == 'Array then
       %array_lazy_assume% (%go_array% label) value element_contract
     else
       %blame% label,
 
   "$func" = fun domain codomain label value =>
-    if %typeof% value == `Function then
+    if %typeof% value == 'Function then
       (fun x => %assume% codomain (%go_codom% label) (value (%assume% domain (%chng_pol% (%go_dom% label)) x)))
     else
       %blame% label,
@@ -1395,7 +1395,7 @@
     contract (%insert_type_variable% sealing_key polarity label) value,
 
   "$enums" = fun case label value =>
-    if %typeof% value == `Enum then
+    if %typeof% value == 'Enum then
       %assume% case label value
     else
       %blame% (%label_with_message% "not an enum tag" label),
@@ -1404,7 +1404,7 @@
     %blame% (%label_with_message% "tag not included in the enum type" label),
 
   "$record" = fun field_contracts tail_contract label value =>
-    if %typeof% value == `Record then
+    if %typeof% value == 'Record then
       # Returns the sub-record of `l` containing only those fields which are not
       # present in `r`. If `l` has a sealed polymorphic tail then it will be
       # preserved.
@@ -1438,7 +1438,7 @@
       %blame% (%label_with_message% "not a record" label),
 
   "$dyn_record" = fun contract label value =>
-    if %typeof% value == `Record then
+    if %typeof% value == 'Record then
       %dictionary_assume% (%go_dict% label) value contract
     else
       %blame% (%label_with_message% "not a record" label),
@@ -1492,7 +1492,7 @@
       ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 then
             value
           else
@@ -1515,7 +1515,7 @@
       ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 && value >= 0 then
             value
           else
@@ -1538,7 +1538,7 @@
       ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value % 1 == 0 && value > 0 then
             value
           else
@@ -1559,7 +1559,7 @@
       ```
       "%
       = fun label value =>
-        if %typeof% value == `Number then
+        if %typeof% value == 'Number then
           if value != 0 then
             value
           else
@@ -1927,7 +1927,7 @@
       ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if s == "true" || s == "True" then
             "true"
           else
@@ -1955,7 +1955,7 @@
       = let pattern = m%"^[+-]?(\d+(\.\d*)?(e[+-]?\d+)?|\.\d+(e[+-]?\d+)?)$"% in
       let is_num_literal = %str_is_match% pattern in
       fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if is_num_literal s then
             s
           else
@@ -1980,7 +1980,7 @@
       ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if length s == 1 then
             s
           else
@@ -2001,8 +2001,8 @@
 
       For example:
       ```nickel
-        (`Foo | Stringable) =>
-          `Foo
+        ('Foo | Stringable) =>
+          'Foo
         (false | Stringable) =>
           false
         ("bar" ++ "foo" | Stringable) =>
@@ -2014,10 +2014,10 @@
       = contract.from_predicate (fun value =>
         let type = builtin.typeof value in
         value == null
-        || type == `Number
-        || type == `Bool
-        || type == `String
-        || type == `Enum),
+        || type == 'Number
+        || type == 'Bool
+        || type == 'String
+        || type == 'Enum),
 
     NonEmpty
       | doc m%"
@@ -2034,7 +2034,7 @@
       ```
       "%
       = fun l s =>
-        if %typeof% s == `String then
+        if %typeof% s == 'String then
           if %str_length% s > 0 then
             s
           else
@@ -2332,7 +2332,7 @@
       ```nickel
       from 42 =>
         "42"
-      from `Foo =>
+      from 'Foo =>
         "Foo"
       from null =>
         "null"
@@ -2360,7 +2360,7 @@
 
       For example:
       ```nickel
-      from_enum `MyEnum =>
+      from_enum 'MyEnum =>
         "MyEnum"
       ```
       "%


### PR DESCRIPTION
We decided to change the syntax for enum tags in Nickel from `` `Tag `` to `'Tag`. The newest unstable branch of the Nickel tree-sitter grammar supports that change. Additionally, it reflects the change of naming for some builtin types, namely `Str` became `String` and `Num` became `Number`.

None of these changes should affect the parse tree structure, ~so no queries should need changing.~ Well, that was a nice dream 😅