### PR TITLE
Add update-flake-lock workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,23 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v24
+        with:
+          # Providing a secret token is necessary for the PRs to run CI
+          # See https://github.com/DeterminateSystems/update-flake-lock#with-a-personal-authentication-token
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
# Add workflow to automatically update flake.lock

## Description

This PR adds a workflow to automatically update flake.lock weekly. In order to work , we need to add some maintainer's Personal Access Token to the secrets of this repository, under `GH_TOKEN_FOR_UPDATES`. See the link in the in the workflow.