### PR TITLE
toml: enforce final (oxford) comma in multiline arrays, remove from singleline arrays

### DIFF
--- a/topiary/languages/toml.scm
+++ b/topiary/languages/toml.scm
@@ -58,6 +58,17 @@
   (comment)? @do_nothing
 )
 
+; remove trailing comma from last element of single line array
+(array
+  ("," @delete . "]")(#single_line_only!)
+)
+
+; add trailing comma if absent to last string of multiline array
+(array
+  (((string) @append_delimiter) . ","* @do_nothing . (comment)? . "]")(#delimiter! ",")
+  (#multi_line_only!)
+)
+
 ; Indent arrays. They will only be indented inmulti-line blocks.
 
 (array

--- a/topiary/tests/samples/expected/toml.toml
+++ b/topiary/tests/samples/expected/toml.toml
@@ -66,7 +66,7 @@ hosts = [
   # Multi-
   # line comment
   "alpha",
-  "omega"
+  "omega",
 ]
 
 ["zip"]
@@ -76,18 +76,24 @@ comment = "this cve is only valid with attacker-controlled flags to zip"
 ["unzip"]
 cve = [
   "CVE-2018-13410",
-  "CVE-2018-1340"
+  "CVE-2018-1340",
 ]
 cve = [ "CVE-2018-13410", "foo", "CVE-2018-1340" ]
 
 comment = "this cve is only valid with attacker-controlled flags to zip"
 
 ["inline.comments"]
+singleline_remove_trailing_comma = [ "foo", "bar", "baz" ]
 multiline_with_comments = [
   "bar",
   "blee",
   "baz", # dont
-  "boo"
+  "boo", #do
+]
+multiline_comma_comment = [
+  "first",
+  "next",
+  "last", # best
 ]
 
 [dog."tater.man"]

--- a/topiary/tests/samples/input/toml.toml
+++ b/topiary/tests/samples/input/toml.toml
@@ -84,9 +84,15 @@ cve = ["CVE-2018-13410",
 comment = "this cve is only valid with attacker-controlled flags to zip"
 
 ["inline.comments"]
+singleline_remove_trailing_comma = [ "foo","bar","baz" ,     ]
 multiline_with_comments = ["bar","blee",
 "baz",         # dont
-"boo"
+"boo" #do
+]
+multiline_comma_comment = [
+    "first",
+    "next",
+    "last", # best
 ]
 
 [dog."tater.man"]


### PR DESCRIPTION
this is more a preference, but it comes from a learned (python)
annoyance- if you want to keep a set of things in sorted order, then
every time the last item changes you have to go in and pick around the
commas. in python it's a lot worse due to implicit string coercion,
this is thankfully just illegal in toml, but still feels a good move for
consistency and ease of sorting.
