### PR TITLE
Fix and update `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,23 @@ This, on the other hand, will not work:
 @append_space (infix_operator)
 ```
 
+### `@leaf`
+
+Some nodes should not have their contents formatted at all; the classic
+example being string literals. The `@leaf` capture will mark such nodes
+as leaves -- even if they admit their own structure -- and leave them
+unformatted.
+
+#### Example
+
+```scheme
+; Don't format strings or comments
+[
+  (string)
+  (comment)
+] @leaf
+```
+
 ### `@allow_blank_line_before`
 
 The matched nodes will be allowed to have a blank line before them, if

--- a/README.md
+++ b/README.md
@@ -756,33 +756,6 @@ not activate.
 Note that `@append_delimiter` is the same as `@append_space` when the
 delimiter is set to `" "` (i.e., a space).
 
-### `@append_multiline_delimiter` / `@prepend_multiline_delimiter`
-
-The matched nodes will have a multi-line-only delimiter appended to
-them. It will be printed only in multi-line nodes, and omitted in
-single-line nodes. The delimiter must be specified using the predicate
-`#delimiter!`.
-
-#### Example
-
-```scheme
-; Add a semicolon at the end of lists only if they are multi-line, to avoid [1; 2; 3;].
-(list_expression
-  (#delimiter! ";")
-  (_) @append_multiline_delimiter
-  .
-  ";"? @do_nothing
-  .
-  "]"
-  .
-)
-```
-
-If there is already a semicolon, the `@do_nothing` instruction will be
-activated and prevent the other instructions in the query (the
-`@append_multiline_delimiter`, here) from applying. Likewise, if the
-node is single-line, the delimiter will not be appended either.
-
 ### `@append_empty_softline` / `@prepend_empty_softline`
 
 The matched nodes will have an empty softline appended or prepended to

--- a/README.md
+++ b/README.md
@@ -1680,13 +1680,14 @@ debugging output's 0-based position.)
 
 ### Terminal-Based Playground
 
-Nix users may also find the `playground.sh` script to be helpful in
+Nix users may also find the `bin/playground.sh` script to be helpful in
 aiding the interactive development of query files. When run in a
-terminal, it will format the given source input with the requested query
-file, updating the output on any inotify event against those files.
+terminal, inside the Nix development shell, it will format the given
+source input with the requested query file, updating the output on any
+inotify event against those files.
 
 ```
-Usage: ${PROGNAME} LANGUAGE [QUERY_FILE] [INPUT_SOURCE]
+Usage: playground LANGUAGE [QUERY_FILE] [INPUT_SOURCE]
 
 LANGUAGE can be one of the supported languages (e.g., "ocaml", "rust",
 etc.). The packaged formatting queries for this language can be
@@ -1698,6 +1699,9 @@ to find the bundled integration test input file for the given language.
 
 For example, the playground can be run in a tmux pane, with your editor
 of choice open in another.
+
+> [!WARNING]
+> The use of inotify limits this tool to Linux systems, only.
 
 ## Related Tools
 


### PR DESCRIPTION
# Fix and update `README`
Resolves #840
Resolves #841

## Description

Fixes an observed regression in the `README` from #354. The offending PR couldn't be found and `git blame` wasn't helpful. This is slightly annoying as it leaves some room for doubt over other potential divergence.

I did find one other copy-and-paste fail, for the TTY playground.

I also took the opportunity to document `@leaf` and the considerations around query and capture order.

## Checklist
Checklist before merging:
- [ ] ~CHANGELOG.md updated~
- [x] README.md up-to-date
