### PR TITLE
Fix Nickel inconsistent formatting of annotated let-bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This name should be decided amongst the team before the release.
 ### Fixed
 - [#720](https://github.com/tweag/topiary/pull/720) [#722](https://github.com/tweag/topiary/pull/722) [#723](https://github.com/tweag/topiary/pull/723) [#724](https://github.com/tweag/topiary/pull/724) [#735](https://github.com/tweag/topiary/pull/735)
 [#738](https://github.com/tweag/topiary/pull/738) [#739](https://github.com/tweag/topiary/pull/739) [#745](https://github.com/tweag/topiary/pull/745) Various OCaml improvements
+- [#744](https://github.com/tweag/topiary/pull/744) Nickel: fix the indentation of `in` for annotated multiline let-bindings
 
 ### Changed
 - [#704](https://github.com/tweag/topiary/pull/704) Refactors our postprocessing code to be more versatile.

--- a/topiary-cli/tests/samples/expected/nickel.ncl
+++ b/topiary-cli/tests/samples/expected/nickel.ncl
@@ -139,7 +139,20 @@
         1
       else
         3
-    )
+    ),
+
+    # regression test for https://github.com/tweag/topiary/issues/743
+    # (partially fixed)
+    let foo
+      | Number
+      = [
+        1,
+        2,
+        3
+      ]
+    in
+    foo
+    @ [],
   ],
 
   # Nickel standard library as of 44aef1672a09a76a71946fbf822713747ab7b9df

--- a/topiary-cli/tests/samples/input/nickel.ncl
+++ b/topiary-cli/tests/samples/input/nickel.ncl
@@ -127,7 +127,21 @@ bar == 'Goodbye
           if x == 1 then
               1
 else
-    3)
+    3),
+
+    # regression test for https://github.com/tweag/topiary/issues/743
+    # (partially fixed)
+    let foo
+    | Number
+    =
+[
+    1,
+    2,
+    3
+]
+in
+foo
+@ [],
   ],
 
   # Nickel standard library as of 44aef1672a09a76a71946fbf822713747ab7b9df

--- a/topiary-queries/queries/nickel.scm
+++ b/topiary-queries/queries/nickel.scm
@@ -343,7 +343,7 @@
 
 ; Add a new line before the last annotation and the following equal sign.
 ;
-; [^annotations-followed-by-eq]: Ideally, we would like to only add this new
+; [^annotations-followed-by-eq]: Ideally, we would like to add this new
 ; line for multi-line annotations only. That is, we would like to have the
 ; following formatting:
 ;

--- a/topiary-queries/queries/nickel.scm
+++ b/topiary-queries/queries/nickel.scm
@@ -398,11 +398,9 @@
 ; Ideally, we would like to indent only when annotations are multi-line, but
 ; this isn't current possible; see [^annotations-followed-by-eq].
 (_
-  (annot)
-  .
-  "=" @prepend_indent_start
-  .
-  (_) @append_indent_end
+  (annot) @append_indent_start
+  "="
+  (term) @append_indent_end
 )
 
 ; Break a multi-line polymorphic type annotation after the type


### PR DESCRIPTION
# Nickel formatting of annotated let-bindings

Closes #743

## Description

This is a tentative fix of #743, but I have yet to figure out how to properly handle the indentation part.

## Checklist

Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
