### PR TITLE
Update patch version (4.0.2 -> 4.0.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client-app"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "tokio",
  "topiary-config",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "assert_cmd",
  "async-scoped",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-config"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "cc",
  "clap",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "criterion",
  "env_logger 0.10.2",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-playground"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "itertools 0.11.0",
  "topiary-config",
@@ -2147,11 +2147,11 @@ dependencies = [
 
 [[package]]
 name = "topiary-queries"
-version = "0.4.2"
+version = "0.4.3"
 
 [[package]]
 name = "topiary-tree-sitter-facade"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "js-sys",
  "topiary-web-tree-sitter-sys",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-web-tree-sitter-sys"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["Tweag"]
 homepage = "https://topiary.tweag.io"


### PR DESCRIPTION
A previous merge commit added support for let-blocks to Nickel formatting. To make use of this change from Nickel, we need to publish a new version of `topiary-queries` to crates.io. As now customary, we bump the patch version of the workspace, and bother publishing a new version for topiary-queries only.