### PR TITLE
cargo-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,140 @@
+# CI that:
+#
+# * checks for a Git Tag that looks like a release
+# * creates a Github Release™ and fills in its text
+# * builds artifacts with cargo-dist (executable-zips, installers)
+# * uploads those artifacts to the Github Release™
+#
+# Note that the Github Release™ will be created before the artifacts,
+# so there will be a few minutes where the release has no artifacts
+# and then they will slowly trickle in, possibly failing. To make
+# this more pleasant we mark the release as a "draft" until all
+# artifacts have been successfully uploaded. This allows you to
+# choose what to do with partial successes and avoids spamming
+# anyone with notifications before the release is actually ready.
+name: Release
+
+permissions:
+  contents: write
+
+# This task will run whenever you push a git tag that looks like a version
+# like "v1", "v1.2.0", "v0.1.0-prerelease01", "my-app-v1.0.0", etc.
+# The version will be roughly parsed as ({PACKAGE_NAME}-)?v{VERSION}, where
+# PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
+# must be a Cargo-style SemVer Version.
+#
+# If PACKAGE_NAME is specified, then we will create a Github Release™ for that
+# package (erroring out if it doesn't have the given version or isn't cargo-dist-able).
+#
+# If PACKAGE_NAME isn't specified, then we will create a Github Release™ for all
+# (cargo-dist-able) packages in the workspace with that version (this is mode is
+# intended for workspaces with only one dist-able package, or with all dist-able
+# packages versioned/released in lockstep).
+#
+# If you push multiple tags at once, separate instances of this workflow will
+# spin up, creating an independent Github Release™ for each one.
+#
+# If there's a prerelease-style suffix to the version then the Github Release™
+# will be marked as a prerelease.
+on:
+  push:
+    tags:
+      - '*-?v[0-9]+*'
+
+jobs:
+  # Create the Github Release™ so the packages have something to be uploaded to
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      has-releases: ${{ steps.create-release.outputs.has-releases }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update 1.67.1 --no-self-update && rustup default 1.67.1
+      - name: Install cargo-dist
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.7/cargo-dist-installer.sh | sh
+      - id: create-release
+        run: |
+          cargo dist plan --tag=${{ github.ref_name }} --output-format=json > dist-manifest.json
+          echo "dist plan ran successfully"
+          cat dist-manifest.json
+
+          # Create the Github Release™ based on what cargo-dist thinks it should be
+          ANNOUNCEMENT_TITLE=$(jq --raw-output ".announcement_title" dist-manifest.json)
+          IS_PRERELEASE=$(jq --raw-output ".announcement_is_prerelease" dist-manifest.json)
+          jq --raw-output ".announcement_github_body" dist-manifest.json > new_dist_announcement.md
+          gh release create ${{ github.ref_name }} --draft --prerelease="$IS_PRERELEASE" --title="$ANNOUNCEMENT_TITLE" --notes-file=new_dist_announcement.md
+          echo "created announcement!"
+
+          # Upload the manifest to the Github Release™
+          gh release upload ${{ github.ref_name }} dist-manifest.json
+          echo "uploaded manifest!"
+
+          # Disable all the upload-artifacts tasks if we have no actual releases
+          HAS_RELEASES=$(jq --raw-output ".releases != null" dist-manifest.json)
+          echo "has-releases=$HAS_RELEASES" >> "$GITHUB_OUTPUT"
+
+  # Build and packages all the things
+  upload-artifacts:
+    # Let the initial task tell us to not run (currently very blunt)
+    needs: create-release
+    if: ${{ needs.create-release.outputs.has-releases == 'true' }}
+    strategy:
+      matrix:
+        # For these target platforms
+        include:
+        - os: ubuntu-20.04
+          dist-args: --artifacts=global
+          install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.7/cargo-dist-installer.sh | sh
+        - os: macos-11
+          dist-args: --artifacts=local --target=aarch64-apple-darwin --target=x86_64-apple-darwin
+          install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.7/cargo-dist-installer.sh | sh
+        - os: ubuntu-20.04
+          dist-args: --artifacts=local --target=x86_64-unknown-linux-gnu
+          install-dist: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.0.7/cargo-dist-installer.sh | sh
+        - os: windows-2019
+          dist-args: --artifacts=local --target=x86_64-pc-windows-msvc
+          install-dist: irm  https://github.com/axodotdev/cargo-dist/releases/download/v0.0.7/cargo-dist-installer.ps1 | iex
+
+    runs-on: ${{ matrix.os }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update 1.67.1 --no-self-update && rustup default 1.67.1
+      - name: Install cargo-dist
+        run: ${{ matrix.install-dist }}
+      - name: Run cargo-dist
+        # This logic is a bit janky because it's trying to be a polyglot between
+        # powershell and bash since this will run on windows, macos, and linux!
+        # The two platforms don't agree on how to talk about env vars but they
+        # do agree on 'cat' and '$()' so we use that to marshal values between commands.
+        run: |
+          # Actually do builds and make zips and whatnot
+          cargo dist build --tag=${{ github.ref_name }} --output-format=json ${{ matrix.dist-args }} > dist-manifest.json
+          echo "dist ran successfully"
+          cat dist-manifest.json
+
+          # Parse out what we just built and upload it to the Github Release™
+          jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json > uploads.txt
+          echo "uploading..."
+          cat uploads.txt
+          gh release upload ${{ github.ref_name }} $(cat uploads.txt)
+          echo "uploaded!"
+
+  # Mark the Github Release™ as a non-draft now that everything has succeeded!
+  publish-release:
+    # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
+    needs: [create-release, upload-artifacts]
+    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-artifacts.result == 'skipped' || needs.upload-artifacts.result == 'success') }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: mark release as non-draft
+        run: |
+          gh release edit ${{ github.ref_name }} --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,5 +136,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: mark release as non-draft
+        # TODO: Change to --draft=false
         run: |
