### PR TITLE
Implement multiline delimiter catpures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ futures = "0.3.28"
 itertools = "0.11"
 js-sys = "0.3"
 libloading = "0.8.4"
-log = "0.4"
+log = { version = "0.4", features = ["kv"] }
 nickel-lang-core = { version = "0.8.0", default-features = false }
 predicates = "3.0"
 pretty_assertions = "1.3"

--- a/topiary-cli/tests/samples/expected/rust.rs
+++ b/topiary-cli/tests/samples/expected/rust.rs
@@ -109,3 +109,10 @@ impl MyTrait for MyStruct {
         // ... logic ...
     }
 }
+
+fn main() {
+    self.append(Atom::Empty,
+        node,
+        predicates,
+    );
+}

--- a/topiary-cli/tests/samples/input/rust.rs
+++ b/topiary-cli/tests/samples/input/rust.rs
@@ -112,7 +112,7 @@ impl MyTrait for MyStruct {
 }
 
 fn main() {
-    self.append(Atom::ScopeEnd(scope_information_append()?),
+    self.append(Atom::Empty,
         node,
         predicates
     );

--- a/topiary-cli/tests/samples/input/rust.rs
+++ b/topiary-cli/tests/samples/input/rust.rs
@@ -110,3 +110,10 @@ impl MyTrait for MyStruct {
         // ... logic ...
     }
 }
+
+fn main() {
+    self.append(Atom::ScopeEnd(scope_information_append()?),
+        node,
+        predicates
+    );
+}

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -226,6 +226,15 @@ impl AtomCollection {
                 node,
                 predicates,
             ),
+            "append_multiline_delimiter" => {
+                if self.in_multiline_context(node) {
+                    self.append(
+                        Atom::Literal(requires_delimiter()?.to_string()),
+                        node,
+                        predicates,
+                    )
+                }
+            }
             "append_empty_softline" => {
                 self.append(Atom::Softline { spaced: false }, node, predicates);
             }
@@ -251,6 +260,15 @@ impl AtomCollection {
                 node,
                 predicates,
             ),
+            "prepend_multiline_delimiter" => {
+                if self.in_multiline_context(node) {
+                    self.prepend(
+                        Atom::Literal(requires_delimiter()?.to_string()),
+                        node,
+                        predicates,
+                    )
+                }
+            }
             "prepend_empty_softline" => {
                 self.prepend(Atom::Softline { spaced: false }, node, predicates);
             }
@@ -591,6 +609,22 @@ impl AtomCollection {
         self.append.entry(target_node.id()).or_default().push(atom);
     }
 
+    /// Indicates whether we are in a multiline context or not.
+    /// # Arguments
+    ///
+    /// * `node` - The node to which the atom applies.
+    /// # Returns
+    ///
+    /// A boolean indicating whether a given node has a a parent  labelled as multi-line.
+    /// If the provided node has no parent, the function returns `false`.
+    fn in_multiline_context(&self, node: &Node) -> bool {
+        let parent_id = node.parent().map(|p| p.id());
+
+        parent_id
+            .map(|pid| self.multi_line_nodes.contains(&pid))
+            .unwrap_or(false)
+    }
+
     /// Expands a softline atom to a hardline, space or empty atom depending on
     /// if we are in a multiline context or not.
     ///
@@ -612,34 +646,32 @@ impl AtomCollection {
     ///
     /// A new atom after expanding the softline if applicable.
     fn expand_multiline(&self, atom: Atom, node: &Node) -> Atom {
-        if let Atom::Softline { spaced } = atom {
-            if let Some(parent) = node.parent() {
-                let parent_id = parent.id();
+        let Atom::Softline { spaced } = atom else {
+            return atom;
+        };
+        let Some(parent) = node.parent() else {
+            return Atom::Empty;
+        };
+        let parent_id = parent.id();
 
-                if self.multi_line_nodes.contains(&parent_id) {
-                    log::debug!(
-                        "Expanding softline to hardline in node {} with parent {}: {}",
-                        node.display_one_based(),
-                        parent_id,
-                        parent.display_one_based()
-                    );
-                    Atom::Hardline
-                } else if spaced {
-                    log::debug!(
-                        "Expanding softline to space in node {} with parent {}: {}",
-                        node.display_one_based(),
-                        parent_id,
-                        parent.display_one_based()
-                    );
-                    Atom::Space
-                } else {
-                    Atom::Empty
-                }
-            } else {
-                Atom::Empty
-            }
+        if self.multi_line_nodes.contains(&parent_id) {
+            log::debug!(
+                parent_id;
+                "Expanding softline to hardline in node {}: {}",
+                node.display_one_based(),
+                parent.display_one_based()
+            );
+            Atom::Hardline
+        } else if spaced {
+            log::debug!(
+                parent_id;
+                "Expanding softline to space in node {}: {}",
+                node.display_one_based(),
+                parent.display_one_based()
+            );
+            Atom::Space
         } else {
-            atom
+            Atom::Empty
         }
     }
 

--- a/topiary-queries/queries/rust.scm
+++ b/topiary-queries/queries/rust.scm
@@ -205,3 +205,14 @@
 (
   "," @prepend_antispace
 )
+
+; append trailing comman to newline delimited arguments
+(arguments
+  (#delimiter! ",")
+  (_) @append_multiline_delimiter
+  .
+  ","? @do_nothing
+  .
+  ")"
+  .
+)


### PR DESCRIPTION
# Implement multiline delimiter catpures<!-- Please refer to an issue, or remove this line if the PR is unrelated to an issue -->
Issue: #835 

## Description
Implemented missing features for `@append_multiline_delimiter` and `@prepend_multiline_delimiter` documented in the project README
## Checklist
Checklist before merging:
- [ ] CHANGELOG.md updated
- [ ] README.md up-to-date
