### PR TITLE
[ocaml] Allow blank lines between recursive type definitions

### DIFF
--- a/topiary/languages/ocaml.scm
+++ b/topiary/languages/ocaml.scm
@@ -70,6 +70,12 @@
   (let_and_operator) @allow_blank_line_before
 )
 
+; In a definition including several mutually recursive types,
+; one can skip a line before each of them.
+(type_definition
+  "and" @allow_blank_line_before
+)
+
 ; Append line breaks. If there is a comment following, we don't add anything,
 ; because the input softlines and spaces above will already have sorted out the
 ; formatting.

--- a/topiary/tests/samples/expected/ocaml-interface.mli
+++ b/topiary/tests/samples/expected/ocaml-interface.mli
@@ -4590,16 +4590,19 @@ type 'kind operation = {
   shell: Operation.shell_header;
   protocol_data: 'kind protocol_data;
 }
+
 and 'kind protocol_data = {
   contents: 'kind contents_list;
   signature: signature option;
 }
+
 and _ contents_list =
   | Single : 'kind contents -> 'kind contents_list
   | Cons :
     'kind Kind.manager contents
     * 'rest Kind.manager contents_list ->
       ('kind * 'rest) Kind.manager contents_list
+
 and _ contents =
   | Preendorsement : consensus_content -> Kind.preendorsement contents
   | Endorsement : consensus_content -> Kind.endorsement contents
@@ -4672,6 +4675,7 @@ and _ contents =
       storage_limit: Z.t;
     } ->
       'kind Kind.manager contents
+
 and _ manager_operation =
   | Reveal : public_key -> Kind.reveal manager_operation
   | Transaction :

--- a/topiary/tests/samples/expected/ocaml.ml
+++ b/topiary/tests/samples/expected/ocaml.ml
@@ -677,6 +677,10 @@ let [1; snd] = [1; 2]
 type a = int
 and b = float
 
+type a = int
+
+and b = float
+
 (* Messing around with quoted strings and curly brackets *)
 type string_record = { my_string: string; }
 let quoted_string =

--- a/topiary/tests/samples/input/ocaml.ml
+++ b/topiary/tests/samples/input/ocaml.ml
@@ -655,6 +655,10 @@ let [1; snd] = [1; 2]
 type a = int and
 b = float
 
+type a = int
+
+and b = float
+
 (* Messing around with quoted strings and curly brackets *)
 type string_record = { my_string: string; }
 let quoted_string =


### PR DESCRIPTION
Closes #532