### PR TITLE
fix: missing space for pattern matching of constructor holding record

### DIFF
--- a/topiary-cli/tests/samples/expected/ocaml.ml
+++ b/topiary-cli/tests/samples/expected/ocaml.ml
@@ -1161,6 +1161,11 @@ let _ =
   match foo with
   | Bar ["baz"] -> qux
 
+(* #719: missing space for pattern matching of constructor holding record *)
+let _ =
+  match foo with
+  | Bar { baz } -> qux
+
 (* #659 handling of the `;;` separator *)
 
 let bonjour () = "Bonjour"

--- a/topiary-cli/tests/samples/input/ocaml.ml
+++ b/topiary-cli/tests/samples/input/ocaml.ml
@@ -1092,6 +1092,11 @@ let _ =
   match foo with
   | Bar ["baz"] -> qux
 
+(* #719: missing space for pattern matching of constructor holding record *)
+let _ =
+  match foo with
+  | Bar { baz } -> qux
+
 (* #659 handling of the `;;` separator *)
 
 let bonjour () = "Bonjour"

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -510,6 +510,7 @@
     (local_open_pattern)
     (labeled_argument)
     (list_pattern)
+    (record_pattern)
     ; start equivalence class
     (extended_module_path)
     (module_path)


### PR DESCRIPTION
# fix: missing space for pattern matching of constructor holding record
Issue: #719

## Description

This fixes the formatting of pattern matching of constructors with an inline record pattern, which previously was missing a space.

## Checklist
Checklist before merging:
- [ ] CHANGELOG.md updated
- [x] README.md up-to-date
