### PR TITLE
Nickel: Resolve annotation idempotency

### DIFF
--- a/topiary/languages/nickel.scm
+++ b/topiary/languages/nickel.scm
@@ -264,10 +264,26 @@
   (annot) @prepend_indent_start
 ) @append_indent_end
 
+; Start a scope from the node previous to the annotations.
+; This properly checks if the annotations were intended to be
+; on newlines in such cases as:
+; id
+;   | a -> a
+; which, without the annotations scope, would consider the annotations to be a
+; single line node and format it as such:
+; id | a -> a
+(
+  (#scope_id! "annotations")
+  (_) @begin_scope
+  .
+  (annot) @end_scope
+)
+
 ; Put each annotation -- and the equals sign, if it follows annotations
 ; -- on a new line, in a multi-line context.
 (annot
-  (annot_atom) @prepend_spaced_softline
+  (#scope_id! "annotations")
+  (annot_atom) @prepend_spaced_scoped_softline
 )
 
 (

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -2435,5 +2435,8 @@
       ```
       "%
       = fun s => %enum_from_str% s,
-  }
+  },
+
+  id
+    | a -> a,
 }

--- a/topiary/tests/samples/input/nickel.ncl
+++ b/topiary/tests/samples/input/nickel.ncl
@@ -2425,5 +2425,8 @@
       ```
       "%
       = fun s => %enum_from_str% s,
-  }
+  },
+
+  id |
+    a -> a,
 }


### PR DESCRIPTION
Done by starting a scope on the previous node instead of on the first annotation.This ensures that a single line annotation that was clearly put on a newline on purpose is actually formatted as such. This is the final PR in a series that fully resolves #547 (with the exception of the parsing error, which is currently being discussed in the Nickel team). 