### PR TITLE
Bump tree-sitter to 0.24 (not a release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This name should be decided amongst the team before the release.
 - [#747](https://github.com/tweag/topiary/pull/747) Added support for specifying paths to prebuilt grammars in Topiary's configuration
 
 ### Changed
+- [#794](https://github.com/tweag/topiary/pull/794) Bump the `tree-sitter` dependency to 0.24 @ZedThree
 - [#780](https://github.com/tweag/topiary/pull/780) Measuring scopes are now independent from captures order
 - [#790](https://github.com/tweag/topiary/pull/790) No longer merge config files by default, use priority instead.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,6 +1991,7 @@ dependencies = [
  "topiary-tree-sitter-facade",
  "topiary-web-tree-sitter-sys",
  "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907d8581360765417f8f2e0e7d602733bbed60156b4465b7617243689ef9b83d"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1436,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1626,6 +1629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "simple-counter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1660,12 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"
@@ -1991,11 +2006,13 @@ dependencies = [
  "prettydiff",
  "serde",
  "serde_json",
+ "streaming-iterator",
  "test-log",
  "tokio",
  "tokio-test",
  "topiary-tree-sitter-facade",
  "topiary-web-tree-sitter-sys",
+ "tree-sitter",
  "tree-sitter-json",
  "tree-sitter-ocaml",
 ]
@@ -2021,8 +2038,10 @@ name = "topiary-tree-sitter-facade"
 version = "0.5.1"
 dependencies = [
  "js-sys",
+ "streaming-iterator",
  "topiary-web-tree-sitter-sys",
  "tree-sitter",
+ "tree-sitter-language",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -2089,30 +2108,39 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.22.6"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
+checksum = "b67baf55e7e1b6806063b1e51041069c90afff16afcbbccd278d899f9d84bca4"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax 0.8.4",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-json"
-version = "0.21.0"
-source = "git+https://github.com/tree-sitter/tree-sitter-json.git?rev=94f5c527b2965465956c2000ed6134dd24daf2a7#94f5c527b2965465956c2000ed6134dd24daf2a7"
+version = "0.24.8"
+source = "git+https://github.com/tree-sitter/tree-sitter-json.git?rev=4d770d31f732d50d3ec373865822fbe659e47c75#4d770d31f732d50d3ec373865822fbe659e47c75"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
+name = "tree-sitter-language"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ddffe35a0e5eeeadf13ff7350af564c6e73993a24db62caee1822b185c2600"
+
+[[package]]
 name = "tree-sitter-ocaml"
-version = "0.22.0"
-source = "git+https://github.com/tree-sitter/tree-sitter-ocaml.git?rev=036226e5edb410aec004cc7ac0f4b2014dd04a0e#036226e5edb410aec004cc7ac0f4b2014dd04a0e"
+version = "0.23.2"
+source = "git+https://github.com/tree-sitter/tree-sitter-ocaml.git?rev=98c2130c59ca7553b47086f91c5d22180151ad55#98c2130c59ca7553b47086f91c5d22180151ad55"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,17 +70,19 @@ prettydiff = { version = "0.6.4", default-features = false }
 rayon = "1.10.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+streaming-iterator = "0.1.9"
 tempfile = "3.12"
 test-log = "0.2"
 tokio = "1.32"
 tokio-test = "0.4"
 toml = "0.8"
-tree-sitter = "0.22.6"
+tree-sitter = "0.24"
+tree-sitter-language = "0.1"
 # tree-sitter-bash = { git = "https://github.com/tree-sitter/tree-sitter-bash", rev = "1b0321ee85701d5036c334a6f04761cdc672e64c" }
 # tree-sitter-css = { git = "https://github.com/tree-sitter/tree-sitter-css.git", rev = "02b4ee757654b7d54fe35352fd8e53a8a4385d42" }
-tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json.git", rev = "94f5c527b2965465956c2000ed6134dd24daf2a7" }
+tree-sitter-json = { git = "https://github.com/tree-sitter/tree-sitter-json.git", rev = "4d770d31f732d50d3ec373865822fbe659e47c75" }
 # tree-sitter-nickel = { git = "https://github.com/nickel-lang/tree-sitter-nickel", rev = "43433d8477b24cd13acaac20a66deda49b7e2547" }
-tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml.git", rev = "036226e5edb410aec004cc7ac0f4b2014dd04a0e" }
+tree-sitter-ocaml = { git = "https://github.com/tree-sitter/tree-sitter-ocaml.git", rev = "98c2130c59ca7553b47086f91c5d22180151ad55" }
 # tree-sitter-ocamllex = { git = "https://github.com/314eter/tree-sitter-ocamllex.git", rev = "4b9898ccbf198602bb0dec9cd67cc1d2c0a4fad2" }
 # tree-sitter-query = { git = "https://github.com/nvim-treesitter/tree-sitter-query", rev = "a0ccc351e5e868ec1f8135e97aa3b53c663cf2df" }
 # tree-sitter-rust = { git = "https://github.com/tree-sitter/tree-sitter-rust.git", rev = "e0e8b6de6e4aa354749c794f5f36a906dcccda74" }
@@ -96,8 +98,3 @@ topiary-tree-sitter-facade = { version = "0.5.1", path = "./topiary-tree-sitter-
 topiary-core = { version = "0.5.1", path = "./topiary-core" }
 topiary-config = { version = "0.5.1", path = "./topiary-config" }
 topiary-queries = { version = "0.5.1", path = "./topiary-queries" }
-
-# tree-sitter-json's dependency on Tree-sitter is looser than ours, so
-# we have to pin its version to maintain API compatibility
-[patch."https://github.com/tree-sitter/tree-sitter-json"]
-tree-sitter = "0.22.6"

--- a/topiary-config/Cargo.toml
+++ b/topiary-config/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true, features = ["derive"] }
 tempfile.workspace = true
 toml.workspace = true
 tree-sitter.workspace = true
+tree-sitter-language.workspace = true
 
 topiary-tree-sitter-facade.workspace = true
 topiary-web-tree-sitter-sys.workspace = true

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -156,7 +156,7 @@ impl Language {
         };
 
         let language = unsafe {
-            let language_fn: Symbol<unsafe extern "C" fn() -> *const()> =
+            let language_fn: Symbol<unsafe extern "C" fn() -> *const ()> =
                 library.get(language_fn_name.as_bytes())?;
             tree_sitter_language::LanguageFn::from_raw(*language_fn)
         };

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -156,9 +156,9 @@ impl Language {
         };
 
         let language = unsafe {
-            let language_fn: Symbol<unsafe extern "C" fn() -> tree_sitter::Language> =
+            let language_fn: Symbol<unsafe extern "C" fn() -> *const()> =
                 library.get(language_fn_name.as_bytes())?;
-            language_fn()
+            tree_sitter_language::LanguageFn::from_raw(*language_fn)
         };
         std::mem::forget(library);
         Ok(topiary_tree_sitter_facade::Language::from(language))

--- a/topiary-core/Cargo.toml
+++ b/topiary-core/Cargo.toml
@@ -19,8 +19,10 @@ pretty_assertions = { workspace = true }
 prettydiff = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+streaming-iterator = { workspace = true }
 topiary-tree-sitter-facade = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
+tree-sitter = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures = { workspace = true }

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -188,7 +188,7 @@ pub enum Operation {
 /// let input = "[1,2]".to_string();
 /// let mut input = input.as_bytes();
 /// let mut output = Vec::new();
-/// let json = tree_sitter_json::language();
+/// let json = topiary_tree_sitter_facade::Language::from(tree_sitter_json::LANGUAGE);
 ///
 /// let mut query_file = BufReader::new(File::open("../topiary-queries/queries/json.scm").expect("query file"));
 /// let mut query_content = String::new();

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -389,7 +389,7 @@ mod tests {
         let mut input = r#"{"foo":{"bar"}}"#.as_bytes();
         let mut output = Vec::new();
         let query_content = "(#language! json)";
-        let grammar = topiary_tree_sitter_facade::Language::from(tree_sitter_json::language());
+        let grammar = topiary_tree_sitter_facade::Language::from(tree_sitter_json::LANGUAGE);
         let language = Language {
             name: "json".to_owned(),
             query: TopiaryQuery::new(&grammar, query_content).unwrap(),
@@ -425,7 +425,7 @@ mod tests {
 
         let mut output = Vec::new();
         let query_content = fs::read_to_string("../topiary-queries/queries/json.scm").unwrap();
-        let grammar = tree_sitter_json::language().into();
+        let grammar = tree_sitter_json::LANGUAGE.into();
         let language = Language {
             name: "json".to_owned(),
             query: TopiaryQuery::new(&grammar, &query_content).unwrap(),

--- a/topiary-tree-sitter-facade/Cargo.toml
+++ b/topiary-tree-sitter-facade/Cargo.toml
@@ -14,6 +14,8 @@ description = """
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tree-sitter.workspace = true
+tree-sitter-language.workspace = true
+streaming-iterator.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys.workspace = true

--- a/topiary-tree-sitter-facade/src/language.rs
+++ b/topiary-tree-sitter-facade/src/language.rs
@@ -80,10 +80,10 @@ mod native {
         }
     }
 
-    impl From<tree_sitter::Language> for Language {
+    impl From<tree_sitter_language::LanguageFn> for Language {
         #[inline]
-        fn from(inner: tree_sitter::Language) -> Self {
-            Self { inner }
+        fn from(inner: tree_sitter_language::LanguageFn) -> Self {
+            Self { inner: tree_sitter::Language::new(inner) }
         }
     }
 

--- a/topiary-tree-sitter-facade/src/language.rs
+++ b/topiary-tree-sitter-facade/src/language.rs
@@ -83,7 +83,9 @@ mod native {
     impl From<tree_sitter_language::LanguageFn> for Language {
         #[inline]
         fn from(inner: tree_sitter_language::LanguageFn) -> Self {
-            Self { inner: tree_sitter::Language::new(inner) }
+            Self {
+                inner: tree_sitter::Language::new(inner),
+            }
         }
     }
 

--- a/topiary-tree-sitter-facade/src/parser.rs
+++ b/topiary-tree-sitter-facade/src/parser.rs
@@ -4,7 +4,7 @@
 mod native {
     use crate::{
         error::{IncludedRangesError, LanguageError, ParserError},
-        language::Language,
+        language::{Language, LanguageRef},
         logger::{Logger, LoggerReturn},
         point::Point,
         range::Range,
@@ -31,7 +31,7 @@ mod native {
         }
 
         #[inline]
-        pub fn language(&self) -> Option<Language> {
+        pub fn language(&self) -> Option<LanguageRef> {
             self.inner.language().map(Into::into)
         }
 

--- a/topiary-tree-sitter-facade/src/query_match.rs
+++ b/topiary-tree-sitter-facade/src/query_match.rs
@@ -1,36 +1,25 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
     use crate::query_capture::QueryCapture;
-    use std::convert::TryFrom;
+    pub use tree_sitter::QueryMatches;
 
-    pub struct QueryMatch<'tree> {
-        pub(crate) inner: tree_sitter::QueryMatch<'tree, 'tree>,
+    pub trait QueryMatch<'tree> {
+        fn pattern_index(&self) -> usize;
+
+        fn captures(&self) -> impl ExactSizeIterator<Item = QueryCapture<'tree>>;
     }
 
-    impl<'tree> QueryMatch<'tree> {
+    impl<'tree> QueryMatch<'tree> for tree_sitter::QueryMatch<'tree, 'tree> {
         #[inline]
-        pub fn pattern_index(&self) -> u32 {
-            u32::try_from(self.inner.pattern_index).unwrap()
+        fn pattern_index(&self) -> usize {
+            self.pattern_index
         }
 
         #[inline]
-        pub fn captures(&self) -> impl ExactSizeIterator<Item = QueryCapture<'tree>> {
-            self.inner.captures.iter().map(Into::into)
+        fn captures(&self) -> impl ExactSizeIterator<Item = QueryCapture<'tree>> {
+            self.captures.iter().map(Into::into)
         }
     }
-
-    impl<'tree> From<tree_sitter::QueryMatch<'tree, 'tree>> for QueryMatch<'tree> {
-        #[inline]
-        fn from(inner: tree_sitter::QueryMatch<'tree, 'tree>) -> Self {
-            Self { inner }
-        }
-    }
-
-    impl<'tree> std::panic::RefUnwindSafe for QueryMatch<'tree> {}
-
-    impl<'tree> Unpin for QueryMatch<'tree> {}
-
-    impl<'tree> std::panic::UnwindSafe for QueryMatch<'tree> {}
 }
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
# Bump tree-sitter to 0.24

Closes #684 

## Description

Biggest difficulty is that `tree_sitter::QueryMatches` is now a `StreamingIterator`, returning references rather than values. This makes it very difficult to store in a new type.

Instead make `topiary_tree_sitter_facade::QueryMatch` a trait rather than a new type. This seems to be the easiest way to preserve as much of the existing structure as possible.

Not tested for the wasm32 build, so possibly some changes required there to match.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [ ] README.md up-to-date
