### PR TITLE
Create the query only once

### DIFF
--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -20,7 +20,7 @@ use crate::{
     output::OutputFile,
     visualise::Visualisation,
 };
-use topiary::{formatter, Language, Operation, SupportedLanguage};
+use topiary::{formatter, Language, Operation, SupportedLanguage, TopiaryQuery};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -130,7 +130,7 @@ async fn run() -> CLIResult<()> {
         language.query_file()?
     };
 
-    let query = (|| {
+    let query_content = (|| {
         let mut reader = BufReader::new(File::open(&query_path)?);
         let mut contents = String::new();
         reader.read_to_string(&mut contents)?;
@@ -145,6 +145,7 @@ async fn run() -> CLIResult<()> {
     })?;
 
     let grammar = language.grammar().await?;
+    let query = TopiaryQuery::new(&grammar, &query_content)?;
 
     let operation = if let Some(visualisation) = args.visualise {
         Operation::Visualise {

--- a/topiary-playground/src/lib.rs
+++ b/topiary-playground/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg(target_arch = "wasm32")]
-use topiary::{formatter, Configuration, FormatterResult, Operation};
+use topiary::{formatter, Configuration, FormatterResult, Operation, TopiaryQuery};
 #[cfg(target_arch = "wasm32")]
 use tree_sitter_facade::TreeSitter;
 #[cfg(target_arch = "wasm32")]
@@ -41,7 +41,7 @@ pub async fn format(
 #[cfg(target_arch = "wasm32")]
 async fn format_inner(
     input: &str,
-    query: &str,
+    query_content: &str,
     language_name: &str,
     check_idempotence: bool,
     tolerate_parsing_errors: bool,
@@ -51,11 +51,12 @@ async fn format_inner(
     let configuration = Configuration::parse_default_configuration()?;
     let language = configuration.get_language(language_name)?;
     let grammar = language.grammar_wasm().await?;
+    let query = TopiaryQuery::new(&grammar, query_content)?;
 
     formatter(
         &mut input.as_bytes(),
         &mut output,
-        query,
+        &query,
         language,
         &grammar,
         Operation::Format {

--- a/topiary/benches/benchmark.rs
+++ b/topiary/benches/benchmark.rs
@@ -2,15 +2,16 @@ use criterion::async_executor::FuturesExecutor;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs;
 use std::io;
-use topiary::Configuration;
 use topiary::{formatter, Operation};
+use topiary::{Configuration, TopiaryQuery};
 
 async fn format() {
     let input = fs::read_to_string("tests/samples/input/ocaml.ml").unwrap();
-    let query = fs::read_to_string("../languages/ocaml.scm").unwrap();
+    let query_content = fs::read_to_string("../languages/ocaml.scm").unwrap();
     let configuration = Configuration::parse_default_configuration().unwrap();
     let language = configuration.get_language("ocaml").unwrap();
     let grammar = language.grammar().await.unwrap();
+    let query = TopiaryQuery::new(&grammar, &query_content).unwrap();
 
     let mut input = input.as_bytes();
     let mut output = io::BufWriter::new(Vec::new());

--- a/topiary/tests/sample-tester.rs
+++ b/topiary/tests/sample-tester.rs
@@ -7,7 +7,7 @@ use test_log::test;
 
 use topiary::{
     apply_query, formatter, test_utils::pretty_assert_eq, Configuration, FormatterError, Language,
-    Operation,
+    Operation, TopiaryQuery,
 };
 
 #[test(tokio::test)]
@@ -31,9 +31,11 @@ async fn input_output_tester() {
 
             let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
             let mut output = Vec::new();
-            let query = fs::read_to_string(language.query_file().unwrap()).unwrap();
+            let query_content = fs::read_to_string(language.query_file().unwrap()).unwrap();
 
             let grammar = language.grammar().await.unwrap();
+
+            let query = TopiaryQuery::new(&grammar, &query_content).unwrap();
 
             info!(
                 "Formatting file {} as {}.",
@@ -78,9 +80,11 @@ async fn formatted_query_tester() {
 
         let mut input = BufReader::new(fs::File::open(file.path()).unwrap());
         let mut output = Vec::new();
-        let query = fs::read_to_string(language.query_file().unwrap()).unwrap();
+        let query_content = fs::read_to_string(language.query_file().unwrap()).unwrap();
 
         let grammar = language.grammar().await.unwrap();
+
+        let query = TopiaryQuery::new(&grammar, &query_content).unwrap();
 
         formatter(
             &mut input,
@@ -122,7 +126,9 @@ async fn exhaustive_query_tester() {
 
         let grammar = language.grammar().await.unwrap();
 
-        apply_query(&input_content, &query_content, &grammar, false, true).unwrap_or_else(|e| {
+        let query = TopiaryQuery::new(&grammar, &query_content).unwrap();
+
+        apply_query(&input_content, &query, &grammar, false, true).unwrap_or_else(|e| {
             if let FormatterError::PatternDoesNotMatch(_) = e {
                 panic!("Found untested query in file {query_file:?}:\n{e}");
             } else {


### PR DESCRIPTION
The query is then used between the formatting and the idempotence check. The TopiaryQuery struct helps keep the API clean.
### Benchmark comparison with `skip_idempotence` set to false.
#### main:
```
format_ocaml            time:   [655.12 ms 658.89 ms 662.75 ms]
```

#### after this PR:
```
format_ocaml            time:   [430.05 ms 432.33 ms 434.68 ms]
                        change: [-34.911% -34.385% -33.879%] (p = 0.00 < 0.05)
```


### Flamegraphs of a simple OCaml format
#### main:
![flamegraph_main](https://github.com/tweag/topiary/assets/10973664/0752a307-4c67-4941-b882-c637df994f5e)

#### after this PR:
![flamegraph_new](https://github.com/tweag/topiary/assets/10973664/3faa0a47-dfae-4728-b00f-fc28ebd9d30c)
