### PR TITLE
Fix playground CI test problem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,20 +22,22 @@ jobs:
           authToken: "${{ secrets.CACHIX_TWEAG_TOPIARY_AUTH_TOKEN }}"
 
       - name: Set up frontend cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
-          path: '**/node_modules'
-          key: node_modules-${{ hashFiles('**/package-lock.json')}}
+          path: |
+            **/node_modules
+            ~/.cache/puppeteer
+          key: frontend_${{ matrix.os }}_${{ hashFiles('**/package-lock.json') }}
 
-      - name: Clippy, test, and benchmark
-        if: matrix.os == 'ubuntu-latest'
-        run: export GC_DONT_GC=1; nix -L flake check
+    # - name: Clippy, test, and benchmark
+    #   if: matrix.os == 'ubuntu-latest'
+    #   run: export GC_DONT_GC=1; nix -L flake check
 
-      - name: Build and test executable
-        run: 'echo \{ \"foo\": \"bar\" \} | nix run . -- fmt -l json'
+    # - name: Build and test executable
+    #   run: 'echo \{ \"foo\": \"bar\" \} | nix run . -- fmt -l json'
 
-      - name: Verify that usage in README.md matches CLI output
-        run: ./verify-documented-usage.sh
+    # - name: Verify that usage in README.md matches CLI output
+    #   run: ./verify-documented-usage.sh
 
       - name: Build web playground Wasm app
         if: success() && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,15 @@ jobs:
             ~/.cache/puppeteer
           key: frontend_${{ matrix.os }}_${{ hashFiles('**/package-lock.json') }}
 
-    # - name: Clippy, test, and benchmark
-    #   if: matrix.os == 'ubuntu-latest'
-    #   run: export GC_DONT_GC=1; nix -L flake check
+      - name: Clippy, test, and benchmark
+        if: matrix.os == 'ubuntu-latest'
+        run: export GC_DONT_GC=1; nix -L flake check
 
-    # - name: Build and test executable
-    #   run: 'echo \{ \"foo\": \"bar\" \} | nix run . -- fmt -l json'
+      - name: Build and test executable
+        run: 'echo \{ \"foo\": \"bar\" \} | nix run . -- fmt -l json'
 
-    # - name: Verify that usage in README.md matches CLI output
-    #   run: ./verify-documented-usage.sh
+      - name: Verify that usage in README.md matches CLI output
+        run: ./verify-documented-usage.sh
 
       - name: Build web playground Wasm app
         if: success() && matrix.os == 'ubuntu-latest'

--- a/update-wasm-grammars.sh
+++ b/update-wasm-grammars.sh
@@ -75,6 +75,18 @@ ocamllex() {
   echo -e "${GREEN}Ocamllex: Done${NC}"
 }
 
+bash() {
+  echo -e "${BLUE}Bash: Fetching${NC}"
+  git clone --depth=1 https://github.com/tree-sitter/tree-sitter-bash.git "${WORKDIR}/tree-sitter-bash" &> /dev/null
+  REV=$(ref_for_language "bash")
+  pushd "${WORKDIR}/tree-sitter-bash" &> /dev/null
+    git checkout "$REV" &> /dev/null
+  popd &> /dev/null
+  echo -e "${ORANGE}Bash: Building${NC}"
+  tree-sitter build-wasm "${WORKDIR}/tree-sitter-bash"
+  echo -e "${GREEN}Bash: Done${NC}"
+}
+
 rust() {
   echo -e "${BLUE}Rust: Fetching${NC}"
   git clone --depth=1 https://github.com/tree-sitter/tree-sitter-rust.git "${WORKDIR}/tree-sitter-rust" &> /dev/null
@@ -86,7 +98,6 @@ rust() {
   tree-sitter build-wasm "${WORKDIR}/tree-sitter-rust"
   echo -e "${GREEN}Rust: Done${NC}"
 }
-
 
 toml() {
   echo -e "${BLUE}TOML: Fetching${NC}"
@@ -112,6 +123,6 @@ tree-sitter-query() {
   echo -e "${GREEN}Query: Done${NC}"
 }
 
-(trap 'kill 0' SIGINT; json & nickel & ocaml & ocamllex & rust & toml & tree-sitter-query & wait)
+(trap 'kill 0' SIGINT; json & nickel & ocaml & ocamllex & bash & rust & toml & tree-sitter-query & wait)
 
 echo -e "${GREEN}Done! All grammars have been updated${NC}"


### PR DESCRIPTION
The problem was that the frontend's NPM modules were being cached incorrectly: this included Puppeteer, so it wasn't reinstalled, but _didn't_ include Puppeteer's Chrome. Updated the cache to include Puppeteer's Chrome.

(Also updated the `update-wasm-grammars.sh` script to generate the Bash Tree-sitter WASM.)

Resolves #665