### PR TITLE
Consider `quoted_key` as a leaf

### DIFF
--- a/topiary/languages/toml.scm
+++ b/topiary/languages/toml.scm
@@ -1,7 +1,10 @@
 ; Sometimes we want to indicate that certain parts of our source text should
 ; not be formatted, but taken as is. We use the leaf capture name to inform the
 ; tool of this.
-(string) @leaf
+[
+  (string)
+  (quoted_key)
+] @leaf
 
 ; Allow blank line before
 [

--- a/topiary/languages/toml.scm
+++ b/topiary/languages/toml.scm
@@ -28,7 +28,7 @@
 )
 
 (table
-  [(bare_key) (dotted_key)]
+  [(bare_key) (dotted_key) (quoted_key)]
   .
   "]" @append_hardline
 )

--- a/topiary/tests/samples/expected/toml.toml
+++ b/topiary/tests/samples/expected/toml.toml
@@ -64,3 +64,7 @@ hosts = [
   "alpha",
   "omega"
 ]
+
+# Issue 621
+[dog."tater.man"]
+type.name = "pug"

--- a/topiary/tests/samples/expected/toml.toml
+++ b/topiary/tests/samples/expected/toml.toml
@@ -68,3 +68,10 @@ hosts = [
 # Issue 621
 [dog."tater.man"]
 type.name = "pug"
+
+["zip"]
+cve = [
+  "CVE-2018-13410",
+  # total garbage CVE.
+]
+comment = "this cve is only valid with attacker-controlled flags to zip"

--- a/topiary/tests/samples/input/toml.toml
+++ b/topiary/tests/samples/input/toml.toml
@@ -68,3 +68,6 @@ hosts = [
   "omega"
 ]
 
+# Issue 621
+[dog."tater.man"]
+type.name = "pug"

--- a/topiary/tests/samples/input/toml.toml
+++ b/topiary/tests/samples/input/toml.toml
@@ -71,3 +71,9 @@ hosts = [
 # Issue 621
 [dog."tater.man"]
 type.name = "pug"
+
+["zip"]
+cve = [
+  "CVE-2018-13410",  # total garbage CVE.
+]
+comment = "this cve is only valid with attacker-controlled flags to zip"


### PR DESCRIPTION
This prevents the deletion of the containing anonymous nodes.

Before, this:
```toml
[dog."tater.man"]
type.name = "pug"
```
was formatted to
```toml
[dog.""]
type.name = "pug"
```
After, it is formatted to:
```toml
[dog."tater.man"]
type.name = "pug"
```

Solves #621