### PR TITLE
Playground now follows its own branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,27 +46,27 @@ jobs:
         run: nix run .#verify-documented-usage
 
       - name: Build web playground Wasm app
-        if: success() && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         run: nix build .#topiary-playground
 
       - name: Copy web playground Wasm app into playground frontend
-        if: success() && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         run: |
           mkdir -p web-playground/src/wasm-app
           cp -r result/* web-playground/src/wasm-app/
 
       - name: Move sample input and queries into playground frontend
-        if: success() && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         run: |
           mkdir -p web-playground/src/samples
           mv web-playground/src/wasm-app/languages_export.ts web-playground/src/samples/
 
       - name: Install web playground frontend dependencies
-        if: success() && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         run: npm install --prefix web-playground
 
       - name: Start web playground frontend
-        if: success() && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         run: |
           npm run dev --prefix web-playground &
           # Loop until there's a response
@@ -75,28 +75,28 @@ jobs:
           done
 
       - name: Test web playground frontend
-        if: success() && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         run: npm run e2e --prefix web-playground
 
       - name: Make web playground frontend release build
-        if: success() && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         run: npm run build --prefix web-playground
 
       - name: Copy playground into website
-        if: success() && matrix.os == 'ubuntu-latest'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         run: |
           rm -rf website/playground
           cp -r web-playground/dist website/playground
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v1.0.7
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main'
+        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
         with:
           path: 'website'
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/playground'
 
     permissions:
       pages: write      # to deploy to Pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ This name should be decided amongst the team before the release.
 - [#716](https://github.com/tweag/topiary/pull/716) Dynamicly fetch, compile, and load language grammars. Topiary now no longer ships with statically linked grammars.
 - [#732](https://github.com/tweag/topiary/pull/732) Change how function application and parenthesized expressions are treated in Nickel to reduce the overall noise and indentation
 - [#736](https://github.com/tweag/topiary/pull/668) Updates our Nickel grammar, and adds support for let blocks.
+- [#769](https://github.com/tweag/topiary/pull/769) Move the web playground to a separate branch
 
 ## v0.4.0 - Exquisite Elm - 2024-05-15
 


### PR DESCRIPTION
## Description
This PR makes the [playground](https://topiary.tweag.io/playground/) follow its own `playground` branch, instead of `main`.

This has become necessary because some fixes we want to add to `main` break the playground, because of some upstream issues in the `tree-sitter` library. Unfortunately, we currently lack the expertise to address those issues, yet we still want to keep updating `main`.


## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
