### PR TITLE
Optimize LALRPOP compilation to reduce build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,9 @@ topiary-tree-sitter-facade = { version = "0.5.1", path = "./topiary-tree-sitter-
 topiary-core = { version = "0.5.1", path = "./topiary-core" }
 topiary-config = { version = "0.5.1", path = "./topiary-config" }
 topiary-queries = { version = "0.5.1", path = "./topiary-queries" }
+
+[profile.dev.package.lalrpop]
+opt-level = 3
+
+[profile.release.package.lalrpop]
+opt-level = 3


### PR DESCRIPTION
# Improve LALRPOP build time

## Description

Since the introduction of Nickel as the configuration language for Topiary, the build time from scratch has taken a big hit. It turns out we had build time issues in Nickel as well some time ago, and it was due to LALRPOP: the latter does quite a bit of work at build time to generate the parser, but by default cargo builds `build-dependencies` without optimizations, in order to optimize for compilation time. However, in this case, the optimum is actually to aggressively optimize LARLPOP at build time.

We got good results by changing the configuration in Nickel's `Cargo.toml`. Unfortunately, as noted in https://github.com/tweag/nickel/issues/2123, this setting doesn't propagate to downstream dependencies. I don't have a nice solution for now, but a temporary one is just to reproduce the override here in Topiary as well.

### Results

I did a few tries with and without the setting, and got a consistent ~33% build time reduction after a `cargo clean`:

```text
cargo build --bin topiary --profile release  527,14s user 20,58s system 172% cpu 5:16,87 total
cargo build --bin topiary --profile release  348,13s user 20,29s system 399% cpu 1:32,17 total
```

## Checklist

Checklist before merging:
- [ ] CHANGELOG.md updated
- [ ] README.md up-to-date

P.S: I think I won't include that in the CHANGELOG, I don't know if it's really useful to know for end-users. Happy to do it if you think it's worth it, though.