### PR TITLE
[OCaml] exclude type constraints from scope in type bindings

### DIFF
--- a/languages/ocaml.scm
+++ b/languages/ocaml.scm
@@ -598,10 +598,6 @@
   (comment)* @do_nothing
 )
 
-(type_binding
-  (type_constraint) @prepend_spaced_softline
-)
-
 ; only add softlines after "else" if it's not part of an "else if" construction
 (
   "else" @append_spaced_softline
@@ -815,7 +811,6 @@
   [
     (application_expression)
     (class_body_type)
-    (constructed_type)
     (if_expression)
     (function_type)
     (let_expression)
@@ -1074,6 +1069,7 @@
   (_) @append_indent_end
 )
 
+; Some more rules for type bindings:
 ; Don't indent for record types nor polymorphic variant types:
 ; they are already indented, and we don't process double indentation well enough
 (type_binding
@@ -1097,6 +1093,7 @@
   .
   (type_constraint)? @do_nothing
 )
+
 (type_binding
   [
     "="
@@ -1125,6 +1122,37 @@
   ")" @prepend_empty_softline @prepend_indent_end
   .
 ) @prepend_spaced_softline
+
+; Consider type constraints to be "out of the block" when deciding
+; whether to add a newline between "=" and a constructed type.
+; This allows the following to be formatted as it is:
+;
+; type 'a x = 'a option
+;   constraint 'a = ('b,'c)
+(type_binding
+  [
+    "="
+    "+="
+  ] @begin_scope @append_spaced_scoped_softline
+  .
+  [
+    (constructed_type)
+    (function_type)
+    (hash_type)
+    (object_type)
+    (package_type)
+    (parenthesized_type)
+    (tuple_type)
+    (type_constructor_path)
+    (type_variable)
+    (variant_declaration)
+  ] @end_scope
+  (#scope_id! "type_binding_before_constraint")
+)
+
+(type_binding
+  (type_constraint) @prepend_spaced_softline
+)
 
 ; Make an indented block after "of" or ":" in constructor declarations
 ;

--- a/topiary/tests/samples/expected/ocaml.ml
+++ b/topiary/tests/samples/expected/ocaml.ml
@@ -936,10 +936,13 @@ let id (type s) (x : s) : s = x
 type foo = { a: 'a. ('a, mandatory) arg -> 'a; }
 type foo = (int, int) result
 
-(* exotic types *)
+(* types with constraints *)
 type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
   ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
   constraint 'meth = [< meth]
+
+type 'a x = 'a option
+  constraint 'a = 'b
 
 (* Indentation of multi-line types in PPX syntax *)
 let h =

--- a/topiary/tests/samples/expected/ocaml.mli
+++ b/topiary/tests/samples/expected/ocaml.mli
@@ -4895,8 +4895,7 @@ module Operation: sig
 
   val contents_list_encoding : packed_contents_list Data_encoding.t
 
-  type 'kind t =
-    'kind operation = {
+  type 'kind t = 'kind operation = {
     shell: Operation.shell_header;
     protocol_data: 'kind protocol_data;
   }
@@ -5261,7 +5260,8 @@ end
 (** This module re-exports definitions from {!Liquidity_baking_repr} and
     {!Liquidity_baking_storage}. *)
 module Liquidity_baking: sig
-  type liquidity_baking_toggle_vote = Liquidity_baking_repr.liquidity_baking_toggle_vote =
+  type liquidity_baking_toggle_vote =
+    Liquidity_baking_repr.liquidity_baking_toggle_vote =
     | LB_on
     | LB_off
     | LB_pass

--- a/topiary/tests/samples/input/ocaml.ml
+++ b/topiary/tests/samples/input/ocaml.ml
@@ -889,10 +889,13 @@ let id (type s) (x : s) : s = x
 type foo = { a : 'a. ('a, mandatory) arg -> 'a; }
 type foo = (int, int) result
 
-(* exotic types *)
+(* types with constraints *)
 type (+'meth, 'prefix, 'params, 'query, 'input, 'output) service =
   ('meth, 'prefix, 'params, 'query, 'input, 'output, error) raw
   constraint 'meth = [< meth]
+
+type 'a x = 'a option
+  constraint 'a = 'b
 
 (* Indentation of multi-line types in PPX syntax *)
 let h =


### PR DESCRIPTION
This has the extra benefit of leaving two type bindings in `ocaml.mli` as they originally were (the initial formatting is better).

Closes #451 