### PR TITLE
Attempt: Correct checkout for Nix flake updater to run

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
 # Ensure all text is checked out with Unix EOL
 * text eol=lf
 
+# Ensure binary files aren't considered as text
+*.png binary
+*.wasm binary
+
 # Hide our tests from language detection so GitHub correctly detects Topiary as a Rust project
 topiary-cli/tests/samples/** linguist-vendored


### PR DESCRIPTION
# Attempt: Correct checkout for Nix flake updater to run

## Description

The Nix flake update action [failed](https://github.com/tweag/topiary/actions/runs/13477909315/job/37659368819). It failed because, when the repository is checked out, a bunch of binary files (`*.png` and `*.wasm`) are checked out in a weird state.

This PR is a (naive) attempt to fix that: We set PNG and WASM files to be `binary` in `.gitattributes` to ensure they are not considered as text :crossed_fingers:

## Checklist

(No changes needed to docs)