### PR TITLE
No longer use error code 1 fore "unspecified error".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ This name should be decided amongst the team before the release.
 - [#720](https://github.com/tweag/topiary/pull/720) [#722](https://github.com/tweag/topiary/pull/722) [#723](https://github.com/tweag/topiary/pull/723) [#724](https://github.com/tweag/topiary/pull/724) [#735](https://github.com/tweag/topiary/pull/735)
 [#738](https://github.com/tweag/topiary/pull/738) [#739](https://github.com/tweag/topiary/pull/739) [#745](https://github.com/tweag/topiary/pull/745) [#755](https://github.com/tweag/topiary/pull/755) [#759](https://github.com/tweag/topiary/pull/759) Various OCaml improvements
 - [#744](https://github.com/tweag/topiary/pull/744) Nickel: fix the indentation of `in` for annotated multiline let-bindings
+- [#761](https://github.com/tweag/topiary/pull/761) No longer use error code 1 for unspecified errors
 
 ### Changed
 - [#704](https://github.com/tweag/topiary/pull/704) Refactors our postprocessing code to be more versatile.

--- a/README.md
+++ b/README.md
@@ -387,7 +387,6 @@ formatting. Otherwise, the following exit codes are defined:
 
 | Reason                       | Code |
 | :--------------------------- | ---: |
-| Unspecified error            |    1 |
 | CLI argument parsing error   |    2 |
 | I/O error                    |    3 |
 | Topiary query error          |    4 |
@@ -396,6 +395,7 @@ formatting. Otherwise, the following exit codes are defined:
 | Idempotency error            |    7 |
 | Unspecified formatting error |    8 |
 | Multiple errors              |    9 |
+| Unspecified error            |   10 |
 
 When given multiple inputs, Topiary will do its best to process them
 all, even in the presence of errors. Should _any_ errors occur, Topiary

--- a/topiary-cli/src/error.rs
+++ b/topiary-cli/src/error.rs
@@ -92,8 +92,11 @@ impl From<TopiaryError> for ExitCode {
             // Bad arguments: Exit 2
             // (Handled by clap: https://github.com/clap-rs/clap/issues/3426)
 
-            // Anything else: Exit 1
-            _ => 1,
+            // Things went well but Topiary needs to answer 'false' in a clean way: Exit 1
+            // (Not used at the moment)
+
+            // Anything else: Exit 10
+            _ => 10,
         };
 
         ExitCode::from(exit_code)


### PR DESCRIPTION
## Description
Error code 1 is usually used for
> things went well and I need to answer 'no' or 'false' in a clean way

This PR changes the code of "unspecified error" from 1 to 10

Closes #611

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
