### PR TITLE
[OCaml] Support `package_type` in `type_binding`

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -1087,6 +1087,7 @@
     (function_type)
     (hash_type)
     (object_type)
+    (package_type)
     (parenthesized_type)
     (tuple_type)
     (type_constructor_path)
@@ -1107,6 +1108,7 @@
     (function_type)
     (hash_type)
     (object_type)
+    (package_type)
     (parenthesized_type)
     (tuple_type)
     (type_constructor_path)
@@ -1116,6 +1118,13 @@
   .
   (type_constraint) @append_indent_end
 )
+
+(package_type
+  .
+  "(" @append_empty_softline @append_indent_start
+  ")" @prepend_empty_softline @prepend_indent_end
+  .
+) @prepend_spaced_softline
 
 ; Make an indented block after "of" or ":" in constructor declarations
 ;

--- a/topiary-playground/languages_export.ts
+++ b/topiary-playground/languages_export.ts
@@ -4762,6 +4762,7 @@ export xyzzy=$(
     (function_type)
     (hash_type)
     (object_type)
+    (package_type)
     (parenthesized_type)
     (tuple_type)
     (type_constructor_path)
@@ -4782,6 +4783,7 @@ export xyzzy=$(
     (function_type)
     (hash_type)
     (object_type)
+    (package_type)
     (parenthesized_type)
     (tuple_type)
     (type_constructor_path)
@@ -4791,6 +4793,13 @@ export xyzzy=$(
   .
   (type_constraint) @append_indent_end
 )
+
+(package_type
+  .
+  "(" @append_empty_softline @append_indent_start
+  ")" @prepend_empty_softline @prepend_indent_end
+  .
+) @prepend_spaced_softline
 
 ; Make an indented block after "of" or ":" in constructor declarations
 ;

--- a/topiary/tests/samples/expected/ocaml.mli
+++ b/topiary/tests/samples/expected/ocaml.mli
@@ -3658,10 +3658,13 @@ module Sc_rollup: sig
       end
     end
 
-    type ('state, 'proof, 'output) implementation = (module S with
-    type state = 'state
-    and type proof = 'proof
-    and type output_proof = 'output)
+    type ('state, 'proof, 'output) implementation =
+      (
+        module S with
+        type state = 'state
+        and type proof = 'proof
+        and type output_proof = 'output
+      )
 
     type t =
       Packed : ('state, 'proof, 'output) implementation -> t


### PR DESCRIPTION
Formats the following:
```ocaml
type ('a,'b,'c) x = (module R with type a = 'a and type b = 'b and
type c = 'c)
```
as
```ocaml
type ('a, 'b, 'c) x =
  (
    module R with
    type a = 'a
    and type b = 'b
    and type c = 'c
  )
```
Closes #450 