### PR TITLE
chore: Use official grammar repo for OpenSCAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This name should be decided amongst the team before the release.
 - [#859](https://github.com/tweag/topiary/pull/859) Break up integration tests per language, thanks to @mkatychev
 - [#871](https://github.com/tweag/topiary/pull/859) Switch to `mold` linker for CI tests, thanks to @mkatychev
 - [#893](https://github.com/tweag/topiary/pull/893) Use `gix` lib instead of system `git`
+- [#896](https://github.com/tweag/topiary/pull/896) Use official grammar repo for OpenSCAD, thanks to @mkatychev
 
 <!-- ### Deprecated -->
 <!-- - <Soon-to-be removed features> -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ This name should be decided amongst the team before the release.
 ### Changed
 <!-- - <Changes in existing functionality> -->
 - [#859](https://github.com/tweag/topiary/pull/859) Break up integration tests per language, thanks to @mkatychev
-- [#871](https://github.com/tweag/topiary/pull/859) Switch to `mold` linker for CI tests, thanks to @mkatychev
+- [#871](https://github.com/tweag/topiary/pull/871) Switch to `mold` linker for CI tests, thanks to @mkatychev
 - [#893](https://github.com/tweag/topiary/pull/893) Use `gix` lib instead of system `git`
 - [#896](https://github.com/tweag/topiary/pull/896) Use official grammar repo for OpenSCAD, thanks to @mkatychev
 

--- a/flake.lock
+++ b/flake.lock
@@ -118,15 +118,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1739738314,
-        "narHash": "sha256-nnHtt0tWuJRjE5xw3zFJ6+hO/GKPmAfEaGkYIX30SjE=",
-        "owner": "mkatychev",
+        "lastModified": 1741276805,
+        "narHash": "sha256-wPLI5iUAkmv0CsJ5s9qeghFqIPxCvq6s9n3F9b2FKMk=",
+        "owner": "openscad",
         "repo": "tree-sitter-openscad",
-        "rev": "8c31270f69a7eaebbe70d59dc65363727afb4fae",
+        "rev": "654280c0ea7beaa81c402f199a13f25379535f89",
         "type": "github"
       },
       "original": {
-        "owner": "mkatychev",
+        "owner": "openscad",
         "repo": "tree-sitter-openscad",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1741367336,
-        "narHash": "sha256-QsTWsBWXvcrTHMhZK5sTz8Omyxn4tSszg/U5Y1BLzFM=",
+        "lastModified": 1741655582,
+        "narHash": "sha256-UzdI9R2/TCCLO1VHwPgYYYaSLM/6pWFiZxJ/TiDXgLo=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "74ff50e899726ef85314978f60e9f7858462b21f",
+        "rev": "a99f72f78f43ef5b7883126f5454d86d8670b97d",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1741479724,
-        "narHash": "sha256-fnyETBKSVRa5abjOiRG/IAzKZq5yX8U6oRrHstPl4VM=",
+        "lastModified": 1741481578,
+        "narHash": "sha256-JBTSyJFQdO3V8cgcL08VaBUByEU6P5kXbTJN6R0PFQo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "60202a2e3597a3d91f5e791aab03f45470a738b5",
+        "rev": "bb1c9567c43e4434f54e9481eb4b8e8e0d50f0b5",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741310760,
-        "narHash": "sha256-aizILFrPgq/W53Jw8i0a1h1GZAAKtlYOrG/A5r46gVM=",
+        "lastModified": 1741708242,
+        "narHash": "sha256-cNRqdQD4sZpN7JLqxVOze4+WsWTmv2DGH0wNCOVwrWc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "de0fe301211c267807afd11b12613f5511ff7433",
+        "rev": "b62d2a95c72fb068aecd374a7262b37ed92df82b",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1741400194,
-        "narHash": "sha256-tEpgT+q5KlGjHSm8MnINgTPErEl8YDzX3Eps8PVc09g=",
+        "lastModified": 1741746673,
+        "narHash": "sha256-7L4J5F96ku6DBkbEwxNdPZF41bAEhMMoHUlZD/jGYq4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "16b6045a232fea0e9e4c69e55a6e269607dd8e3f",
+        "rev": "7af16cbd1464fddde8ad0c4ed7baaa2292445ba4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
     };
 
     tree-sitter-openscad = {
-      url = "github:mkatychev/tree-sitter-openscad";
+      url = "github:openscad/tree-sitter-openscad";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/topiary-config/languages.ncl
+++ b/topiary-config/languages.ncl
@@ -76,8 +76,8 @@
     openscad = {
       extensions = ["scad"],
       grammar.source.git = {
-        git = "https://github.com/mkatychev/tree-sitter-openscad.git",
-        rev = "270e5ff749edfacc84a6e4a434abd4e8b0f70bbe",
+        git = "https://github.com/openscad/tree-sitter-openscad.git",
+        rev = "654280c0ea7beaa81c402f199a13f25379535f89",
       },
     },
 

--- a/topiary-config/languages.ncl
+++ b/topiary-config/languages.ncl
@@ -77,7 +77,7 @@
       extensions = ["scad"],
       grammar.source.git = {
         git = "https://github.com/openscad/tree-sitter-openscad.git",
-        rev = "654280c0ea7beaa81c402f199a13f25379535f89",
+        rev = "acc196e969a169cadd8b7f8d9f81ff2d30e3e253",
       },
     },
 


### PR DESCRIPTION
# Use official grammar repo for OpenSCAD

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->

References https://github.com/Leathong/openscad-LSP/issues/35

## Description

tree-sitter-openscad has moved to the https://github.com/openscad org where the NPM package, crate, and python lib are pushed from. This PR updates the grammar location in `languages.ncl` and `flake.nix` to point to https://github.com/openscad/tree-sitter-openscad/

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] [`CHANGELOG.md`](/CHANGELOG.md) updated
- [x] [`README.md`](/README.md) up-to-date
