### PR TITLE
Only trim line breaks in pretty-printing

### DIFF
--- a/topiary/src/pretty.rs
+++ b/topiary/src/pretty.rs
@@ -37,7 +37,7 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                     // as a `Hardline` in the atom stream.
                     writeln!(buffer)?;
                 }
-                write!(buffer, "{}", content.trim_end())?;
+                write!(buffer, "{}", content.trim_end_matches('\n'))?;
             }
 
             Atom::Literal(s) => write!(buffer, "{s}")?,


### PR DESCRIPTION
This feels like tinkering, rather than a proper solution to #492, but it works for now.

Closes #492 
Closes #488 