### PR TITLE
530 idempotency parsing error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This name should be decided amongst the team before the release.
 * [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be indented properly using the new predicate @multi_line_indent_all.
 * [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and convenience functions for using the built-in queries.
 * [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
+* [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
 
 ## [0.2.3] - 2023-06-20
 [0.2.2]: https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3

--- a/topiary-cli/src/error.rs
+++ b/topiary-cli/src/error.rs
@@ -43,8 +43,8 @@ impl error::Error for TopiaryError {
 impl From<TopiaryError> for ExitCode {
     fn from(e: TopiaryError) -> Self {
         let exit_code = match e {
-            // Formatting errors: Exit 8
-            TopiaryError::Lib(FormatterError::Formatting(_)) => 8,
+            // Idempotency parsing errors: Exit 8
+            TopiaryError::Lib(FormatterError::IdempotenceParsing(_)) => 8,
 
             // Idempotency errors: Exit 7
             TopiaryError::Lib(FormatterError::Idempotence) => 7,

--- a/topiary/src/lib.rs
+++ b/topiary/src/lib.rs
@@ -273,7 +273,7 @@ fn idempotence_check(
     let mut input = content.as_bytes();
     let mut output = io::BufWriter::new(Vec::new());
 
-    formatter(
+    match formatter(
         &mut input,
         &mut output,
         query,
@@ -283,28 +283,24 @@ fn idempotence_check(
             skip_idempotence: true,
             tolerate_parsing_errors,
         },
-    )?;
-    let reformatted = String::from_utf8(output.into_inner()?)?;
-    let res = if content == reformatted {
-        Ok(())
-    } else {
-        log::error!("Failed idempotence check");
-        log::error!("{}", StrComparison::new(content, &reformatted));
-        Err(FormatterError::Idempotence)
-    };
+    ) {
+        Ok(()) => {
+            let reformatted = String::from_utf8(output.into_inner()?)?;
 
-    if let Err(err) = res {
-        match err {
-            // If topiary ran smoothly on its own output,
-            // but produced a different output, it is a Idempotence error.
-            FormatterError::Idempotence => Err(FormatterError::Idempotence),
-            // On the other hand, if it failed to run on its output,
-            // it means that when formatting the code, topiary somehow broke it.
-            // Hence it is a formatting error.
-            _ => Err(FormatterError::Formatting(Box::new(err))),
+            if content == reformatted {
+                Ok(())
+            } else {
+                log::error!("Failed idempotence check");
+                log::error!("{}", StrComparison::new(content, &reformatted));
+                Err(FormatterError::Idempotence)
+            }
         }
-    } else {
-        res
+        Err(error) => match error {
+            FormatterError::Parsing { .. } => {
+                Err(FormatterError::IdempotenceParsing(Box::new(error)))
+            }
+            _ => Err(error),
+        },
     }
 }
 

--- a/topiary/src/lib.rs
+++ b/topiary/src/lib.rs
@@ -295,12 +295,10 @@ fn idempotence_check(
                 Err(FormatterError::Idempotence)
             }
         }
-        Err(error) => match error {
-            FormatterError::Parsing { .. } => {
-                Err(FormatterError::IdempotenceParsing(Box::new(error)))
-            }
-            _ => Err(error),
-        },
+        Err(error @ FormatterError::Parsing { .. }) => {
+            Err(FormatterError::IdempotenceParsing(Box::new(error)))
+        }
+        Err(error) => Err(error),
     }
 }
 


### PR DESCRIPTION
Fixes #530.

- Improved error message when idempotency fails due to invalid output in the first pass.
