### PR TITLE
doc: disambiguate `grammar.source.path` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,11 +563,11 @@ nickel = {
 },
 ```
 
-To specify a prebuilt grammar, specify the `grammar.source.path` attribute:
+To specify a prebuilt grammar, specify the `grammar.source.path` attribute, which must point to a compiled grammar file:
 ```nickel
 nickel = {
   extensions = ["ncl"],
-  grammar.source.path = "/path/to/compiled/grammar/file",
+  grammar.source.path = "/path/to/compiled/grammar/file.so",
 },
 ```
 


### PR DESCRIPTION
## Description
This PR clarifies the use of `grammar.source.path` in the config file.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
