### PR TITLE
Support converting from tree_sitter::Language

### DIFF
--- a/topiary-tree-sitter-facade/src/language.rs
+++ b/topiary-tree-sitter-facade/src/language.rs
@@ -80,12 +80,17 @@ mod native {
         }
     }
 
+    impl From<tree_sitter::Language> for Language {
+        #[inline]
+        fn from(inner: tree_sitter::Language) -> Self {
+            Self { inner }
+        }
+    }
+
     impl From<tree_sitter_language::LanguageFn> for Language {
         #[inline]
         fn from(inner: tree_sitter_language::LanguageFn) -> Self {
-            Self {
-                inner: tree_sitter::Language::new(inner),
-            }
+            Language::from(tree_sitter::Language::new(inner))
         }
     }
 


### PR DESCRIPTION
# Support converting from tree_sitter::Language

## Description

#794 replaced a `From<tree_sitter::Language>` implementation with a `From<tree_sitter_language::LanguageFn>` implementation. But I see no reason we can't have both, so this PR re-instates the former.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] [`CHANGELOG.md`](/CHANGELOG.md) updated
- [ ] [`README.md`](/README.md) up-to-date
