### PR TITLE
Optionally follow symlinks when specifying input files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This name should be decided amongst the team before the release.
 - [#786](https://github.com/tweag/topiary/pull/786) Re-introduce tests to check that all of the language queries are useful.
 - [#747](https://github.com/tweag/topiary/pull/747) Added support for specifying paths to prebuilt grammars in Topiary's configuration
 - [#832](https://github.com/tweag/topiary/pull/832) Added `typos-cli` to workspace `Cargo.toml` for spellchecking @mkatychev
+- [#851](https://github.com/tweag/topiary/pull/851) Added support for following symlinks when specifying input files for formatting
 
 ### Changed
 - [#794](https://github.com/tweag/topiary/pull/794) Bump the `tree-sitter` dependency to 0.24, thanks to @ZedThree

--- a/README.md
+++ b/README.md
@@ -211,8 +211,7 @@ Arguments:
   [FILES]...
           Input files and directories (omit to read from stdin)
 
-          Language detection and query selection is automatic, mapped from file extensions defined
-          in the Topiary configuration.
+          Language detection and query selection is automatic, mapped from file extensions defined in the Topiary configuration.
 
 Options:
   -t, --tolerate-parsing-errors
@@ -222,10 +221,13 @@ Options:
           Do not check that formatting twice gives the same output
 
   -l, --language <LANGUAGE>
-          Topiary language identifier (for formatting stdin)
+          Topiary language identifier (when formatting stdin)
 
   -q, --query <QUERY>
           Topiary query file override (when formatting stdin)
+
+  -L, --follow-symlinks
+          Follow symlinks (when formatting files)
 
   -C, --configuration <CONFIGURATION>
           Configuration file
@@ -263,8 +265,8 @@ example, using Graphviz's `dot`: `topiary visualise input.ocaml | dot -T png
 ```
 Visualise the input's Tree-sitter parse tree
 
-Visualise generates a graph representation of the parse tree that can be rendered by external
-visualisation tools, such as Graphviz. By default, the output is in the DOT format.
+Visualise generates a graph representation of the parse tree that can be rendered by external visualisation tools, such as
+Graphviz. By default, the output is in the DOT format.
 
 Usage: topiary visualise [OPTIONS] <--language <LANGUAGE>|FILE>
 
@@ -272,8 +274,7 @@ Arguments:
   [FILE]
           Input file (omit to read from stdin)
 
-          Language detection and query selection is automatic, mapped from file extensions defined
-          in the Topiary configuration.
+          Language detection and query selection is automatic, mapped from file extensions defined in the Topiary configuration.
 
 Options:
   -f, --format <FORMAT>
@@ -286,7 +287,7 @@ Options:
           - json: JSON serialisation
 
   -l, --language <LANGUAGE>
-          Topiary language identifier (for formatting stdin)
+          Topiary language identifier (when formatting stdin)
 
   -q, --query <QUERY>
           Topiary query file override (when formatting stdin)
@@ -348,8 +349,7 @@ Generate shell completion script
 Usage: topiary completion [OPTIONS] [SHELL]
 
 Arguments:
-  [SHELL]  Shell (omit to detect from the environment) [possible values: bash, elvish, fish,
-           powershell, zsh]
+  [SHELL]  Shell (omit to detect from the environment) [possible values: bash, elvish, fish, powershell, zsh]
 
 Options:
   -C, --configuration <CONFIGURATION>  Configuration file [env: TOPIARY_CONFIG_FILE]
@@ -404,12 +404,11 @@ Arguments:
   [FILE]
           Input file (omit to read from stdin)
 
-          Language detection and query selection is automatic, mapped from file extensions defined
-          in the Topiary configuration.
+          Language detection and query selection is automatic, mapped from file extensions defined in the Topiary configuration.
 
 Options:
   -l, --language <LANGUAGE>
-          Topiary language identifier (for formatting stdin)
+          Topiary language identifier (when formatting stdin)
 
   -q, --query <QUERY>
           Topiary query file override (when formatting stdin)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ Arguments:
   [FILES]...
           Input files and directories (omit to read from stdin)
 
-          Language detection and query selection is automatic, mapped from file extensions defined in the Topiary configuration.
+          Language detection and query selection is automatic, mapped from file extensions defined
+          in the Topiary configuration.
 
 Options:
   -t, --tolerate-parsing-errors
@@ -283,8 +284,8 @@ example, using Graphviz's `dot`: `topiary visualise input.ocaml | dot -T png
 ```
 Visualise the input's Tree-sitter parse tree
 
-Visualise generates a graph representation of the parse tree that can be rendered by external visualisation tools, such as
-Graphviz. By default, the output is in the DOT format.
+Visualise generates a graph representation of the parse tree that can be rendered by external
+visualisation tools, such as Graphviz. By default, the output is in the DOT format.
 
 Usage: topiary visualise [OPTIONS] <--language <LANGUAGE>|FILE>
 
@@ -292,7 +293,8 @@ Arguments:
   [FILE]
           Input file (omit to read from stdin)
 
-          Language detection and query selection is automatic, mapped from file extensions defined in the Topiary configuration.
+          Language detection and query selection is automatic, mapped from file extensions defined
+          in the Topiary configuration.
 
 Options:
   -f, --format <FORMAT>
@@ -369,7 +371,8 @@ Generate shell completion script
 Usage: topiary completion [OPTIONS] [SHELL]
 
 Arguments:
-  [SHELL]  Shell (omit to detect from the environment) [possible values: bash, elvish, fish, powershell, zsh]
+  [SHELL]  Shell (omit to detect from the environment) [possible values: bash, elvish, fish,
+           powershell, zsh]
 
 Options:
   -C, --configuration <CONFIGURATION>  Configuration file [env: TOPIARY_CONFIG_FILE]
@@ -424,7 +427,8 @@ Arguments:
   [FILE]
           Input file (omit to read from stdin)
 
-          Language detection and query selection is automatic, mapped from file extensions defined in the Topiary configuration.
+          Language detection and query selection is automatic, mapped from file extensions defined
+          in the Topiary configuration.
 
 Options:
   -l, --language <LANGUAGE>

--- a/README.md
+++ b/README.md
@@ -253,11 +253,22 @@ input files.
 > [!TIP]
 > `fmt` is a recognised alias of the `format` subcommand.
 
-> [!WARNING]
-> Topiary performs in-place file formatting by writing the formatted
-> output to a temporary file and then replacing that with the original
-> input file. For files with multiple links, on filesystems where that
-> makes sense, this will break the link.
+> [!TIP]
+> Topiary will not accept a process substitution (or any other named
+> pipe) as formatting input. Instead, arrange for a redirection into
+> Topiary's standard input:
+>
+> ```bash
+> # This won't work
+> topiary format <(some_command)
+>
+> # Do this instead
+> some_command | topiary format --language LANGUAGE
+> ```
+
+> [!NOTE]
+> Topiary will skip over files that have multiple (hard) links to avoid
+> breaking said links. A warning will be logged to indicate this.
 
 #### Visualise
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,14 @@ the input files' extensions. To format standard input, you must specify
 the `--language` and, optionally, `--query` arguments, omitting any
 input files.
 
-Note: `fmt` is a recognised alias of the `format` subcommand.
+> [!TIP]
+> `fmt` is a recognised alias of the `format` subcommand.
+
+> [!WARNING]
+> Topiary performs in-place file formatting by writing the formatted
+> output to a temporary file and then replacing that with the original
+> input file. For files with multiple links, on filesystems where that
+> makes sense, this will break the link.
 
 #### Visualise
 
@@ -313,8 +320,9 @@ the input file's extension. To visualise standard input, you must
 specify the `--language` and, optionally, `--query` arguments, omitting
 the input file. The visualisation output is written to standard out.
 
-Note: `vis`, `visualize` and `view` are recognised aliases of the
-`visualise` subcommand.
+> [!TIP]
+> `vis`, `visualize` and `view` are recognised aliases of the
+> `visualise` subcommand.
 
 #### Configuration
 
@@ -333,7 +341,8 @@ Options:
 ```
 <!-- usage:end:config -->
 
-Note: `cfg` is a recognised alias of the `config` subcommand.
+> [!TIP]
+> `cfg` is a recognised alias of the `config` subcommand.
 
 #### Shell Completion
 
@@ -1660,18 +1669,20 @@ suggested way to work:
    CST output that starts with a line like this: `CST node: {Node
    compilation_unit (0, 0) - (5942, 0)} - Named: true`.
 
-   :bulb: As an alternative to using the debugging output, the
-   `vis` visualisation subcommand line option exists to output the
-   Tree-sitter syntax tree in a variety of formats.
+> [!TIP]
+> As an alternative to using the debugging output, the `vis`
+> visualisation subcommand line option exists to output the Tree-sitter
+> syntax tree in a variety of formats.
 
 5. The test run will output all the differences between the actual
    output and the expected output, e.g. missing spaces between tokens.
    Pick a difference you would like to fix, and find the line number and
    column in the input file.
 
-   :bulb: Keep in mind that the CST output uses 0-based line and column
-   numbers, so if your editor reports line 40, column 37, you probably
-   want line 39, column 36.
+> [!NOTE]
+> Keep in mind that the CST output uses 0-based line and column numbers,
+> so if your editor reports line 40, column 37, you probably want line
+> 39, column 36.
 
 6. In the CST debug or visualisation output, find the nodes in this
    region, such as the following:

--- a/README.md
+++ b/README.md
@@ -268,8 +268,16 @@ input files.
 > ```
 
 > [!NOTE]
-> Topiary will skip over files that have multiple (hard) links to avoid
-> breaking said links. A warning will be logged to indicate this.
+> Topiary will skip over some input files under certain conditions,
+> which are logged at varying levels:
+>
+> | Condition                                     | Level   |
+> | :-------------------------------------------- | :------ |
+> | Cannot access file                            | Error   |
+> | Not a regular file (e.g., FIFO, socket, etc.) | Warning |
+> | A symlink without `--follow-symlinks`         | Warning |
+> | File with multiple (hard) links               | Error   |
+> | File does not exist (e.g., broken symlink)    | Error   |
 
 #### Visualise
 

--- a/topiary-cli/src/cli.rs
+++ b/topiary-cli/src/cli.rs
@@ -58,7 +58,7 @@ pub struct GlobalArgs {
 // NOTE This abstraction is largely to workaround clap-rs/clap#4707
 #[derive(Args, Debug)]
 pub struct FromStdin {
-    /// Topiary language identifier (for formatting stdin)
+    /// Topiary language identifier (when formatting stdin)
     #[arg(short, long)]
     pub language: String,
 
@@ -109,6 +109,10 @@ pub struct AtLeastOneInput {
     /// Language detection and query selection is automatic, mapped from file extensions defined in
     /// the Topiary configuration.
     pub files: Vec<PathBuf>,
+
+    /// Follow symlinks (when formatting files)
+    #[arg(short = 'L', long)]
+    pub follow_symlinks: bool,
 }
 
 // NOTE When changing the subcommands, please update verify-documented-usage.sh respectively.
@@ -172,16 +176,34 @@ pub enum Commands {
 }
 
 /// Given a vector of paths, recursively expand those that identify as directories, in place
-fn traverse_fs(files: &mut Vec<PathBuf>) -> CLIResult<()> {
+fn traverse_fs(files: &mut Vec<PathBuf>, follow_symlinks: bool) -> CLIResult<()> {
     let mut expanded = vec![];
 
     for file in &mut *files {
-        if file.is_dir() {
+        let is_dir = if follow_symlinks {
+            file.is_dir()
+        } else {
+            file.is_dir() && !file.is_symlink()
+        };
+
+        if is_dir {
+            // Descend into directory, symlink-aware as required
             let mut subfiles = file.read_dir()?.flatten().map(|f| f.path()).collect();
-            traverse_fs(&mut subfiles)?;
+            traverse_fs(&mut subfiles, follow_symlinks)?;
             expanded.append(&mut subfiles);
         } else {
-            expanded.push(file.to_path_buf());
+            if file.is_symlink() && !follow_symlinks {
+                log::debug!(
+                    "{} is a symlink, which we're not following",
+                    file.to_string_lossy()
+                );
+                continue;
+            }
+
+            // Only push the file if the canonicalisation succeeds (i.e., skip broken symlinks)
+            if let Ok(candidate) = file.canonicalize() {
+                expanded.push(candidate.to_path_buf());
+            }
         }
     }
 
@@ -217,17 +239,23 @@ pub fn get_args() -> CLIResult<Cli> {
 
     match &mut args.command {
         Commands::Format {
-            inputs: AtLeastOneInput { files, .. },
+            inputs:
+                AtLeastOneInput {
+                    files,
+                    follow_symlinks,
+                    ..
+                },
             ..
         } => {
             // If we're given a list of FILES... then we assume them to all be on disk, even if "-"
             // is passed as an argument (i.e., interpret this as a valid filename, rather than as
-            // stdin). We deduplicate this list to avoid formatting the same file multiple times
-            // and recursively expand directories until we're left with a list of unique
-            // (potential) files as input sources.
+            // stdin). We recursively expand directories until we're left with a list of
+            // (potential) files, as input sources. This is finally deduplicated to avoid
+            // formatting the same file multiple times (e.g., in the case that a symlink points to
+            // a file within the set, or if the same file is specified twice at the command line).
+            traverse_fs(files, *follow_symlinks)?;
             files.sort_unstable();
             files.dedup();
-            traverse_fs(files)?;
         }
 
         Commands::Visualise {

--- a/topiary-cli/src/fs.rs
+++ b/topiary-cli/src/fs.rs
@@ -1,0 +1,144 @@
+use crate::error::CLIResult;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+enum FileType {
+    /// Regular file
+    File,
+
+    /// Directory
+    Directory,
+
+    /// Something else, which we don't care about
+    /// (e.g., FIFOs, sockets, etc.)
+    SomethingElse,
+}
+
+enum Hardlink {
+    Links(u64),
+    Unknown,
+}
+
+struct FileMeta {
+    filetype: FileType,
+    symlink: bool,
+    hardlink: Hardlink,
+}
+
+impl FileMeta {
+    fn new<P: AsRef<Path>>(path: &P) -> CLIResult<Self> {
+        // Stat a potential symlink
+        let lmeta = fs::symlink_metadata(path)?;
+        let symlink = lmeta.is_symlink();
+
+        // Follow the symlink, if necessary
+        let meta = if symlink { fs::metadata(path)? } else { lmeta };
+
+        let filetype = {
+            if meta.is_file() {
+                FileType::File
+            } else if meta.is_dir() {
+                FileType::Directory
+            } else {
+                FileType::SomethingElse
+            }
+        };
+
+        let hardlink = if cfg!(unix) {
+            Hardlink::Links(meta.nlink())
+        } else if cfg!(windows) {
+            // TODO Windows has fs::MetadataExt::number_of_links, but this is experimental as of
+            // writing (see https://github.com/rust-lang/rust/issues/63010)
+            Hardlink::Unknown
+        } else {
+            Hardlink::Unknown
+        };
+
+        Ok(Self {
+            filetype,
+            symlink,
+            hardlink,
+        })
+    }
+
+    fn ignore(&self) -> bool {
+        matches!(self.filetype, FileType::SomethingElse)
+    }
+
+    fn is_dir(&self) -> bool {
+        matches!(self.filetype, FileType::Directory)
+    }
+
+    fn is_symlink(&self) -> bool {
+        self.symlink
+    }
+
+    fn has_multiple_links(&self) -> bool {
+        matches!(self.hardlink, Hardlink::Links(n) if n > 1)
+    }
+}
+
+/// Given a vector of paths, recursively expand those that identify as directories, in place.
+/// Follow symlinks, if specified, and skip over files with multiple links. Ultimately, we'll
+/// finish with a vector of canonical paths to real files with a single link.
+pub fn traverse(files: &mut Vec<PathBuf>, follow_symlinks: bool) -> CLIResult<()> {
+    let mut expanded = vec![];
+
+    for file in &mut *files {
+        // Using FileMeta means we, at most, stat each file twice
+        let meta = match FileMeta::new(file) {
+            Ok(meta) => meta,
+            Err(_) => {
+                log::warn!("Skipping {}: cannot access", file.to_string_lossy());
+                continue;
+            }
+        };
+
+        // Skip over everything we don't care about
+        if meta.ignore() {
+            continue;
+        }
+
+        let is_dir = if follow_symlinks {
+            meta.is_dir()
+        } else {
+            meta.is_dir() && !meta.is_symlink()
+        };
+
+        if is_dir {
+            // Descend into directory, symlink-aware as required
+            let mut subfiles = file.read_dir()?.flatten().map(|f| f.path()).collect();
+            traverse(&mut subfiles, follow_symlinks)?;
+            expanded.append(&mut subfiles);
+        } else {
+            if meta.is_symlink() && !follow_symlinks {
+                log::debug!(
+                    "{} is a symlink; use --follow-symlinks to follow",
+                    file.to_string_lossy()
+                );
+                continue;
+            }
+
+            if meta.has_multiple_links() {
+                log::warn!(
+                    "Skipping {} as it has multiple links, which Topiary would break",
+                    file.to_string_lossy()
+                );
+                continue;
+            }
+
+            // Only push the file if the canonicalisation succeeds (i.e., skip broken symlinks)
+            if let Ok(candidate) = file.canonicalize() {
+                expanded.push(candidate);
+            }
+        }
+    }
+
+    *files = expanded;
+    Ok(())
+}

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod error;
+mod fs;
 mod io;
 mod language;
 mod visualisation;


### PR DESCRIPTION
# Optionally follow (and resolve) symlinks when specifying input files
Resolves #834

## Description

Provides an `-L`/`--follow-symlinks` option to `topiary format` which will follow and resolve symlinks when computing the set of input files. If this CLI option is specified, then the filesystem traversal:

* Can "break out" of the specified directories by following any directory symlinks elsewhere.
* Will resolve symlinked files to their canonical path (skipping, if the link is broken).

The deduplication now happens after the traversal, rather than before, to dedup symlinks that point to files that exist within the input file set. (This means that if you do, say, `topiary format directory directory`, then it will do twice as much work before dedup'ing, but that's an edge case that's not worth worrying about.)

## Checklist
Checklist before merging:
- [x] Depends on #849
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
