### PR TITLE
fix(docs): fix outdated example that uses `@begin_scope` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1231,8 +1231,8 @@ This Tree-sitter query:
 (#language! ocaml)
 
 (parenthesized_expression
-  "(" @begin_scope @append_empty_softline @append_indent_start
-  ")" @end_scope @prepend_empty_softline @prepend_indent_end
+  "(" @append_begin_scope @append_empty_softline @append_indent_start
+  ")" @append_end_scope @prepend_empty_softline @prepend_indent_end
   (#scope_id! "tuple")
 )
 


### PR DESCRIPTION
## Description
the current `README.md` has an example that referred to an old variant of starting scopes

## Checklist
Checklist before merging:
- [ ] CHANGELOG.md updated
- [X] README.md up-to-date
