### PR TITLE
Ignore pre-commit config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 /.envrc
 /.direnv
 *.profraw
+.pre-commit-config.yaml


### PR DESCRIPTION
Lets everybody add their own pre-commit config to their local working copy. For example:

```
# See https://pre-commit.com for more information
# See https://pre-commit.com/hooks.html for more hooks
repos:
-   repo: https://github.com/pre-commit/pre-commit-hooks
    rev: v4.4.0
    hooks:
    -   id: check-added-large-files
    -   id: check-case-conflict
    -   id: check-executables-have-shebangs
    -   id: check-merge-conflict
    -   id: check-toml
    -   id: check-xml
    -   id: check-yaml
    -   id: destroyed-symlinks
    -   id: detect-private-key
    -   id: end-of-file-fixer
    -   id: mixed-line-ending
    -   id: trailing-whitespace

-   repo: https://github.com/python-jsonschema/check-jsonschema
    rev: 0.23.3
    hooks:
    -   id: check-github-actions
```
