### PR TITLE
Various small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ This name should be decided amongst the team before the release.
 - [#822](https://github.com/tweag/topiary/pull/822) Various Bash fixes and improvements
 - [#813](https://github.com/tweag/topiary/pull/813) In-place writing on Windows (also introduced a minimal Windows CI)
 - [#826](https://github.com/tweag/topiary/pull/826) Various Tree-sitter query fixes, thanks to @mkatychev
+- [#853](https://github.com/tweag/topiary/pull/853) Small fixes to CLI logging and IO
 
 ## v0.5.1 - Fragrant Frangipani - 2024-10-22
 

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -266,7 +266,8 @@ impl OutputFile {
     pub fn persist(self) -> CLIResult<()> {
         if let Self::Disk { mut staged, output } = self {
             // Rewind to the beginning of the staged output
-            staged.seek(io::SeekFrom::Start(0))?;
+            staged.flush()?;
+            staged.rewind()?;
 
             // Open the actual output for writing and copy the staged contents
             let mut writer = File::create(&output)?;

--- a/topiary-config/src/source.rs
+++ b/topiary-config/src/source.rs
@@ -124,9 +124,13 @@ impl fmt::Display for Source {
             Self::Builtin => write!(f, "Built-in configuration"),
 
             Self::File(path) => {
-                // We only stringify the path when we know it exists, so the call to `canonicalize`
-                // is safe to unwrap. (All bets are off, if called from elsewhere.)
-                write!(f, "{}", path.canonicalize().unwrap().to_string_lossy())
+                // If the configuration is provided through a file, then we know by this point that
+                // it must exist and so the call to `canonicalize` will succeed. However, special
+                // cases -- such as process substitution, which creates a temporary FIFO -- may
+                // fail if the shell has cleaned things up from under us; in which case, we
+                // fallback to the original `path`.
+                let config = path.canonicalize().unwrap_or(path.clone());
+                write!(f, "{}", config.to_string_lossy())
             }
         }
     }


### PR DESCRIPTION
# Various small fixes in preparation for v0.6.0

Resolves #823
Resolves #825
Resolves #843

## Description

* Don't panic with info (or higher) logging when using process substitution to provide configuration.
* Sensible logging of configuration sources.
* Clean-up temporary files on process interruption.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