-          gh release edit ${{ github.ref_name }} --draft=false
+          gh release edit ${{ github.ref_name }} --draft=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,18 +124,3 @@ jobs:
           cat uploads.txt
           gh release upload ${{ github.ref_name }} $(cat uploads.txt)
           echo "uploaded!"
-
-  # Mark the Github Release™ as a non-draft now that everything has succeeded!
-  publish-release:
-    # Only run after all the other tasks, but it's ok if upload-artifacts was skipped
-    needs: [create-release, upload-artifacts]
-    if: ${{ always() && needs.create-release.result == 'success' && (needs.upload-artifacts.result == 'skipped' || needs.upload-artifacts.result == 'success') }}
-    runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: mark release as non-draft
-        # TODO: Change to --draft=false
-        run: |
-          gh release edit ${{ github.ref_name }} --draft=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ This name should be decided amongst the team before the release.
 * [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
 * [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
 
-## (Example release) Topiary v0.2.4: Cyclic Cypress
+## v0.2.4 - Cyclic Cypress
 [0.2.3]: https://github.com/tweag/topiary/compare/v0.2.3...v0.2.4
 
 ### Added
@@ -60,7 +60,7 @@ This name should be decided amongst the team before the release.
 ### Fixed
 * [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
 
-## Topiary v0.2.3: Cyclic Cypress
+## v0.2.3 - Cyclic Cypress
 [0.2.2]: https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3
 
 ### Added
@@ -76,7 +76,7 @@ This name should be decided amongst the team before the release.
 ### Fixed
 * [#522](https://github.com/tweag/topiary/pull/522) Reverted the bump to the OCaml grammar and queries. This bump (for as of yet unknown reasons) had a catastrophic impact on Topiary's performance.
 
-## Topiary v0.2.2: Cyclic Cypress
+## v0.2.2 - Cyclic Cypress
 [0.2.1]: https://github.com/tweag/topiary/compare/v0.2.1...v0.2.2
 
 ### Added
@@ -94,13 +94,13 @@ This name should be decided amongst the team before the release.
  * [#493](https://github.com/tweag/topiary/pull/493) Fixed [#492](https://github.com/tweag/topiary/issues/492) by only trimming newlines in prettyprinting.
  * [#491](https://github.com/tweag/topiary/pull/493) Fixed [#481](https://github.com/tweag/topiary/issues/492), a SIGSEGV in exhaustivity testing.
 
-## Topiary v0.2.1: Cyclic Cypress
+## v0.2.1 - Cyclic Cypress
 [0.2.1]: https://github.com/tweag/topiary/compare/v0.2.0...v0.2.1
 
 ### Fixed
 * Correctly bumped version number in `Cargo.toml`.
 
-## Topiary v0.2.0: Cyclic Cypress
+## v0.2.0 - Cyclic Cypress
 [0.2.0]: https://github.com/tweag/topiary/compare/v0.1.0...v0.2.0
 
 ### Added
@@ -129,7 +129,7 @@ This name should be decided amongst the team before the release.
 * Don't process queries that match below leaf nodes.
 * Skip over zero-byte matched nodes.
 
-## Topiary v0.1.0: Benevolent Beech
+## v0.1.0 - Benevolent Beech
 [0.1.0]: https://github.com/tweag/topiary/compare/v0.0.1-prototype...v0.1.0
 
 This first public release focuses on the Topiary engine and providing
@@ -166,7 +166,7 @@ required to do so.
 * Basic formatter authoring tools (terminal-based playground and tree visualisation)
 * `pre-commit-hooks.nix` support
 
-## Topiary v0.0.1-prototype: Archetypal Aspen
+## v0.0.1-prototype - Archetypal Aspen
 [0.0.1-prototype]: https://github.com/tweag/topiary/releases/tag/v0.0.1-prototype
 
 This prototype release was created exclusively to show the validity of the idea of using Tree-sitter to build a formatter. It includes only a prototype JSON formatter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,22 @@ This name should be decided amongst the team before the release.
 
 ----------------------------------------------------------------------->
 
-## [Unreleased]
-[unreleased]: https://github.com/tweag/topiary/compare/v0.2.3...HEAD
-* [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be indented properly using the new predicate @multi_line_indent_all.
-* [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and convenience functions for using the built-in queries.
-* [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
-* [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
+## [0.2.4] - 2023-06-27
+[0.2.3]: https://github.com/tweag/topiary/compare/v0.2.3...v0.2.4
+
+### Added
+* [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be
+  indented properly using the new predicate @multi_line_indent_all.
+* [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and
+  convenience functions for using the built-in queries.
+
+### Changed
+* [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to
+  0.20.3
+
+### Fixed
+* [#535](https://github.com/tweag/topiary/pull/535) Improved error message when
+  idempotency fails due to invalid output in the first pass.
 
 ## [0.2.3] - 2023-06-20
 [0.2.2]: https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,14 @@ This name should be decided amongst the team before the release.
 
 [Full list of changes](https://github.com/tweag/topiary/compare/v0.2.3...HEAD)
 
-* [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be indented properly using the new predicate @multi_line_indent_all.
+### Added
+* [#538](https://github.com/tweag/topiary/pull/538) Using `cargo-dist` to release Topiary binaries.
 * [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and convenience functions for using the built-in queries.
-* [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
+* [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be indented properly using the new predicate @multi_line_indent_all.
+
+### Changed
 * [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
+* [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
 
 ## v0.2.3 - Cyclic Cypress - 2023-06-20
 
@@ -78,8 +82,8 @@ This name should be decided amongst the team before the release.
  * [#480](https://github.com/tweag/topiary/pull/480) Shows which languages are marked as experimental in the playground.
 
 ### Changed
- * [#490](https://github.com/tweag/topiary/pull/490) Bumped the Nickel grammar.
  * [#494](https://github.com/tweag/topiary/pull/494) Bumped the OCaml grammar, and fixed for the renamed `infix_operator` named node.
+ * [#490](https://github.com/tweag/topiary/pull/490) Bumped the Nickel grammar.
 
 ### Fixed
  * [#493](https://github.com/tweag/topiary/pull/493) Fixed [#492](https://github.com/tweag/topiary/issues/492) by only trimming newlines in prettyprinting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and [`cargo-dist`'s expected
+format](https://opensource.axo.dev/cargo-dist/book/simple-guide.html#release-notes),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!----------------------------------------------------------------------
 The "Unreleased" section should be amended as major changes are merged
@@ -37,7 +40,14 @@ This name should be decided amongst the team before the release.
 
 ----------------------------------------------------------------------->
 
-## [0.2.4] - 2023-06-27
+## [Unreleased]
+[unreleased]: https://github.com/tweag/topiary/compare/v0.2.3...HEAD
+* [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be indented properly using the new predicate @multi_line_indent_all.
+* [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and convenience functions for using the built-in queries.
+* [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
+* [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
+
+## (Example release) Topiary v0.2.4: Cyclic Cypress
 [0.2.3]: https://github.com/tweag/topiary/compare/v0.2.3...v0.2.4
 
 ### Added
@@ -50,7 +60,7 @@ This name should be decided amongst the team before the release.
 ### Fixed
 * [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
 
-## [0.2.3] - 2023-06-20
+## Topiary v0.2.3: Cyclic Cypress
 [0.2.2]: https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3
 
 ### Added
@@ -66,7 +76,7 @@ This name should be decided amongst the team before the release.
 ### Fixed
 * [#522](https://github.com/tweag/topiary/pull/522) Reverted the bump to the OCaml grammar and queries. This bump (for as of yet unknown reasons) had a catastrophic impact on Topiary's performance.
 
-## [0.2.2] - 2023-06-12
+## Topiary v0.2.2: Cyclic Cypress
 [0.2.1]: https://github.com/tweag/topiary/compare/v0.2.1...v0.2.2
 
 ### Added
@@ -84,13 +94,13 @@ This name should be decided amongst the team before the release.
  * [#493](https://github.com/tweag/topiary/pull/493) Fixed [#492](https://github.com/tweag/topiary/issues/492) by only trimming newlines in prettyprinting.
  * [#491](https://github.com/tweag/topiary/pull/493) Fixed [#481](https://github.com/tweag/topiary/issues/492), a SIGSEGV in exhaustivity testing.
 
-## [0.2.1] - 2023-05-23
+## Topiary v0.2.1: Cyclic Cypress
 [0.2.1]: https://github.com/tweag/topiary/compare/v0.2.0...v0.2.1
 
 ### Fixed
 * Correctly bumped version number in `Cargo.toml`.
 
-## [0.2.0]: Cyclic Cypress - 2023-05-22
+## Topiary v0.2.0: Cyclic Cypress
 [0.2.0]: https://github.com/tweag/topiary/compare/v0.1.0...v0.2.0
 
 ### Added
@@ -119,7 +129,7 @@ This name should be decided amongst the team before the release.
 * Don't process queries that match below leaf nodes.
 * Skip over zero-byte matched nodes.
 
-## [0.1.0]: Benevolent Beech - 2023-03-09
+## Topiary v0.1.0: Benevolent Beech
 [0.1.0]: https://github.com/tweag/topiary/compare/v0.0.1-prototype...v0.1.0
 
 This first public release focuses on the Topiary engine and providing
@@ -156,7 +166,7 @@ required to do so.
 * Basic formatter authoring tools (terminal-based playground and tree visualisation)
 * `pre-commit-hooks.nix` support
 
-## [0.0.1-prototype]: Archetypal Aspen - 2022-06-14
+## Topiary v0.0.1-prototype: Archetypal Aspen
 [0.0.1-prototype]: https://github.com/tweag/topiary/releases/tag/v0.0.1-prototype
 
 This prototype release was created exclusively to show the validity of the idea of using Tree-sitter to build a formatter. It includes only a prototype JSON formatter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ This name should be decided amongst the team before the release.
 * [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
 * [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
 
-## v0.2.3 - Cyclic Cypress
+## v0.2.3 - Cyclic Cypress - 2023-06-20
 [0.2.2]: https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3
 
 ### Added
@@ -63,7 +63,7 @@ This name should be decided amongst the team before the release.
 ### Fixed
 * [#522](https://github.com/tweag/topiary/pull/522) Reverted the bump to the OCaml grammar and queries. This bump (for as of yet unknown reasons) had a catastrophic impact on Topiary's performance.
 
-## v0.2.2 - Cyclic Cypress
+## v0.2.2 - Cyclic Cypress - 2023-06-12
 [0.2.1]: https://github.com/tweag/topiary/compare/v0.2.1...v0.2.2
 
 ### Added
@@ -81,13 +81,13 @@ This name should be decided amongst the team before the release.
  * [#493](https://github.com/tweag/topiary/pull/493) Fixed [#492](https://github.com/tweag/topiary/issues/492) by only trimming newlines in prettyprinting.
  * [#491](https://github.com/tweag/topiary/pull/493) Fixed [#481](https://github.com/tweag/topiary/issues/492), a SIGSEGV in exhaustivity testing.
 
-## v0.2.1 - Cyclic Cypress
+## v0.2.1 - Cyclic Cypress - 2023-05-23
 [0.2.1]: https://github.com/tweag/topiary/compare/v0.2.0...v0.2.1
 
 ### Fixed
 * Correctly bumped version number in `Cargo.toml`.
 
-## v0.2.0 - Cyclic Cypress
+## v0.2.0 - Cyclic Cypress - 2023-05-22
 [0.2.0]: https://github.com/tweag/topiary/compare/v0.1.0...v0.2.0
 
 ### Added
@@ -116,7 +116,7 @@ This name should be decided amongst the team before the release.
 * Don't process queries that match below leaf nodes.
 * Skip over zero-byte matched nodes.
 
-## v0.1.0 - Benevolent Beech
+## v0.1.0 - Benevolent Beech - 2023-03-09
 [0.1.0]: https://github.com/tweag/topiary/compare/v0.0.1-prototype...v0.1.0
 
 This first public release focuses on the Topiary engine and providing
@@ -153,7 +153,7 @@ required to do so.
 * Basic formatter authoring tools (terminal-based playground and tree visualisation)
 * `pre-commit-hooks.nix` support
 
-## v0.0.1-prototype - Archetypal Aspen
+## v0.0.1-prototype - Archetypal Aspen - 2022-06-14
 [0.0.1-prototype]: https://github.com/tweag/topiary/releases/tag/v0.0.1-prototype
 
 This prototype release was created exclusively to show the validity of the idea of using Tree-sitter to build a formatter. It includes only a prototype JSON formatter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,19 +47,6 @@ This name should be decided amongst the team before the release.
 * [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
 * [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
 
-## v0.2.4 - Cyclic Cypress
-[0.2.3]: https://github.com/tweag/topiary/compare/v0.2.3...v0.2.4
-
-### Added
-* [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be indented properly using the new predicate @multi_line_indent_all.
-* [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and convenience functions for using the built-in queries.
-
-### Changed
-* [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
-
-### Fixed
-* [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
-
 ## v0.2.3 - Cyclic Cypress
 [0.2.2]: https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,15 +40,18 @@ This name should be decided amongst the team before the release.
 
 ----------------------------------------------------------------------->
 
-## [Unreleased]
-[unreleased]: https://github.com/tweag/topiary/compare/v0.2.3...HEAD
+## Unreleased
+
+[Full list of changes](https://github.com/tweag/topiary/compare/v0.2.3...HEAD)
+
 * [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be indented properly using the new predicate @multi_line_indent_all.
 * [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and convenience functions for using the built-in queries.
 * [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
 * [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
 
 ## v0.2.3 - Cyclic Cypress - 2023-06-20
-[0.2.2]: https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3
+
+[Full list of changes](https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3)
 
 ### Added
 * [#513](https://github.com/tweag/topiary/pull/513) Added the `-t, --tolerate-parsing-errors` flags to Topiary, `tolerate_parsing_errors` to the `Format` operation of the library, and a "Tolerate parsing errors" checkmark to the playground. These options make Topiary ignore errors in the parsed file, and attempt to format it.
@@ -64,7 +67,8 @@ This name should be decided amongst the team before the release.
 * [#522](https://github.com/tweag/topiary/pull/522) Reverted the bump to the OCaml grammar and queries. This bump (for as of yet unknown reasons) had a catastrophic impact on Topiary's performance.
 
 ## v0.2.2 - Cyclic Cypress - 2023-06-12
-[0.2.1]: https://github.com/tweag/topiary/compare/v0.2.1...v0.2.2
+
+[Full list of changes](https://github.com/tweag/topiary/compare/v0.2.1...v0.2.2)
 
 ### Added
  * [#498](https://github.com/tweag/topiary/pull/498) Updated the playground to include a nicer editor.
@@ -82,13 +86,15 @@ This name should be decided amongst the team before the release.
  * [#491](https://github.com/tweag/topiary/pull/493) Fixed [#481](https://github.com/tweag/topiary/issues/492), a SIGSEGV in exhaustivity testing.
 
 ## v0.2.1 - Cyclic Cypress - 2023-05-23
-[0.2.1]: https://github.com/tweag/topiary/compare/v0.2.0...v0.2.1
+
+[Full list of changes](https://github.com/tweag/topiary/compare/v0.2.0...v0.2.1)
 
 ### Fixed
 * Correctly bumped version number in `Cargo.toml`.
 
 ## v0.2.0 - Cyclic Cypress - 2023-05-22
-[0.2.0]: https://github.com/tweag/topiary/compare/v0.1.0...v0.2.0
+
+[Full list of changes](https://github.com/tweag/topiary/compare/v0.1.0...v0.2.0)
 
 ### Added
 * Topiary [website](https://topiary.tweag.io), web-based [playground](https://topiary.tweag.io/playground) and logos.
@@ -117,7 +123,8 @@ This name should be decided amongst the team before the release.
 * Skip over zero-byte matched nodes.
 
 ## v0.1.0 - Benevolent Beech - 2023-03-09
-[0.1.0]: https://github.com/tweag/topiary/compare/v0.0.1-prototype...v0.1.0
+
+[Full list of changes](https://github.com/tweag/topiary/compare/v0.0.1-prototype...v0.1.0)
 
 This first public release focuses on the Topiary engine and providing
 decent OCaml formatting support, with the formatting capture names
@@ -154,6 +161,7 @@ required to do so.
 * `pre-commit-hooks.nix` support
 
 ## v0.0.1-prototype - Archetypal Aspen - 2022-06-14
-[0.0.1-prototype]: https://github.com/tweag/topiary/releases/tag/v0.0.1-prototype
+
+[Full list of changes](https://github.com/tweag/topiary/releases/tag/v0.0.1-prototype)
 
 This prototype release was created exclusively to show the validity of the idea of using Tree-sitter to build a formatter. It includes only a prototype JSON formatter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,48 +41,30 @@ This name should be decided amongst the team before the release.
 [0.2.3]: https://github.com/tweag/topiary/compare/v0.2.3...v0.2.4
 
 ### Added
-* [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be
-  indented properly using the new predicate @multi_line_indent_all.
-* [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and
-  convenience functions for using the built-in queries.
+* [#526](https://github.com/tweag/topiary/pull/526) Multi-line comments can be indented properly using the new predicate @multi_line_indent_all.
+* [#528](https://github.com/tweag/topiary/pull/528) Added a sample app and convenience functions for using the built-in queries.
 
 ### Changed
-* [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to
-  0.20.3
+* [#533](https://github.com/tweag/topiary/pull/533) Update tree-sitter-ocaml to 0.20.3
 
 ### Fixed
-* [#535](https://github.com/tweag/topiary/pull/535) Improved error message when
-  idempotency fails due to invalid output in the first pass.
+* [#535](https://github.com/tweag/topiary/pull/535) Improved error message when idempotency fails due to invalid output in the first pass.
 
 ## [0.2.3] - 2023-06-20
 [0.2.2]: https://github.com/tweag/topiary/compare/v0.2.2...v0.2.3
 
 ### Added
-* [#513](https://github.com/tweag/topiary/pull/513) Added the `-t, --tolerate-
- parsing-errors` flags to Topiary, `tolerate_parsing_errors` to the `Format`
- operation of the library, and a "Tolerate parsing errors" checkmark to the
- playground. These options make Topiary ignore errors in the parsed file, and
- attempt to format it.
-* [#506](https://github.com/tweag/topiary/pull/506) Allows the users to
- configure Topiary through a user-defined configuration file. More information
- can be found in the `README.md`.
+* [#513](https://github.com/tweag/topiary/pull/513) Added the `-t, --tolerate-parsing-errors` flags to Topiary, `tolerate_parsing_errors` to the `Format` operation of the library, and a "Tolerate parsing errors" checkmark to the playground. These options make Topiary ignore errors in the parsed file, and attempt to format it.
+* [#506](https://github.com/tweag/topiary/pull/506) Allows the users to configure Topiary through a user-defined configuration file. More information can be found in the `README.md`.
 
 ### Changed
-* [#523](https://github.com/tweag/topiary/pull/523) Skips rebuilding the tree-
-  sitter `Query` when performing the idempotence check. This improves performance
-  when not skipping the idempotence check by about `35%` for OCaml formatting.
+* [#523](https://github.com/tweag/topiary/pull/523) Skips rebuilding the tree-sitter `Query` when performing the idempotence check. This improves performance when not skipping the idempotence check by about `35%` for OCaml formatting.
 
 ### Removed
-* [#508](https://github.com/tweag/topiary/pull/508) Simplified language
-  detection by treating `ocaml` and `ocaml_interface` as two distinct languages.
-  This ensures we only have one grammar per language. This
-  removed the `-l ocaml_implementation` flag from Topiary and the
-  `SupportedLanguage::OcamlImplementation` from the library.
+* [#508](https://github.com/tweag/topiary/pull/508) Simplified language detection by treating `ocaml` and `ocaml_interface` as two distinct languages. This ensures we only have one grammar per language. This removed the `-l ocaml_implementation` flag from Topiary and the `SupportedLanguage::OcamlImplementation` from the library.
 
 ### Fixed
-* [#522](https://github.com/tweag/topiary/pull/522) Reverted the bump to the
- OCaml grammar and queries. This bump (for as of yet unknown reasons) had a
- catastrophic impact on Topiary's performance.
+* [#522](https://github.com/tweag/topiary/pull/522) Reverted the bump to the OCaml grammar and queries. This bump (for as of yet unknown reasons) had a catastrophic impact on Topiary's performance.
 
 ## [0.2.2] - 2023-06-12
 [0.2.1]: https://github.com/tweag/topiary/compare/v0.2.1...v0.2.2
@@ -99,10 +81,8 @@ This name should be decided amongst the team before the release.
  * [#494](https://github.com/tweag/topiary/pull/494) Bumped the OCaml grammar, and fixed for the renamed `infix_operator` named node.
 
 ### Fixed
- * [#493](https://github.com/tweag/topiary/pull/493) Fixed
-   [#492](https://github.com/tweag/topiary/issues/492) by only trimming newlines in prettyprinting.
- * [#491](https://github.com/tweag/topiary/pull/493) Fixed
-   [#481](https://github.com/tweag/topiary/issues/492), a SIGSEGV in exhaustivity testing.
+ * [#493](https://github.com/tweag/topiary/pull/493) Fixed [#492](https://github.com/tweag/topiary/issues/492) by only trimming newlines in prettyprinting.
+ * [#491](https://github.com/tweag/topiary/pull/493) Fixed [#481](https://github.com/tweag/topiary/issues/492), a SIGSEGV in exhaustivity testing.
 
 ## [0.2.1] - 2023-05-23
 [0.2.1]: https://github.com/tweag/topiary/compare/v0.2.0...v0.2.1
@@ -114,8 +94,7 @@ This name should be decided amongst the team before the release.
 [0.2.0]: https://github.com/tweag/topiary/compare/v0.1.0...v0.2.0
 
 ### Added
-* Topiary [website](https://topiary.tweag.io), web-based
-  [playground](https://topiary.tweag.io/playground) and logos.
+* Topiary [website](https://topiary.tweag.io), web-based [playground](https://topiary.tweag.io/playground) and logos.
 * Full Nickel formatting support.
 * Improved OCaml formatting support.
 * `@append_antispace` and `@prepend_antispace` formatting capture names.
@@ -125,10 +104,8 @@ This name should be decided amongst the team before the release.
 * Maintain a CHANGELOG and a documented release process.
 
 ### Changed
-* Move to a build configuration file, rather than a mixture of
-  hardcoding and parsing query predicates at runtime.
-* Conditional predicates, in the query language, to reduce the number of
-  formatting capture names.
+* Move to a build configuration file, rather than a mixture of hardcoding and parsing query predicates at runtime.
+* Conditional predicates, in the query language, to reduce the number of formatting capture names.
 * Higher fidelity exit codes.
 * Idempotency check in terminal-based playground.
 * Reduced verbosity of failed integration test output.
@@ -182,6 +159,4 @@ required to do so.
 ## [0.0.1-prototype]: Archetypal Aspen - 2022-06-14
 [0.0.1-prototype]: https://github.com/tweag/topiary/releases/tag/v0.0.1-prototype
 
-This prototype release was created exclusively to show the validity of
-the idea of using Tree-sitter to build a formatter. It includes only a
-prototype JSON formatter.
+This prototype release was created exclusively to show the validity of the idea of using Tree-sitter to build a formatter. It includes only a prototype JSON formatter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,6 @@ required to do so.
 
 ## v0.0.1-prototype - Archetypal Aspen - 2022-06-14
 
-[Full list of changes](https://github.com/tweag/topiary/releases/tag/v0.0.1-prototype)
+[Full list of changes](https://github.com/tweag/topiary/compare/03e1fc8...v0.0.1-prototype)
 
 This prototype release was created exclusively to show the validity of the idea of using Tree-sitter to build a formatter. It includes only a prototype JSON formatter.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "topiary"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap 4.3.3",
  "criterion",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "assert_cmd",
  "clap 4.3.3",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-playground"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cfg-if",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "topiary"
-version = "0.2.4"
+version = "0.2.3"
 dependencies = [
  "clap 4.3.3",
  "criterion",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-cli"
-version = "0.2.4"
+version = "0.2.3"
 dependencies = [
  "assert_cmd",
  "clap 4.3.3",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-playground"
-version = "0.2.4"
+version = "0.2.3"
 dependencies = [
  "cfg-if",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ exclude = ["samples"]
 lto = true
 opt-level = 's'
 
+# The profile that 'cargo dist' will build with
+[profile.dist]
+inherits = "release"
+lto = "thin"
+
 [workspace.dependencies]
 assert_cmd = "2.0"
 cfg-if = "1.0.0"
@@ -49,3 +54,16 @@ unescape = "0.1"
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", default-features = false, package = "web-tree-sitter-sys" }
+
+# Config for 'cargo dist'
+[workspace.metadata.dist]
+# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.0.7"
+# The preferred Rust toolchain to use in CI (rustup toolchain syntax)
+rust-toolchain-version = "1.67.1"
+# CI backends to support (see 'cargo dist generate-ci')
+ci = ["github"]
+# The installers to generate for each app
+installers = ["shell", "powershell"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.4"
+version = "0.2.3"
 edition = "2021"
 authors = ["Tweag"]
 homepage = "https://topiary.tweag.io"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,19 @@ opt-level = 's'
 inherits = "release"
 lto = "thin"
 
+# Config for 'cargo dist'
+[workspace.metadata.dist]
+# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.0.7"
+# The preferred Rust toolchain to use in CI (rustup toolchain syntax)
+rust-toolchain-version = "1.67.1"
+# CI backends to support (see 'cargo dist generate-ci')
+ci = ["github"]
+# The installers to generate for each app
+installers = ["shell", "powershell"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+
 [workspace.dependencies]
 assert_cmd = "2.0"
 cfg-if = "1.0.0"
@@ -54,16 +67,3 @@ unescape = "0.1"
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 web-tree-sitter = { git = "https://github.com/tweag/web-tree-sitter-sys", default-features = false, package = "web-tree-sitter-sys" }
-
-# Config for 'cargo dist'
-[workspace.metadata.dist]
-# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.0.7"
-# The preferred Rust toolchain to use in CI (rustup toolchain syntax)
-rust-toolchain-version = "1.67.1"
-# CI backends to support (see 'cargo dist generate-ci')
-ci = ["github"]
-# The installers to generate for each app
-installers = ["shell", "powershell"]
-# Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Tweag"]
 homepage = "https://topiary.tweag.io"

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -76,6 +76,6 @@ fetch, overriding the low default. As of writing, there's no way to set
 this to "unlimited"; adjust as necessary.
 
 <!-- Links -->
-[changelog]: /changelog.md
+[changelog]: /CHANGELOG.md
 [changelog-refresh]: #generating-the-pr-list-for-the-changelog
 [releases]: https://github.com/tweag/topiary/releases

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -35,10 +35,10 @@
     ```
 
 * Let `cargo dist` create a new [draft release][releases].
-  * Update the release title to `Topiary v<RELEASE>`, or `Topiary
-    v<RELEASE>: <NAME>` for point releases.
-  * Verify the [CHANGELOG] contents.
-  * Publish.
+  * Verify the release.
+  * Publish the draft release.
+  * If all went well, consider if we should let [CI publish the draft
+    automatically][auto-publish].
 
 * Publicise.
 
@@ -79,3 +79,4 @@ this to "unlimited"; adjust as necessary.
 [changelog]: /CHANGELOG.md
 [changelog-refresh]: #generating-the-pr-list-for-the-changelog
 [releases]: https://github.com/tweag/topiary/releases
+[auto-publish]: https://github.com/tweag/topiary/pull/538/commits/230d7bc662a042188c79d586472c4e8632ffd6a9

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,9 @@
   * Retitle the "Unreleased" section to this release and create a fresh
     "Unreleased" section (see comments in the [CHANGELOG] for details).
 
+    Do not wrap bullet points in multiple lines. GitHub will use those line
+    breaks in the Release Notes display.
+
     :bulb: Point releases (i.e., not patch releases) should also be
     given a name, taking the form `ADJECTIVE TREE`, incrementing
     alphabetically. This name should be decided amongst the team before
@@ -21,15 +24,20 @@
   * Commit and merge (squash, if necessary) on green CI and peer
     approval.
 
-  * Tag the merged commit with the release version, prefixed with a `v`
-    (e.g., `v1.0.0`).
+  * Tag the merged commit with the release version, prefixed with a `v` (e.g.,
+    `v0.1.0`). The version number must match the one in `Cargo.toml`, otherwise
+    `cargo dist` will fail during CI.
 
-* [Draft a new release][draft-release] in GitHub.
-  * Set the tag to that created in the previous step, now on `main`.
-  * Set the release title to `Topiary v<RELEASE>`, or `Topiary
+    ```bash
+    git tag "v0.1.0"
+    git push
+    git push --tags
+    ```
+
+* Let `cargo dist` create a new [draft release][releases].
+  * Update the release title to `Topiary v<RELEASE>`, or `Topiary
     v<RELEASE>: <NAME>` for point releases.
-  * Copy-and-paste the [CHANGELOG] contents for this release
-    into the description.
+  * Verify the [CHANGELOG] contents.
   * Publish.
 
 * Publicise.
@@ -70,4 +78,4 @@ this to "unlimited"; adjust as necessary.
 <!-- Links -->
 [changelog]: /changelog.md
 [changelog-refresh]: #generating-the-pr-list-for-the-changelog
-[draft-release]: https://github.com/tweag/topiary/releases/new
+[releases]: https://github.com/tweag/topiary/releases


### PR DESCRIPTION
Fixes #415.

CI will automatically cut a release like this when pushing a new version tag.

![image](https://github.com/tweag/topiary/assets/55164/f4d53c7f-e4a2-49e5-8292-4285843f65fb)

