### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "client-app"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "tokio",
  "topiary-config",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "async-scoped",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "directories",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "env_logger 0.10.2",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-playground"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "itertools 0.11.0",
  "topiary-config",
@@ -1345,11 +1345,11 @@ dependencies = [
 
 [[package]]
 name = "topiary-queries"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "topiary-tree-sitter-facade"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "js-sys",
  "topiary-web-tree-sitter-sys",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-web-tree-sitter-sys"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Tweag"]
 homepage = "https://topiary.tweag.io"


### PR DESCRIPTION
Prepare a release of `topiary-queries` with the latest Nickel queries to `crates.io`. For the time being, it was decided that it's ok to bump the patch version for such an update. I hesitated to do this just for `topiary-queries`, but that would mean to stop using the workspace version for `topiary-queries`, but the added risk of being out of sync (or to just forget to bump `topiary-queries`'s version during an update) isn't worth it IMHO. Instead, I think we should just accept to bump the whole workspace version.

I don't know if a GitHub release is very useful to do in this case (or a cargo release of other Topiary crates). I think it's fine to keep all the others crates at `0.4.0` on GitHub and crates.io until the next update, and just publish `topiary-queries`. But I'm happy to do otherwise.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
