### PR TITLE
Ocaml: modules can be on one line

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -80,7 +80,7 @@
     (module_definition)
     (module_type_definition)
     (type_definition)
-  ] @append_hardline
+  ] @append_spaced_softline
   .
   "in"? @do_nothing
   .
@@ -125,7 +125,7 @@
   [
     (value_definition)
     (value_specification)
-  ] @append_hardline
+  ] @append_spaced_softline
   .
   [
     (exception_definition)

--- a/topiary-playground/languages_export.ts
+++ b/topiary-playground/languages_export.ts
@@ -3755,7 +3755,7 @@ export xyzzy=$(
     (module_definition)
     (module_type_definition)
     (type_definition)
-  ] @append_hardline
+  ] @append_spaced_softline
   .
   "in"? @do_nothing
   .
@@ -3800,7 +3800,7 @@ export xyzzy=$(
   [
     (value_definition)
     (value_specification)
-  ] @append_hardline
+  ] @append_spaced_softline
   .
   [
     (exception_definition)
@@ -6157,6 +6157,14 @@ let not = function true -> false | false -> true
 let not x = match x with | true -> false | false -> true
 
 exception MyException of string
+
+(* Idempotence failures from #441 *)
+let _ =
+  let module Lift = Mlfi_types.TypEq.Lift (struct type 'a c = 'a S.t end) in ()
+
+(* Slight variant of #441 *)
+let _ =
+  let module Foo = struct let f = 0 let g = 1 in ()
 `,
   },
   "rust": {

--- a/topiary/tests/samples/expected/ocaml.ml
+++ b/topiary/tests/samples/expected/ocaml.ml
@@ -1027,3 +1027,11 @@ let not = function true -> false | false -> true
 let not x = match x with true -> false | false -> true
 
 exception MyException of string
+
+(* Idempotence failures from #441 *)
+let _ =
+  let module Lift = Mlfi_types.TypEq.Lift(struct type 'a c = 'a S.t end) in ()
+
+(* Slight variant of #441 *)
+let _ =
+  let module Foo = struct let f = 0 let g = 1 in ()

--- a/topiary/tests/samples/input/ocaml.ml
+++ b/topiary/tests/samples/input/ocaml.ml
@@ -972,3 +972,11 @@ let not = function true -> false | false -> true
 let not x = match x with | true -> false | false -> true
 
 exception MyException of string
+
+(* Idempotence failures from #441 *)
+let _ =
+  let module Lift = Mlfi_types.TypEq.Lift (struct type 'a c = 'a S.t end) in ()
+
+(* Slight variant of #441 *)
+let _ =
+  let module Foo = struct let f = 0 let g = 1 in ()


### PR DESCRIPTION
This solves the first example from #441 .

Generally speaking, all the hard lines are suspicious (in Ocaml in particular, but probably in every language), but I haven't t investigated further (I got hit by this one yesterday, so got incentivised to solve it; the playground is amazing for this sort of debugging by the way).