### PR TITLE
toml: allow inline comments in multiline arrays

### DIFF
--- a/topiary/languages/toml.scm
+++ b/topiary/languages/toml.scm
@@ -52,9 +52,11 @@
 
 ; Softlines. These become either a space or a newline, depending on whether we
 ; format their node as single-line or multi-line.
-[
-  ","
-] @append_spaced_softline
+(
+  "," @append_spaced_softline
+  .
+  (comment)? @do_nothing
+)
 
 ; Indent arrays. They will only be indented inmulti-line blocks.
 

--- a/topiary/tests/samples/expected/toml.toml
+++ b/topiary/tests/samples/expected/toml.toml
@@ -82,6 +82,14 @@ cve = [ "CVE-2018-13410", "foo", "CVE-2018-1340" ]
 
 comment = "this cve is only valid with attacker-controlled flags to zip"
 
+["inline.comments"]
+multiline_with_comments = [
+  "bar",
+  "blee",
+  "baz", # dont
+  "boo"
+]
+
 [dog."tater.man"]
 type.name = "pug"
 type."speed.mph" = 300

--- a/topiary/tests/samples/input/toml.toml
+++ b/topiary/tests/samples/input/toml.toml
@@ -83,6 +83,11 @@ cve = ["CVE-2018-13410",
 
 comment = "this cve is only valid with attacker-controlled flags to zip"
 
+["inline.comments"]
+multiline_with_comments = ["bar","blee",
+"baz",         # dont
+"boo"
+]
 
 [dog."tater.man"]
 type.name = "pug"


### PR DESCRIPTION
previously, if you had comments on individual items in a multiline
array, e.g.

```toml
children = [
  "michael",
  "gob", # i don't care too much for this one
  "lindsay",
]
```

topiary would confusingly move the comment _below_ the element it was
placed next to-

```toml
children = [
  "michael",
  "gob",
  # i don't care too much for this one
  "lindsay",
]
```
which can destroy the intent of the comment. this rule update now
preserves inline comments and won't insert a linebreak after a separator
if followed by one.
