### PR TITLE
Indentation on multi-line call containing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ This name should be decided amongst the team before the release.
 
 ### Fixed
 - [#720](https://github.com/tweag/topiary/pull/720) [#722](https://github.com/tweag/topiary/pull/722) [#723](https://github.com/tweag/topiary/pull/723) [#724](https://github.com/tweag/topiary/pull/724) [#735](https://github.com/tweag/topiary/pull/735)
-[#738](https://github.com/tweag/topiary/pull/738) [#739](https://github.com/tweag/topiary/pull/739) Various OCaml improvements
+[#738](https://github.com/tweag/topiary/pull/738) [#739](https://github.com/tweag/topiary/pull/739) [#745](https://github.com/tweag/topiary/pull/745) Various OCaml improvements
 
 ### Changed
 - [#704](https://github.com/tweag/topiary/pull/704) Refactors our postprocessing code to be more versatile.

--- a/topiary-cli/tests/samples/expected/ocaml.ml
+++ b/topiary-cli/tests/samples/expected/ocaml.ml
@@ -1187,8 +1187,8 @@ let () =
 
 let () =
   foo x (fun y ->
-    zzzzzzzzzz
-  )
+      zzzzzzzzzz
+    )
 
 let foo x = function
   | y -> zzzzzzzzzz
@@ -1206,9 +1206,9 @@ let () =
 
 let () =
   foo x (function
-    | y -> zzzzzzzzzz
-    | u -> vvvvvvvvv
-  )
+      | y -> zzzzzzzzzz
+      | u -> vvvvvvvvv
+    )
 
 (* #727 proper formatting of multi-lined typed function argument *)
 let foo
@@ -1240,6 +1240,17 @@ type x = [`Foo | `Bar]
 type x = [> `Foo | `Bar]
 type x = [< `Foo | `Bar]
 type x = {a: int; b: int; c: int}
+
+(* #726 multi-line calls containing functions *)
+let _ =
+  foo
+    bar
+    (fun baz ->
+      baaaaaaz
+    )
+    (fun qux ->
+      quuuuuux
+    )
 
 (* #659 handling of the `;;` separator *)
 

--- a/topiary-cli/tests/samples/input/ocaml.ml
+++ b/topiary-cli/tests/samples/input/ocaml.ml
@@ -1182,6 +1182,17 @@ type x = [> `Foo | `Bar]
 type x = [< `Foo | `Bar]
 type x = { a: int; b: int; c: int }
 
+(* #726 multi-line calls containing functions *)
+let _ =
+  foo
+    bar
+    (fun baz ->
+      baaaaaaz
+    )
+    (fun qux ->
+      quuuuuux
+    )
+
 (* #659 handling of the `;;` separator *)
 
 let bonjour () = "Bonjour"

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -1157,12 +1157,14 @@
 ; _before_ the application. This allows the following to be formatted as such:
 ; let () =
 ;   foo bar (fun x ->
-;     something horrible onto x
-;   )
+;       something horrible onto x
+;     )
 (application_expression
   .
-  (_) @prepend_begin_scope @append_indent_start
+  (_) @append_indent_start @prepend_begin_scope
   (#scope_id! "function_application")
+  (_) @append_indent_end
+  .
 )
 (application_expression
   (#scope_id! "function_application")
@@ -1171,7 +1173,7 @@
       (fun_expression)
       (function_expression)
     ]? @do_nothing
-  ) @append_end_scope @append_indent_end
+  ) @append_end_scope
   .
 )
 (application_expression
@@ -1180,8 +1182,8 @@
     [
       (fun_expression)
       (function_expression)
-    ]
-  ) @prepend_end_scope @prepend_indent_end
+    ] @prepend_end_scope
+  )
   .
 )
 (application_expression


### PR DESCRIPTION
## Description
Allows the following to be formatted as is:
```ocaml
foo
  bar
  (fun baz ->
    baaaaaaz
  )
  (fun qux ->
    quuuuuux
  )
```

This is a kind of a setback regarding the formatting of snippets such as the following:
```ocaml
foo bar (fun x ->
    x
  )
```
But I believe the topiary language isn't sufficiently expressive to currently have both.

Closes #726
## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [ ] README.md up-to-date
