### PR TITLE
Nickel: formatting of single-line annotated let

### DIFF
--- a/topiary-cli/tests/samples/expected/nickel.ncl
+++ b/topiary-cli/tests/samples/expected/nickel.ncl
@@ -141,8 +141,7 @@
         3
     ),
 
-    # regression test for https://github.com/tweag/topiary/issues/743
-    # (partially fixed)
+    # regression tests for https://github.com/tweag/topiary/issues/743
     let foo
       | Number
       = [
@@ -153,6 +152,36 @@
     in
     foo
     @ [],
+    let x | Number = 1 + 1 in x,
+    let x | Number = 1 + 1
+    in x,
+    let x | Number | std.number.PosNat =
+      1
+      + 1
+    in x,
+    let x | Number = 1 + 1
+    in
+    x,
+    let x | Array String = ["a", "b"]
+    in x,
+    let x | Array Number = [
+      1,
+      2,
+      3
+    ]
+    in
+    x,
+    let x
+      | Array Number
+      = [
+        1 + 1,
+        2 + 2,
+        3 + 3,
+      ]
+    in
+    x,
+
+    # let blocks
     let x = 1, y = 2 in x + y,
     let
       x = 1,

--- a/topiary-cli/tests/samples/input/nickel.ncl
+++ b/topiary-cli/tests/samples/input/nickel.ncl
@@ -129,8 +129,7 @@ bar == 'Goodbye
 else
     3),
 
-    # regression test for https://github.com/tweag/topiary/issues/743
-    # (partially fixed)
+    # regression tests for https://github.com/tweag/topiary/issues/743
     let foo
     | Number
     =
@@ -142,6 +141,45 @@ else
 in
 foo
 @ [],
+
+    let x | Number   =    1 + 1 in x,
+    let x | Number = 1 + 1
+      in x,
+
+    let x | Number | std.number.PosNat = 1
++ 1
+      in x,
+
+
+    let x | Number
+      = 1 + 1
+      in
+    x,
+
+    let x | Array String
+      =
+        ["a","b"]
+      in x,
+
+    let x | Array Number
+      = [
+    1,
+    2,
+    3
+    ]
+      in
+    x,
+
+    let x
+      | Array Number
+      =
+        [1 + 1,
+2+2,
+3+3,]
+      in
+    x,
+
+    # let blocks
 
     let x = 1, y = 2 in x + y,
 

--- a/topiary-queries/queries/nickel.scm
+++ b/topiary-queries/queries/nickel.scm
@@ -355,8 +355,9 @@
 
 ;; Annotations
 
-; Start a scope from the node previous to the annotations. This properly checks
-; if the annotations were intended to be on newlines in such cases as:
+; Start a scope from the node preceding the annotations. This scope is used
+; exclusively to lay out annotations on multiple lines. The rule checks if the
+; annotations were intended to be on newlines as in:
 ;
 ; id
 ;   | a -> a
@@ -378,11 +379,24 @@
   (annot_atom) @prepend_spaced_scoped_softline
 )
 
-; Add a new line before the last annotation and the following equal sign.
+; Start a new scope for annotations, used to properly indent any content coming
+; after the annotations. We use Topiary's measuring scope feature: the
+; multi-liness of this scope is entirely decided by the annotations only, but
+; what we want to affect is larger, namely the content of the binding coming
+; after the `=`.
+(
+  (#scope_id! "annotations_with_content")
+  (_) @append_begin_scope @append_begin_measuring_scope
+  .
+  (annot) @append_end_measuring_scope
+  "="
+  (term) @append_end_scope
+)
+
+; Add a new line before the last annotation and the following equal sign, when
+; the annotations are multi-line.
 ;
-; [^annotations-followed-by-eq]: Ideally, we would like to add this new
-; line for multi-line annotations only. That is, we would like to have the
-; following formatting:
+; Indeed, we want to have the following formatting (multi-line):
 ;
 ; let foo
 ;   | Array Number
@@ -393,34 +407,16 @@
 ;   ]
 ; in ...
 ;
-; But
+; But (single-line):
 ;
 ; let foo | Array Number = [
 ;   1,
 ;   2,
 ; ]
 ; in ...
-;
-; While adding a scoped line isn't an issue, note that in the examples above,
-; the indentation of what comes after the `=` sign depends on the multi-liness
-; of the annotations (and thus of the multiliness of the "annotations" scope).
-; However, the RHS isn't part of this scope (and we don't want it to be).
-; Unfortunately, this can't be achieved in current Topiary.
-;
-; In the meantime, we always put the `=` sign a new line, whether in single-line
-; or multi-line mode, and always indent the RHS further in presence of
-; annotations. This give the following formatting for the second example:
-;
-; let foo | Array Number
-;   = [
-;     1,
-;     2,
-;   ]
-; in ...
-;
-; which isn't optimal but still acceptable.
 (
-  (annot) @append_spaced_softline
+  (#scope_id! "annotations_with_content")
+  (annot) @append_spaced_scoped_softline
   .
   "="
 )
@@ -430,11 +426,12 @@
   (annot) @prepend_indent_start @append_indent_end
 )
 
-; Indent the RHS of the let-binding in presence of annotations.
-;
-; Ideally, we would like to indent only when annotations are multi-line, but
-; this isn't current possible; see [^annotations-followed-by-eq].
+; Indent the bound expression of a let-binding (or a field definition) in
+; presence of multi-line annotations. That's where we use the measuring scope of
+; "annotations_with_content": we want this rule to fire only when (annot) is
+; multi-line, regardless of the multi-liness of the ("=" (term)) part.
 (_
+  (#multi_line_scope_only! "annotations_with_content")
   (annot) @append_indent_start
   "="
   (term) @append_indent_end


### PR DESCRIPTION
# Respect formatting of single-line annotated let in Nickel
Issue: #743

## Description

Previously, we were formatting a let-binding followed by a single-line annotation and some content by always putting the `=` sign and the following content on a new line, indenting the content one level to the right.

This was mostly due to a limitation of Topiary around scopes. Today, this limitation has been lifted thanks to the introduction of measuring scopes. We make use of the latter to finally format such let-bindings (and bindings in general) as we originally wanted in #743.

## Checklist

Checklist before merging:
- [ ] CHANGELOG.md updated
- [ ] README.md up-to-date
