### PR TITLE
Output the (column, row) of a patternmatch when outputing at the INFO level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ This name should be decided amongst the team before the release.
 
 [Full list of changes](https://github.com/tweag/topiary/compare/v0.3.0...HEAD)
 
+### Added
+- [#697](https://github.com/tweag/topiary/pull/697) Setting the log level to INFO now outputs the pattern locations in a (row, column) way.
+
 ## v0.3.0 - Dreamy Dracaena - 2023-09-22
 
 [Full list of changes](https://github.com/tweag/topiary/compare/v0.2.3...v0.3.0)

--- a/topiary-cli/src/error.rs
+++ b/topiary-cli/src/error.rs
@@ -23,8 +23,7 @@ pub enum CLIError {
     Multiple,
     UnsupportedLanguage(String),
 
-    /// Could not detect the input language from the (filename,
-    /// Option<extension>)
+    /// Could not detect the input language from the `(filename, Option<extension>)`
     LanguageDetection(PathBuf, Option<String>),
 }
 


### PR DESCRIPTION
# Output the (column, row) of a patternmatch when outputing at the INFO level
<!-- Please refer to an issue, or remove this line if the PR is unrelated to an issue -->
Issue: #681

## Description
This is part one of issue #681, adding the row and column to the debug output while not supporting named patterns yet.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
