### PR TITLE
fix: use slice patterns over iterator

### DIFF
--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -114,6 +114,20 @@ pub enum Atom {
     },
 }
 
+impl Atom {
+    /// This function is only expected to take spaces and newlines as argument.
+    /// It defines the order Blankline > Hardline > Space > Empty.
+    pub(crate) fn dominates(&self, other: &Atom) -> bool {
+        match self {
+            Atom::Empty => false,
+            Atom::Space => matches!(other, Atom::Empty),
+            Atom::Hardline => matches!(other, Atom::Space | Atom::Empty),
+            Atom::Blankline => matches!(other, Atom::Hardline | Atom::Space | Atom::Empty),
+            _ => panic!("Unexpected character in is_dominant"),
+        }
+    }
+}
+
 /// Used in `Atom::ScopedConditional` to apply the containing Atoms only if
 /// the matched node spans a single line or multiple lines
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
# Slices for post_processing!

## Description
This PR refactors our post_process_inner function to use slice pattern matching instead.

# Motivation
Reason for this change it to make it easier to extend the match for patterns longer than just the first 2 atoms.

## Checklist
Checklist before merging:
- [ ] CHANGELOG.md updated
