### PR TITLE
chore: add a light devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,10 +86,17 @@
           pre-commit-hook = builtins.deepSeq self.lib.${system}.pre-commit-hook pkgs.hello;
         };
 
-        devShells = {
-          default = pkgs.callPackage ./shell.nix { checks = self.checks.${system}; inherit craneLib; inherit binPkgs; };
-          wasm = pkgs.callPackage ./shell.nix { checks = self.checks.${system}; craneLib = topiaryPkgs.passtru.craneLibWasm; inherit binPkgs; };
-        };
+        devShells =
+          let
+            checksLight = {
+              inherit (topiaryPkgs) clippy fmt topiary-core topiary-cli;
+            };
+          in
+          {
+            default = pkgs.callPackage ./shell.nix { checks = self.checks.${system}; inherit craneLib; inherit binPkgs; };
+            light = pkgs.callPackage ./shell.nix { checks = checksLight; inherit craneLib; inherit binPkgs; optionals = false; };
+            wasm = pkgs.callPackage ./shell.nix { checks = self.checks.${system}; craneLib = topiaryPkgs.passtru.craneLibWasm; inherit binPkgs; };
+          };
 
         ## For easy use in https://github.com/cachix/pre-commit-hooks.nix
         lib.pre-commit-hook = {

--- a/shell.nix
+++ b/shell.nix
@@ -4,20 +4,26 @@
 , checks ? { }
 , craneLib
 , binPkgs
+, optionals ? true
 }:
-craneLib.devShell {
-  inherit checks;
+craneLib.devShell
+  (
+    {
+      inherit checks;
+    }
+      //
+    (if optionals then {
+      packages = with pkgs; with binPkgs; [
+        cargo-flamegraph
+        rust-analyzer
 
-  packages = with pkgs; with binPkgs; [
-    cargo-flamegraph
-    rust-analyzer
-
-    # Our own scripts
-    # FIXME: Broken
-    # generate-coverage
-    playground
-    update-wasm-app
-    update-wasm-grammars
-    verify-documented-usage
-  ];
-}
+        # Our own scripts
+        # FIXME: Broken
+        # generate-coverage
+        playground
+        update-wasm-app
+        update-wasm-grammars
+        verify-documented-usage
+      ];
+    } else { })
+  )


### PR DESCRIPTION
# Light DevShell
<!-- Please refer to an issue, or remove this line if the PR is unrelated to an issue -->
Issue: #651

## Description
This devShell contains only the bare necessecities for building and testing Topiary. Notably, it drops rust-analyzer, cargo-flamegraph, and our own scripts.

## Checklist
Checklist before merging:
- ~[ ] CHANGELOG.md updated~
- ~[ ] README.md up-to-date~
