### PR TITLE
Nickel: Start infix-chains also for annotated infix_expr

### DIFF
--- a/topiary/languages/nickel.scm
+++ b/topiary/languages/nickel.scm
@@ -118,7 +118,10 @@
 ; operators, which fall under nodes (infix_b_op_7) and (infix_b_op_8).
 (uni_term
   (#scope_id! "infix_chain")
-  (infix_expr) @begin_scope
+  [
+    (infix_expr)
+    (annotated_infix_expr)
+  ] @begin_scope
 ) @end_scope
 
 (infix_expr

--- a/topiary/src/atom_collection.rs
+++ b/topiary/src/atom_collection.rs
@@ -378,11 +378,16 @@ impl AtomCollection {
                 // in its place.
                 let swapped_atom = mem::take(atom);
 
-                log::debug!("Applying prepend of {prepends:?} to {atom:?}.");
+                if !prepends.is_empty() {
+                    log::debug!("Applying prepend of {prepends:?} to {:?}.", &swapped_atom);
+                }
+                if !appends.is_empty() {
+                    log::debug!("Applying append of {appends:?} to {:?}.", &swapped_atom);
+                }
+
                 expanded.append(prepends);
                 expanded.push(swapped_atom);
 
-                log::debug!("Applying append of {appends:?} to {atom:?}.");
                 expanded.append(appends);
             } else {
                 log::debug!("Not a leaf: {atom:?}");


### PR DESCRIPTION
This resolves part of #547, in particular the issue investigated by @torhovland.

```
[
  a && (b & c | d),
  a &&
  (b & c | d),
  a &&
  (b &
  c | d)
]
```
Get correctly formatted as:
```
[
  a && (b & c | d),
  a
  && (b & c | d),
  a
  && (
    b
    & c | d
  )
]
```
@torhovland's reasoning was correct, there was a scoping issue. The scope was started by the `[`, ending after the infix expression. Since the `[` was on a previous line, the entire expression was considered to be multi-line, and thus expanded as such. The scope was started there (and not on the next line) because that line was considered a `annotated_infix_expr` instead of an `infix_expr` which we did not include in our query to start the scope.