### PR TITLE
TOML fixes + formatting our own files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [workspace]
 members = ["topiary-core", "topiary-cli", "topiary-queries", "topiary-playground", "topiary-config", "topiary-web-tree-sitter-sys", "topiary-tree-sitter-facade"]
-default-members = [ "topiary-core", "topiary-cli" ]
+default-members = ["topiary-core", "topiary-cli"]
 exclude = ["samples"]
 resolver = "2"
 
@@ -39,7 +39,7 @@ targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows
 [workspace.dependencies]
 assert_cmd = "2.0"
 async-scoped = { version = "0.7.1", features = ["use-tokio"] }
-clap = { version = "4.3", features = [ "env" ] }
+clap = { version = "4.3", features = ["env"] }
 clap_derive = "4.3"
 clap_complete = "4.4"
 criterion = "0.5"

--- a/topiary-cli/Cargo.toml
+++ b/topiary-cli/Cargo.toml
@@ -3,12 +3,12 @@ name = "topiary-cli"
 description = "CLI app for Topiary, the universal code formatter."
 categories = ["command-line-utilities", "development-tools", "text-processing"]
 keywords = [
-    "cli",
-    "code-formatter",
-    "formatter",
-    "text",
-    "tree-sitter",
-    "utility",
+  "cli",
+  "code-formatter",
+  "formatter",
+  "text",
+  "tree-sitter",
+  "utility",
 ]
 version.workspace = true
 edition.workspace = true

--- a/topiary-cli/tests/samples/expected/toml.toml
+++ b/topiary-cli/tests/samples/expected/toml.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 # For now we just load the tree-sitter language parsers statically.
 # Eventually we will want to dynamically load them, like Helix does.
-clap = { version = "3.2", features = [ "derive" ] }
+clap = { version = "3.2", features = ["derive"] }
 env_logger = "0.9"
 itertools = "0.10"
 log = "0.4"
@@ -43,7 +43,7 @@ dob = 1979-05-27T07:32:00-08:00 # First class dates
 
 [database]
 server = "192.168.1.1"
-ports = [ 8001, 8001, 8002 ]
+ports = [8001, 8001, 8002]
 connection_max = 5000
 enabled = true
 
@@ -59,7 +59,7 @@ ip = "10.0.0.2"
 dc = "eqdc10"
 
 [clients]
-data = [ [ "gamma", "delta" ], [ 1, 2 ] ]
+data = [["gamma", "delta"], [1, 2]]
 
 # Line breaks are OK when inside arrays
 hosts = [
@@ -70,7 +70,7 @@ hosts = [
 ]
 
 ["zip"]
-cve = [ "CVE-2018-13410", "CVE-2018-1340" ] # garbage CVEs
+cve = ["CVE-2018-13410", "CVE-2018-1340"] # garbage CVEs
 comment = "this cve is only valid with attacker-controlled flags to zip"
 
 ["unzip"]
@@ -78,12 +78,12 @@ cve = [
   "CVE-2018-13410",
   "CVE-2018-1340",
 ]
-cve = [ "CVE-2018-13410", "foo", "CVE-2018-1340" ]
+cve = ["CVE-2018-13410", "foo", "CVE-2018-1340"]
 
 comment = "this cve is only valid with attacker-controlled flags to zip"
 
 ["inline.comments"]
-singleline_remove_trailing_comma = [ "foo", "bar", "baz" ]
+singleline_remove_trailing_comma = ["foo", "bar", "baz"]
 multiline_with_comments = [
   "bar",
   "blee",

--- a/topiary-core/languages.toml
+++ b/topiary-core/languages.toml
@@ -34,4 +34,3 @@ extensions = ["toml"]
 [[language]]
 name = "tree_sitter_query"
 extensions = ["scm"]
-

--- a/topiary-playground/Cargo.toml
+++ b/topiary-playground/Cargo.toml
@@ -3,12 +3,12 @@ name = "topiary-playground"
 description = "The WebAssembly code that runs at https://topiary.tweag.io/playground"
 categories = ["development-tools", "text-processing", "webassembly"]
 keywords = [
-    "code-formatter",
-    "formatter",
-    "text",
-    "tree-sitter",
-    "wasm",
-    "webassembly",
+  "code-formatter",
+  "formatter",
+  "text",
+  "tree-sitter",
+  "wasm",
+  "webassembly",
 ]
 version.workspace = true
 edition.workspace = true

--- a/topiary-queries/queries/toml.scm
+++ b/topiary-queries/queries/toml.scm
@@ -55,7 +55,10 @@
 (
   "," @append_spaced_softline
   .
-  (comment)? @do_nothing
+  [
+    (comment)
+    "]"
+  ]? @do_nothing
 )
 
 ; remove trailing comma from last element of single line array
@@ -72,9 +75,9 @@
 ; Indent arrays. They will only be indented inmulti-line blocks.
 
 (array
-  "[" @append_spaced_softline @append_indent_start
+  "[" @append_empty_softline @append_indent_start
 )
 
 (array
-  "]" @prepend_spaced_softline @prepend_indent_end
+  "]" @prepend_empty_softline @prepend_indent_end
 )

--- a/topiary-web-tree-sitter-sys/Cargo.toml
+++ b/topiary-web-tree-sitter-sys/Cargo.toml
@@ -10,7 +10,7 @@ documentation.workspace = true
 readme.workspace = true
 
 [features]
-default = ["web-sys" ]
+default = ["web-sys"]
 node = []
 
 [dependencies]


### PR DESCRIPTION
This PR adds a small modification to the `toml.scm` query file, and uses it to format our own `.toml` files, in the spirit of dogfooding.