### PR TITLE
Remove .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 /.direnv
 *.profraw
 /.vscode
+.envrc


### PR DESCRIPTION
Direnv is intended to be per-user config, not committed to the repository (same as you shouldn’t your text editor configuration). This is both poses a security risk to just run code, but also is preventing customization (& can introduced accidental commits as seen/forecasted in the Nixpkgs footnote link). This project unlike most identified that you may want multiple `devShells` but how does one put use `use flake .#light` if you remove that choice? Users that want an automatic shell can run `echo "use flake .#default" > .envrc && direnv allow` if they so choose.

See more discussion: https://github.com/NixOS/nixpkgs/pull/325793

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.