### PR TITLE
Investigate and fix parallel grammar builds on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Prefetch grammars
+        run: cargo run --all-features -- prefetch
+
       - name: Run test suite
         run: cargo test --all-features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,9 @@ This name should be decided amongst the team before the release.
 
 ### Fixed
 - [#867](https://github.com/tweag/topiary/pull/867) Enable coverage check and add code samples for OpenSCAD
+- [#869](https://github.com/tweag/topiary/pull/869) Disable parallel grammar building on Windows
 
-<!-->
+<!--
 
 ### Security
 - <Vulnerabilities>

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -151,7 +151,8 @@ impl Configuration {
         let tmp_dir_path = tmp_dir.path().to_owned();
 
         // When "parallel" is enabled, we use rayon to fetch and compile all found grammars in parallel.
-        #[cfg(feature = "parallel")]
+        // NOTE The MSVC linker does not seem to like concurrent builds
+        #[cfg(all(feature = "parallel", not(windows)))]
         {
             use rayon::prelude::*;
             self.languages
@@ -160,7 +161,7 @@ impl Configuration {
                 .collect::<Result<Vec<_>, TopiaryConfigFetchingError>>()?;
         }
 
-        #[cfg(not(feature = "parallel"))]
+        #[cfg(any(not(feature = "parallel"), windows))]
         {
             self.languages
                 .iter()

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -150,8 +150,10 @@ impl Configuration {
         let tmp_dir = tempdir()?;
         let tmp_dir_path = tmp_dir.path().to_owned();
 
-        // When "parallel" is enabled, we use rayon to fetch and compile all found grammars in parallel.
-        // NOTE The MSVC linker does not seem to like concurrent builds
+        // When the `parallel` feature is enabled (which it is by default), we use Rayon to fetch
+        // and compile all found grammars concurrently.
+        // NOTE The MSVC linker does not seem to like concurrent builds, so concurrency is disabled
+        // on Windows (see https://github.com/tweag/topiary/issues/868)
         #[cfg(all(feature = "parallel", not(windows)))]
         {
             use rayon::prelude::*;


### PR DESCRIPTION
# Investigate and fix parallel grammar builds on Windows

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
References #868

## Description

For reasons, the MSVC linker does not like building multiple grammars concurrently and it hits a race condition :shrug: It's not at all clear why this happens, so the best we can do for the time being is stick a plaster over the problem: No concurrent grammar builds on Windows.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] [`CHANGELOG.md`](/CHANGELOG.md) updated
- [x] [`README.md`](/README.md) up-to-date
