### PR TITLE
chore(nix): override -> overrideAttrs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,11 +80,11 @@
             wasmBindgenVersion = assert builtins.length wasmBindgenCargoVersions == 1; builtins.elemAt wasmBindgenCargoVersions 0;
           in
           {
-            wasm-bindgen-cli = prev.wasm-bindgen-cli.overrideAttrs (oldAttrs: { # Use overrideAttrs
+            wasm-bindgen-cli = prev.wasm-bindgen-cli.overrideAttrs {
               version = wasmBindgenVersion;
               hash = "sha256-3RJzK7mkYFrs7C/WkhW9Rr4LdP5ofb2FdYGz1P7Uxog=";
               cargoHash = "sha256-tD0OY2PounRqsRiFh8Js5nyknQ809ZcHMvCOLrvYHRE=";
-            });
+            };
           };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -80,11 +80,11 @@
             wasmBindgenVersion = assert builtins.length wasmBindgenCargoVersions == 1; builtins.elemAt wasmBindgenCargoVersions 0;
           in
           {
-            wasm-bindgen-cli = prev.wasm-bindgen-cli.override {
+            wasm-bindgen-cli = prev.wasm-bindgen-cli.overrideAttrs (oldAttrs: { # Use overrideAttrs
               version = wasmBindgenVersion;
               hash = "sha256-3RJzK7mkYFrs7C/WkhW9Rr4LdP5ofb2FdYGz1P7Uxog=";
               cargoHash = "sha256-tD0OY2PounRqsRiFh8Js5nyknQ809ZcHMvCOLrvYHRE=";
-            };
+            });
           };
       };
 


### PR DESCRIPTION
# flake.nix update

Resolves #865

## Description

This is a LLM suggested solution that happens to work on my setup.
I'm not entirely sure about the consequences, at least it won't break the ci workflow.


PS. actually I'm searching for a method to install the latest prebuilt binary in a declarative manner, building it from source is too heavy for me.