### PR TITLE
Measuring scopes are independent from captures order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ This name should be decided amongst the team before the release.
 
 [Full list of changes](https://github.com/tweag/topiary/compare/v0.5.1...HEAD)
 
+### Changed
+- [#780](https://github.com/tweag/topiary/pull/780) Measuring scopes are now independent from captures order
+
 ### Fixed
 - [#779](https://github.com/tweag/topiary/pull/779) Load relevant grammars before CLI tests
 


### PR DESCRIPTION
## Description
This PR orders `[Measuring]{Begin,End}Scope` atoms such that, among a single set of prepends/append:
* `BeginScope`(s) will always be the first element(s)
* `MeasuringScopeBegin`(s) will always come just after
* `EndScope`(s) will always be the last element(s)
* `MeasuringScopeEnd`(s) will always come just before

Closes #778 

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
