### PR TITLE
TOML: Hardline after table-less pairs

### DIFF
--- a/topiary-cli/tests/samples/expected/toml.toml
+++ b/topiary-cli/tests/samples/expected/toml.toml
@@ -1,3 +1,8 @@
+# Table-less pairs (#798)
+foo = "bar"
+baz = 'quux'
+abc = 123
+
 [package]
 
 name = "topiary"

--- a/topiary-cli/tests/samples/input/toml.toml
+++ b/topiary-cli/tests/samples/input/toml.toml
@@ -1,3 +1,7 @@
+# Table-less pairs (#798)
+foo = "bar"
+baz = 'quux'
+abc = 123
 
 [package]
 

--- a/topiary-queries/queries/toml.scm
+++ b/topiary-queries/queries/toml.scm
@@ -19,6 +19,10 @@
   (comment)
 ] @append_hardline
 
+(document
+  (pair) @append_hardline
+)
+
 (table
   (pair) @append_hardline
 )


### PR DESCRIPTION
# TOML: Hardline after table-less pairs

Resolves #798

## Description

Update the TOML queries to add hardlines after table-less pairs.

## Checklist
Checklist before merging:
- [ ] CHANGELOG.md updated
- [ ] README.md up-to-date
