### PR TITLE
Format `languages.ncl` with topiary

### DIFF
--- a/topiary-config/languages.ncl
+++ b/topiary-config/languages.ncl
@@ -18,21 +18,21 @@
 
     json = {
       extensions = [
-          "json",
-          "avsc",
-          "geojson",
-          "gltf",
-          "har",
-          "ice",
-          "JSON-tmLanguage",
-          "jsonl",
-          "mcmeta",
-          "tfstate",
-          "tfstate.backup",
-          "topojson",
-          "webapp",
-          "webmanifest"
-        ],
+        "json",
+        "avsc",
+        "geojson",
+        "gltf",
+        "har",
+        "ice",
+        "JSON-tmLanguage",
+        "jsonl",
+        "mcmeta",
+        "tfstate",
+        "tfstate.backup",
+        "topojson",
+        "webapp",
+        "webmanifest"
+      ],
       grammar = {
         git = "https://github.com/tree-sitter/tree-sitter-json.git",
         rev = "94f5c527b2965465956c2000ed6134dd24daf2a7",


### PR DESCRIPTION
## Description
In the spirit of dogfooding, this PR formats `languages.ncl` with topiary.
## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
