### PR TITLE
installation without cloning repo to local folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ directory:
 cargo install --path topiary-cli
 ```
 
+Or it can be built without cloning the repository locally:
+
+```bash
+cargo install --git https://github.com/tweag/topiary topiary-cli
+```
+
 Topiary needs to find the language query files (`.scm`) to function properly. By
 default, `topiary` looks for a `languages` directory in the current working
 directory.


### PR DESCRIPTION
# installation without cloning repo to local folder

I'm not sure, but maybe this option might be quicker for users like me.  So I propose to add this way of installation into instructions.