### PR TITLE
Metadata fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace.package]
-name = "topiary"
 version = "0.2.1"
 edition = "2021"
 authors = ["Tweag"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ homepage = "https://topiary.tweag.io"
 repository = "https://github.com/tweag/topiary"
 documentation = "https://github.com/tweag/topiary#topiary"
 readme = "README.md"
-license-file = "LICENSE"
 license = "MIT"
 
 [workspace]

--- a/default.nix
+++ b/default.nix
@@ -44,18 +44,6 @@ let
   # Instead, we just want to update the scope that crane will use by appending
   # our specific toolchain there.
   craneLibWasm = craneLib.overrideToolchain rustWithWasmTarget;
-
-  topiaryName = craneLib.crateNameFromCargoToml {
-    cargoToml = ./topiary/Cargo.toml;
-  };
-
-  topiaryCLIName = craneLib.crateNameFromCargoToml {
-    cargoToml = ./topiary-cli/Cargo.toml;
-  };
-
-  topiaryPlaygroundName = craneLib.crateNameFromCargoToml {
-    cargoToml = ./topiary-playground/Cargo.toml;
-  };
 in
 {
   clippy = craneLib.cargoClippy (commonArgs // {
@@ -81,14 +69,12 @@ in
 
   topiary-lib = craneLib.buildPackage (commonArgs // {
     inherit cargoArtifacts;
-    inherit (topiaryName) version;
     pname = "topiary-lib";
     cargoExtraArgs = "-p topiary";
   });
 
   topiary-cli = craneLib.buildPackage (commonArgs // {
     inherit cargoArtifacts;
-    inherit (topiaryCLIName) version;
     pname = "topiary";
     cargoExtraArgs = "-p topiary-cli";
     postInstall = ''
@@ -108,7 +94,6 @@ in
 
   topiary-playground = craneLibWasm.buildPackage (commonArgs // {
     inherit cargoArtifacts;
-    inherit (topiaryPlaygroundName) pname version;
     cargoExtraArgs = "-p topiary-playground --no-default-features --target ${wasmTarget}";
     
     # Tests currently need to be run via `cargo wasi` which

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,8 @@ let
   craneLib = crane.mkLib pkgs;
 
   commonArgs = {
+    pname = "topiary";
+
     src = nix-filter.lib.filter {
       root = ./.;
       include = [
@@ -48,28 +50,22 @@ in
 {
   clippy = craneLib.cargoClippy (commonArgs // {
     inherit cargoArtifacts;
-    pname = "topiary-foo";
     cargoClippyExtraArgs = "-- --deny warnings";
   });
 
   clippy-wasm = craneLibWasm.cargoClippy (commonArgs // {
     inherit cargoArtifacts;
-    pname = "topiary-foo";
     cargoClippyExtraArgs = "-p topiary-playground --target ${wasmTarget} -- --deny warnings";
   });
 
-  fmt = craneLib.cargoFmt (commonArgs // {
-    pname = "topiary-foo";
-  });
+  fmt = craneLib.cargoFmt (commonArgs);
 
   audit = craneLib.cargoAudit (commonArgs // {
     inherit advisory-db;
-    pname = "topiary-foo";
   });
 
   benchmark = craneLib.buildPackage (commonArgs // {
     inherit cargoArtifacts;
-    pname = "topiary-foo";
     cargoTestCommand = "cargo bench --profile release";
   });
 
@@ -100,7 +96,7 @@ in
 
   topiary-playground = craneLibWasm.buildPackage (commonArgs // {
     inherit cargoArtifacts;
-    pname = "topiary-foo";
+    pname = "topiary-playground";
     cargoExtraArgs = "-p topiary-playground --no-default-features --target ${wasmTarget}";
     
     # Tests currently need to be run via `cargo wasi` which

--- a/default.nix
+++ b/default.nix
@@ -48,22 +48,28 @@ in
 {
   clippy = craneLib.cargoClippy (commonArgs // {
     inherit cargoArtifacts;
+    pname = "topiary-foo";
     cargoClippyExtraArgs = "-- --deny warnings";
   });
 
   clippy-wasm = craneLibWasm.cargoClippy (commonArgs // {
     inherit cargoArtifacts;
+    pname = "topiary-foo";
     cargoClippyExtraArgs = "-p topiary-playground --target ${wasmTarget} -- --deny warnings";
   });
 
-  fmt = craneLib.cargoFmt (commonArgs);
+  fmt = craneLib.cargoFmt (commonArgs // {
+    pname = "topiary-foo";
+  });
 
   audit = craneLib.cargoAudit (commonArgs // {
     inherit advisory-db;
+    pname = "topiary-foo";
   });
 
   benchmark = craneLib.buildPackage (commonArgs // {
     inherit cargoArtifacts;
+    pname = "topiary-foo";
     cargoTestCommand = "cargo bench --profile release";
   });
 
@@ -94,6 +100,7 @@ in
 
   topiary-playground = craneLibWasm.buildPackage (commonArgs // {
     inherit cargoArtifacts;
+    pname = "topiary-foo";
     cargoExtraArgs = "-p topiary-playground --no-default-features --target ${wasmTarget}";
     
     # Tests currently need to be run via `cargo wasi` which

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -10,10 +10,7 @@ keywords = [
     "tree-sitter",
     "utility",
 ]
-
-# Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
-version = "0.2.1"
-
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -20,7 +20,6 @@ homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
-license-file.workspace = true
 license.workspace = true
 
 [[bin]]

--- a/topiary-playground/Cargo.toml
+++ b/topiary-playground/Cargo.toml
@@ -10,10 +10,7 @@ keywords = [
     "wasm",
     "webassembly",
 ]
-
-# Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
-version = "0.2.1"
-
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/topiary-playground/Cargo.toml
+++ b/topiary-playground/Cargo.toml
@@ -20,7 +20,6 @@ homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
-license-file.workspace = true
 license.workspace = true
 
 [lib]

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -3,10 +3,7 @@ name = "topiary"
 description = "Formats input source code in a style defined for that language."
 categories = ["development-tools", "text-processing"]
 keywords = ["code-formatter", "formatter", "text", "tree-sitter"]
-
-# Workaround for https://github.com/ipetkov/crane/issues/281#issuecomment-1560575302
-version = "0.2.1"
-
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/topiary/Cargo.toml
+++ b/topiary/Cargo.toml
@@ -13,7 +13,6 @@ homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
-license-file.workspace = true
 license.workspace = true
 
 [dependencies]


### PR DESCRIPTION
Related to #478.

- Fixes Cargo metadata warnings.
- Fixes Crane config so we no longer to specify version in all Cargo.toml files.

