### PR TITLE
Linguist configuration to make Topiary a Rust project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Hide our tests from language detection so GitHub correctly detects Topiary as a Rust project
+topiary/tests/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Hide our tests from language detection so GitHub correctly detects Topiary as a Rust project
-topiary/tests/** linguist-vendored
+topiary/tests/samples/** linguist-vendored


### PR DESCRIPTION
Topiary is considered by GitHub to be an OCaml project because our OCaml tests are rather substantial. I think it is best if we make it so GitHub identifies it as a Rust project for possible contributors.