### PR TITLE
fix: [OCaml] Relocate dangling function line break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ This name should be decided amongst the team before the release.
 - [#760](https://github.com/tweag/topiary/pull/760) Introduce optional `query_name` predicate, to help with query logging and debugging.
 
 ### Fixed
-- [#720](https://github.com/tweag/topiary/pull/720) [#722](https://github.com/tweag/topiary/pull/722) [#723](https://github.com/tweag/topiary/pull/723) [#724](https://github.com/tweag/topiary/pull/724) [#735](https://github.com/tweag/topiary/pull/735) [#738](https://github.com/tweag/topiary/pull/738) [#739](https://github.com/tweag/topiary/pull/739) [#745](https://github.com/tweag/topiary/pull/745) [#755](https://github.com/tweag/topiary/pull/755) [#759](https://github.com/tweag/topiary/pull/759) Various OCaml improvements
+- [#720](https://github.com/tweag/topiary/pull/720) [#722](https://github.com/tweag/topiary/pull/722) [#723](https://github.com/tweag/topiary/pull/723) [#724](https://github.com/tweag/topiary/pull/724) [#735](https://github.com/tweag/topiary/pull/735) [#738](https://github.com/tweag/topiary/pull/738) [#739](https://github.com/tweag/topiary/pull/739) [#745](https://github.com/tweag/topiary/pull/745) [#755](https://github.com/tweag/topiary/pull/755) [#759](https://github.com/tweag/topiary/pull/759) [#764](https://github.com/tweag/topiary/pull/764 Various OCaml improvements
 - [#762](https://github.com/tweag/topiary/pull/762) Various Rust improvements
 - [#744](https://github.com/tweag/topiary/pull/744) Nickel: fix the indentation of `in` for annotated multiline let-bindings
 - [#761](https://github.com/tweag/topiary/pull/761) No longer use error code 1 for unspecified errors

--- a/topiary-cli/tests/samples/expected/ocaml.ml
+++ b/topiary-cli/tests/samples/expected/ocaml.ml
@@ -1308,3 +1308,8 @@ let _ =
     baz
     @@ fun x ->
     x
+
+(* #546 Hanging forms *)
+let _ =
+  somefun @@ fun x ->
+  body

--- a/topiary-cli/tests/samples/input/ocaml.ml
+++ b/topiary-cli/tests/samples/input/ocaml.ml
@@ -1249,3 +1249,8 @@ let _ =
     baz
     @@ fun x ->
     x
+
+(* #546 Hanging forms *)
+let _ =
+  somefun @@
+    fun x -> body

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -1593,6 +1593,33 @@
   ] @append_indent_end
 )
 
+; The following allows
+;
+; somefun @@
+;   fun x -> body
+;
+; to be formatted as
+;
+; somefun @@ fun x ->
+; body
+(infix_expression
+  (#scope_id! "relocate_dangling_function_line_break")
+  (concat_operator) @append_begin_scope @append_begin_measuring_scope
+  .
+  (fun_expression
+    "fun" @prepend_end_measuring_scope
+    "->" @append_end_scope
+  )
+)
+(infix_expression
+  (#multi_line_scope_only! "relocate_dangling_function_line_break")
+  (concat_operator)
+  .
+  (fun_expression
+    "->" @append_hardline
+  )
+)
+
 ; Allow softlines in sequences and ppx sequences, such as
 ; let b =
 ;   foo;


### PR DESCRIPTION
## Description
Allows the following
```ocaml
let _ =
  somefun @@
    fun x -> body
```
to be formatted as
```ocaml
let _ =
  somefun @@ fun x ->
  body
```

Closes #546

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
