### PR TITLE
README.md: improve install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ This won't work if you are running Topiary from another directory than this
 repository. In order to use Topiary without restriction, **you must set the
 environment variable `TOPIARY_LANGUAGE_DIR` to point to the directory where
 Topiary's language query files (`.scm`) are located**. By default, you should
-set it to `<local path of the topiary repository>/queries`, for example:
+set it to `<local path of the topiary repository>/topiary-queries/queries`, for example:
 
 ```sh
 export TOPIARY_LANGUAGE_DIR=/home/me/tools/topiary/topiary-queries/queries


### PR DESCRIPTION
This PR updates the readme's installation instructions to reference the `queries` directory nested under the `topiary-queries` crate. This is consistent with the example `export TOPIARY_LANGUAGE_DIR` command that appears soon after.