### PR TITLE
Append scope to node before annotation

### DIFF
--- a/topiary/languages/nickel.scm
+++ b/topiary/languages/nickel.scm
@@ -274,7 +274,7 @@
 ; id | a -> a
 (
   (#scope_id! "annotations")
-  (_) @prepend_begin_scope
+  (_) @append_begin_scope
   .
   (annot) @append_end_scope
 )

--- a/topiary/tests/samples/expected/nickel.ncl
+++ b/topiary/tests/samples/expected/nickel.ncl
@@ -10,6 +10,18 @@
       id
         | a -> a
     },
+    #571
+    {
+      b =
+        {
+          kind = 'ReplicationController,
+        } | KubernetesConfig,
+      c =
+        {
+          kind = 'ReplicationController,
+        }
+          | KubernetesConfig
+    },
 
     # Interpolated record operation chains (in
     # a multi-line comment)

--- a/topiary/tests/samples/input/nickel.ncl
+++ b/topiary/tests/samples/input/nickel.ncl
@@ -10,6 +10,16 @@
       id |
         a -> a
     },
+    #571
+    {
+      b = {
+        kind = 'ReplicationController,
+      } | KubernetesConfig,
+      c = {
+        kind = 'ReplicationController,
+      }
+      | KubernetesConfig
+    },
 
 # Interpolated record operation chains (in
 # a multi-line comment)


### PR DESCRIPTION
Resolves #571 by only checking if the annotation itself started on a new line rather than the entire node before it.