### PR TITLE
Load JSON and TOML grammars before tests in `cli-testers.rs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ This name should be decided amongst the team before the release.
 
 [Full list of changes](https://github.com/tweag/topiary/compare/v0.5.1...HEAD)
 
+### Fixed
+- [#779](https://github.com/tweag/topiary/pull/779) Load relevant grammars before CLI tests
+
 ## v0.5.1 - Fragrant Frangipani - 2024-10-22
 
 [Full list of changes](https://github.com/tweag/topiary/compare/v0.4.0...v0.5.1)


### PR DESCRIPTION
## Description
We need to prefetch JSON and TOML grammars before running the tests, on pain of race condition:
If multiple calls to Topiary are made in parallel and the grammar is missing, they will all try to fetch and build it, thus creating an empty `.so` file while `g++` is running.
If another instance of Topiary starts at this moment, it will mistake the empty `.so` file for an already built grammar, and try to run with it, resulting in an error.

Closes #767 

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
