### PR TITLE
Crate metadata plus workaround for Crane warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "topiary"
 version = "0.2.1"
 edition = "2021"
 authors = ["Tweag"]
-keywords = ["code-formatter"]
 homepage = "https://topiary.tweag.io"
 documentation = "https://github.com/tweag/topiary#topiary"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,16 @@
-[workspace]
-package.version = "0.2.1"
+[workspace.package]
+name = "topiary"
+version = "0.2.1"
+edition = "2021"
+authors = ["Tweag"]
+keywords = ["code-formatter"]
+homepage = "https://topiary.tweag.io"
+documentation = "https://github.com/tweag/topiary#topiary"
+readme = "README.md"
+license-file = "LICENSE"
+license = "MIT"
 
+[workspace]
 members = ["topiary", "topiary-cli", "topiary-playground"]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.1"
 edition = "2021"
 authors = ["Tweag"]
 homepage = "https://topiary.tweag.io"
+repository = "https://github.com/tweag/topiary"
 documentation = "https://github.com/tweag/topiary#topiary"
 readme = "README.md"
 license-file = "LICENSE"

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,7 +16,7 @@
     alphabetically. This name should be decided amongst the team before
     the release.
 
-  * Bump the package version number in `Cargo.toml` at project root.
+  * Bump the package version number in all the `Cargo.toml` files.
 
   * Commit and merge (squash, if necessary) on green CI and peer
     approval.

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "topiary-cli"
 description = "CLI app for Topiary, the universal code formatter."
-version = { workspace = true }
-edition = "2021"
+version = "0.2.1"                                                  # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+edition.workspace = true
+authors.workspace = true
+keywords.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme.workspace = true
+license-file.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "topiary"

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -1,13 +1,21 @@
 [package]
 name = "topiary-cli"
 description = "CLI app for Topiary, the universal code formatter."
+categories = ["command-line-utilities", "development-tools", "text-processing"]
+keywords = [
+    "cli",
+    "code-formatter",
+    "formatter",
+    "text",
+    "tree-sitter",
+    "utility",
+]
 
 # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
 version = "0.2.1"
 
 edition.workspace = true
 authors.workspace = true
-keywords.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 readme.workspace = true

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -17,6 +17,7 @@ version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
 license-file.workspace = true

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "topiary-cli"
 description = "CLI app for Topiary, the universal code formatter."
-version = "0.2.1"                                                  # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+
+# Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+version = "0.2.1"
+
 edition.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/topiary-playground/Cargo.toml
+++ b/topiary-playground/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "topiary-playground"
 description = "The WebAssembly code that runs at https://topiary.tweag.io/playground"
-version = "0.2.1"                                                                     # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+
+# Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+version = "0.2.1"
+
 edition.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/topiary-playground/Cargo.toml
+++ b/topiary-playground/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "topiary-playground"
 description = "The WebAssembly code that runs at https://topiary.tweag.io/playground"
-version = { workspace = true }
-edition = "2021"
+version = "0.2.1"                                                                     # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+edition.workspace = true
+authors.workspace = true
+keywords.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme.workspace = true
+license-file.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/topiary-playground/Cargo.toml
+++ b/topiary-playground/Cargo.toml
@@ -17,6 +17,7 @@ version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
 license-file.workspace = true

--- a/topiary-playground/Cargo.toml
+++ b/topiary-playground/Cargo.toml
@@ -1,13 +1,21 @@
 [package]
 name = "topiary-playground"
 description = "The WebAssembly code that runs at https://topiary.tweag.io/playground"
+categories = ["development-tools", "text-processing", "webassembly"]
+keywords = [
+    "code-formatter",
+    "formatter",
+    "text",
+    "tree-sitter",
+    "wasm",
+    "webassembly",
+]
 
 # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
 version = "0.2.1"
 
 edition.workspace = true
 authors.workspace = true
-keywords.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 readme.workspace = true

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "topiary"
 description = "Formats input source code in a style defined for that language."
+categories = ["development-tools", "text-processing"]
+keywords = ["code-formatter", "formatter", "text", "tree-sitter"]
 
 # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
 version = "0.2.1"
 
 edition.workspace = true
 authors.workspace = true
-keywords.workspace = true
 homepage.workspace = true
 documentation.workspace = true
 readme.workspace = true

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -1,8 +1,15 @@
 [package]
 name = "topiary"
 description = "Formats input source code in a style defined for that language."
-version = { workspace = true }
-edition = "2021"
+version = "0.2.1"                                                               # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+edition.workspace = true
+authors.workspace = true
+keywords.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+readme.workspace = true
+license-file.workspace = true
+license.workspace = true
 
 [dependencies]
 # For now we just load the tree-sitter language parsers statically.

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
 license-file.workspace = true

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "topiary"
 description = "Formats input source code in a style defined for that language."
-version = "0.2.1"                                                               # Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+
+# Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
+version = "0.2.1"
+
 edition.workspace = true
 authors.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
Fixes #455. Related to #375.

Uses a workaround due to https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302.