### PR TITLE
fix(clippy): apply `needless_lifetimes` clippy fix

### DIFF
--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -115,7 +115,7 @@ pub struct InputFile<'cfg> {
     query: QuerySource,
 }
 
-impl<'cfg> InputFile<'cfg> {
+impl InputFile<'_> {
     /// Convert our `InputFile` into language definition values that Topiary can consume
     pub async fn to_language(&self) -> CLIResult<Language> {
         let grammar = self.language().grammar()?;
@@ -149,7 +149,7 @@ impl<'cfg> InputFile<'cfg> {
     }
 }
 
-impl<'cfg> Read for InputFile<'cfg> {
+impl Read for InputFile<'_> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match &mut self.source {
             InputSource::Stdin => stdin().lock().read(buf),
@@ -312,7 +312,7 @@ impl Write for OutputFile {
 // Convenience conversion:
 // * stdin maps to stdout
 // * Files map to themselves (i.e., for in-place updates)
-impl<'cfg> TryFrom<&InputFile<'cfg>> for OutputFile {
+impl TryFrom<&InputFile<'_>> for OutputFile {
     type Error = TopiaryError;
 
     fn try_from(input: &InputFile) -> CLIResult<Self> {

--- a/topiary-core/benches/benchmark.rs
+++ b/topiary-core/benches/benchmark.rs
@@ -14,7 +14,7 @@ async fn format() {
 
     let language: Language = Language {
         name: "ocaml".to_owned(),
-        query: TopiaryQuery::new(&ocaml.clone().into(), &query_content).unwrap(),
+        query: TopiaryQuery::new(&ocaml.into(), &query_content).unwrap(),
         grammar: ocaml.into(),
         indent: None,
     };

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -154,7 +154,7 @@ pub trait NodeExt {
     fn display_one_based(&self) -> String;
 }
 
-impl<'a> NodeExt for Node<'a> {
+impl NodeExt for Node<'_> {
     fn display_one_based(&self) -> String {
         format!(
             "{{Node {:?} {} - {}}}",
@@ -166,7 +166,7 @@ impl<'a> NodeExt for Node<'a> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl<'a> NodeExt for tree_sitter::Node<'a> {
+impl NodeExt for tree_sitter::Node<'_> {
     fn display_one_based(&self) -> String {
         format!(
             "{{Node {:?} {} - {}}}",
@@ -189,7 +189,7 @@ struct LocalQueryMatch<'a> {
     captures: Vec<QueryCapture<'a>>,
 }
 
-impl<'a> Display for LocalQueryMatch<'a> {
+impl Display for LocalQueryMatch<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,

--- a/topiary-tree-sitter-facade/src/language.rs
+++ b/topiary-tree-sitter-facade/src/language.rs
@@ -6,7 +6,7 @@ mod native {
         pub(crate) inner: tree_sitter::LanguageRef<'a>,
     }
 
-    impl<'a> LanguageRef<'a> {
+    impl LanguageRef<'_> {
         pub fn field_count(&self) -> usize {
             self.inner.field_count()
         }

--- a/topiary-tree-sitter-facade/src/node.rs
+++ b/topiary-tree-sitter-facade/src/node.rs
@@ -243,7 +243,7 @@ mod native {
         }
     }
 
-    impl<'tree> std::fmt::Debug for Node<'tree> {
+    impl std::fmt::Debug for Node<'_> {
         fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
             std::fmt::Debug::fmt(&self.inner, fmt)
         }
@@ -256,7 +256,7 @@ mod native {
         }
     }
 
-    impl<'a> Ord for Node<'a> {
+    impl Ord for Node<'_> {
         fn cmp(&self, that: &Self) -> std::cmp::Ordering {
             let this = self.id();
             let that = that.id();
@@ -270,11 +270,11 @@ mod native {
         }
     }
 
-    impl<'a> std::panic::RefUnwindSafe for Node<'a> {}
+    impl std::panic::RefUnwindSafe for Node<'_> {}
 
-    impl<'a> Unpin for Node<'a> {}
+    impl Unpin for Node<'_> {}
 
-    impl<'a> std::panic::UnwindSafe for Node<'a> {}
+    impl std::panic::UnwindSafe for Node<'_> {}
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/topiary-tree-sitter-facade/src/query_capture.rs
+++ b/topiary-tree-sitter-facade/src/query_capture.rs
@@ -8,7 +8,7 @@ mod native {
         pub(crate) inner: tree_sitter::QueryCapture<'a>,
     }
 
-    impl<'a> QueryCapture<'a> {
+    impl QueryCapture<'_> {
         #[inline]
         pub fn node(&self) -> Node {
             self.inner.node.into()
@@ -21,7 +21,7 @@ mod native {
         }
     }
 
-    impl<'a> std::fmt::Debug for QueryCapture<'a> {
+    impl std::fmt::Debug for QueryCapture<'_> {
         fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
             std::fmt::Debug::fmt(&self.inner, fmt)
         }
@@ -41,11 +41,11 @@ mod native {
         }
     }
 
-    impl<'a> std::panic::RefUnwindSafe for QueryCapture<'a> {}
+    impl std::panic::RefUnwindSafe for QueryCapture<'_> {}
 
-    impl<'a> Unpin for QueryCapture<'a> {}
+    impl Unpin for QueryCapture<'_> {}
 
-    impl<'a> std::panic::UnwindSafe for QueryCapture<'a> {}
+    impl std::panic::UnwindSafe for QueryCapture<'_> {}
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/topiary-tree-sitter-facade/src/query_predicate.rs
+++ b/topiary-tree-sitter-facade/src/query_predicate.rs
@@ -6,7 +6,7 @@ mod native {
         pub(crate) inner: &'query tree_sitter::QueryPredicate,
     }
 
-    impl<'query> QueryPredicate<'query> {
+    impl QueryPredicate<'_> {
         #[inline]
         pub fn operator(&self) -> Cow<str> {
             Cow::Borrowed(&self.inner.operator)
@@ -30,7 +30,7 @@ mod native {
         }
     }
 
-    impl<'query> std::fmt::Debug for QueryPredicate<'query> {
+    impl std::fmt::Debug for QueryPredicate<'_> {
         fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
             std::fmt::Debug::fmt(&self.inner, fmt)
         }
@@ -43,11 +43,11 @@ mod native {
         }
     }
 
-    impl<'query> std::panic::RefUnwindSafe for QueryPredicate<'query> {}
+    impl std::panic::RefUnwindSafe for QueryPredicate<'_> {}
 
-    impl<'query> Unpin for QueryPredicate<'query> {}
+    impl Unpin for QueryPredicate<'_> {}
 
-    impl<'query> std::panic::UnwindSafe for QueryPredicate<'query> {}
+    impl std::panic::UnwindSafe for QueryPredicate<'_> {}
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/topiary-tree-sitter-facade/src/tree_cursor.rs
+++ b/topiary-tree-sitter-facade/src/tree_cursor.rs
@@ -61,11 +61,11 @@ mod native {
         }
     }
 
-    impl<'a> std::panic::RefUnwindSafe for TreeCursor<'a> {}
+    impl std::panic::RefUnwindSafe for TreeCursor<'_> {}
 
-    impl<'a> Unpin for TreeCursor<'a> {}
+    impl Unpin for TreeCursor<'_> {}
 
-    impl<'a> std::panic::UnwindSafe for TreeCursor<'a> {}
+    impl std::panic::UnwindSafe for TreeCursor<'_> {}
 }
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
# fix(clippy): apply `needless_lifetimes` clippy fix

## Description
https://github.com/tweag/topiary/pull/845 [CI run](https://github.com/tweag/topiary/actions/runs/12917298008/job/36023363227?pr=845) complained about unelided lifetimes, ran `cargo clippy --fix` to solve the issue.

## Checklist
Checklist before merging:
- [ ] CHANGELOG.md updated
- [x] README.md up-to-date
