### PR TITLE
Update tree-sitter-nickel to latest grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,8 +1440,8 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-nickel"
-version = "0.0.1"
-source = "git+https://github.com/nickel-lang/tree-sitter-nickel?rev=b1a4718601ebd29a62bf3a7fd1069a99ccf48093#b1a4718601ebd29a62bf3a7fd1069a99ccf48093"
+version = "0.1.0"
+source = "git+https://github.com/nickel-lang/tree-sitter-nickel?rev=091b5dcc7d138901bcc162da9409c0bb626c0d27#091b5dcc7d138901bcc162da9409c0bb626c0d27"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ toml = "0.7"
 tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash" }
 tree-sitter-facade = { git = "https://github.com/tweag/tree-sitter-facade" }
 tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json.git" }
-tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "b1a4718601ebd29a62bf3a7fd1069a99ccf48093" }
+tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "091b5dcc7d138901bcc162da9409c0bb626c0d27" }
 tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml.git" }
 tree-sitter-ocamllex = { git = "https://github.com/314eter/tree-sitter-ocamllex.git" }
 tree-sitter-query = { git = "https://github.com/nvim-treesitter/tree-sitter-query" }


### PR DESCRIPTION
Nickel's grammar was updated to correctly handle the curried dot operator (.) a few weeks ago, and ideally, I `nickel format` should be fixed for the upcoming 1.4 release, which requires Topiary to be updated to use the latest Nickel grammar.