### PR TITLE
Remove Nix dependency: nix-filter

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,6 @@
 , advisory-db
 , crane
 , rust-overlay
-, nix-filter
 , craneLib
 # tree-sitter-Nickel is packaged in Nixpkgs, but it's an older version at the
 # time of writing. Since updating it seems non trivial, and we need Topiary to
@@ -12,6 +11,7 @@
 , tree-sitter-nickel
 }:
 let
+  inherit (pkgs.lib) fileset;
   wasmRustVersion = "1.77.2";
   wasmTarget = "wasm32-unknown-unknown";
 
@@ -22,23 +22,21 @@ let
   commonArgs = {
     pname = "topiary";
 
-    src = nix-filter.lib.filter {
+    src = fileset.toSource {
       root = ./.;
-      include = [
-        "benches"
-        "Cargo.lock"
-        "Cargo.toml"
-        "languages.ncl"
-        "languages_nix.ncl"
-        "tests"
-        "topiary-core"
-        "topiary-cli"
-        "topiary-config"
-        "topiary-playground"
-        "topiary-queries"
-        "topiary-tree-sitter-facade"
-        "topiary-web-tree-sitter-sys"
-        "examples"
+      fileset = fileset.unions [
+        ./Cargo.lock
+        ./Cargo.toml
+        ./languages.ncl
+        ./languages_nix.ncl
+        ./examples
+        ./topiary-core
+        ./topiary-cli
+        ./topiary-config
+        ./topiary-playground
+        ./topiary-queries
+        ./topiary-tree-sitter-facade
+        ./topiary-web-tree-sitter-sys
       ];
     };
 

--- a/flake.lock
+++ b/flake.lock
@@ -54,21 +54,6 @@
         "type": "github"
       }
     },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1723221148,
@@ -106,7 +91,6 @@
         "advisory-db": "advisory-db",
         "crane": "crane",
         "flake-utils": "flake-utils",
-        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "tree-sitter-nickel-input": "tree-sitter-nickel-input"

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
     };
 
     flake-utils.url = "github:numtide/flake-utils";
-    nix-filter.url = "github:numtide/nix-filter";
 
     tree-sitter-nickel-input = {
       url = "github:nickel-lang/tree-sitter-nickel";
@@ -64,7 +63,7 @@
         tree-sitter-nickel = tree-sitter-nickel-input.packages.${system}.default;
 
         topiaryPkgs = pkgs.callPackage ./default.nix {
-          inherit advisory-db crane rust-overlay nix-filter craneLib tree-sitter-nickel;
+          inherit advisory-db crane rust-overlay craneLib tree-sitter-nickel;
         };
         binPkgs = pkgs.callPackage ./bin/default.nix { };
       in


### PR DESCRIPTION
`lib.fileset` made this dependency obsolete. Do not make downstream users depend on it too. Related #613.

This merge request results in less lines of code too.

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
