### PR TITLE
Fix Nickel quoted_enum_tag formatting by considering it a leaf

### DIFF
--- a/topiary/languages/nickel.scm
+++ b/topiary/languages/nickel.scm
@@ -6,6 +6,7 @@
   (str_chunks_single)
   (str_chunks_multi)
   (builtin)
+  (quoted_enum_tag)
 ] @leaf
 
 ; Allow a blank line before the following nodes

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -1211,6 +1211,8 @@
   },
 
   enum = {
+    quotedEnum = '"QuotedEnum",
+
     Tag
       | doc m%"
           Contract to enforce the value is an enum tag.

--- a/topiary/tests/samples/input/nickel.ncl
+++ b/topiary/tests/samples/input/nickel.ncl
@@ -1214,6 +1214,8 @@
   },
 
   enum = {
+    quotedEnum =  '"QuotedEnum" ,
+
     Tag
       | doc m%"
           Contract to enforce the value is an enum tag.


### PR DESCRIPTION
Mentioned in #547 but doesn't resolve all of it.

From #547:
> When parsing a `quoted_enum_tag`, `tree-sitter-nickel` defers to its scanner. The scanner produces a `quoted_enum_tag_start`, which is taken by Topiary and produced correctly. The parser then produces a `chunk_literal_single` containing only the contents of the following string. I.e. the last quote ending the string is completely dropped by `tree-sitter-nickel`.