### PR TITLE
provide & use mainProgram

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -150,6 +150,8 @@ in
     shellHook = ''
       export TOPIARY_LANGUAGE_DIR=$PWD/queries
     '';
+
+    meta.mainProgram = "topiary";
   });
 
   topiary-queries = craneLib.buildPackage (commonArgs

--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,7 @@
           enable = true;
           name = "topiary";
           description = "A general code formatter based on tree-sitter.";
-          entry = "${pkgs.lib.getExe topiaryPkgs.topiary-cli {}} fmt";
+          entry = "${pkgs.lib.getExe (topiaryPkgs.topiary-cli {})} fmt";
           types = [ "text" ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,7 @@
           enable = true;
           name = "topiary";
           description = "A general code formatter based on tree-sitter.";
-          entry = "${topiaryPkgs.topiary-cli {}}/bin/topiary fmt";
+          entry = "${pkgs.lib.getExe topiaryPkgs.topiary-cli {}} fmt";
           types = [ "text" ];
         };
       }


### PR DESCRIPTION
This makes topiary easier to use from Nix… you can now use `nix run`

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.