### PR TITLE
Format typed patterns in function arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ This name should be decided amongst the team before the release.
 
 ### Fixed
 - [#720](https://github.com/tweag/topiary/pull/720) [#722](https://github.com/tweag/topiary/pull/722) [#723](https://github.com/tweag/topiary/pull/723) [#724](https://github.com/tweag/topiary/pull/724) [#735](https://github.com/tweag/topiary/pull/735)
-[#738](https://github.com/tweag/topiary/pull/738) Various OCaml improvements
+[#738](https://github.com/tweag/topiary/pull/738) [#739](https://github.com/tweag/topiary/pull/739) Various OCaml improvements
 
 ### Changed
 - [#704](https://github.com/tweag/topiary/pull/704) Refactors our postprocessing code to be more versatile.

--- a/topiary-cli/tests/samples/expected/ocaml.ml
+++ b/topiary-cli/tests/samples/expected/ocaml.ml
@@ -1210,6 +1210,21 @@ let () =
     | u -> vvvvvvvvv
   )
 
+(* #727 proper formatting of multi-lined typed function argument *)
+let foo
+    (bar :
+      int ->
+      string ->
+      unit
+    )
+    ~(baz :
+      int ->
+      string ->
+      unit
+    )
+  =
+  bar baz
+
 (* #728 missing space in module function arguments *)
 let foo
     (bar : int)

--- a/topiary-cli/tests/samples/input/ocaml.ml
+++ b/topiary-cli/tests/samples/input/ocaml.ml
@@ -1151,6 +1151,21 @@ let () =
     | u -> vvvvvvvvv
   )
 
+(* #727 proper formatting of multi-lined typed function argument *)
+let foo
+  (bar :
+    int ->
+    string ->
+    unit
+  )
+  ~(baz :
+    int ->
+    string ->
+    unit
+  )
+=
+  bar baz
+
 (* #728 missing space in module function arguments *)
 let foo
     (bar : int)

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -1683,6 +1683,37 @@
     "}"
   ] @prepend_antispace
 )
+
+; Formatting typed patterns in function arguments, e.g.
+; let foo
+;   (bar :
+;     int ->
+;     string ->
+;     unit
+;   )
+;   ~(baz :
+;     int ->
+;     string ->
+;     unit
+;   )
+;   =
+;   bar baz
+(typed_pattern
+  .
+  "("
+  ":" @append_spaced_softline @append_indent_start
+  ")" @prepend_indent_end @prepend_empty_softline
+  .
+)
+(parameter
+  "~"
+  .
+  "("
+  ":" @append_spaced_softline @append_indent_start
+  ")" @prepend_indent_end @prepend_empty_softline
+  .
+)
+
 ; Input softlines before and after all comments. This means that the input
 ; decides if a comment should have line breaks before or after. But don't put a
 ; softline directly in front of commas or semicolons.


### PR DESCRIPTION
## Description
Formats the following as is:
```ocaml
let foo
    (bar :
      int ->
      string ->
      unit
    )
    ~(baz :
      int ->
      string ->
      unit
    )
  =
  bar baz
```
Closes #727
## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
