### PR TITLE
Topiary book: Publish book to Topiary website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,55 +52,6 @@ jobs:
       - name: Verify that usage in README.md matches CLI output
         run: nix run .#verify-documented-usage
 
-      - name: Build web playground Wasm app
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        run: nix build .#topiary-playground
-
-      - name: Copy web playground Wasm app into playground frontend
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        run: |
-          mkdir -p web-playground/src/wasm-app
-          cp -r result/* web-playground/src/wasm-app/
-
-      - name: Move sample input and queries into playground frontend
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        run: |
-          mkdir -p web-playground/src/samples
-          mv web-playground/src/wasm-app/languages_export.ts web-playground/src/samples/
-
-      - name: Install web playground frontend dependencies
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        run: npm install --prefix web-playground
-
-      - name: Start web playground frontend
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        run: |
-          npm run dev --prefix web-playground &
-          # Loop until there's a response
-          while [[ "$(curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:5173/playground)" != "200" ]]; do
-            sleep 2
-          done
-
-      - name: Test web playground frontend
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        run: npm run e2e --prefix web-playground
-
-      - name: Make web playground frontend release build
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        run: npm run build --prefix web-playground
-
-      - name: Copy playground into website
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        run: |
-          rm -rf website/playground
-          cp -r web-playground/dist website/playground
-
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v1.0.7
-        if: success() && matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/playground'
-        with:
-          path: 'website'
-
   build-windows:
     # Note: GitHub's Windows runners have a Rust toolchain installed
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
@@ -115,21 +66,3 @@ jobs:
 
       - name: Run test suite
         run: cargo test --all-features
-
-  deploy:
-    needs: build
-    if: github.ref == 'refs/heads/playground'
-
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -99,6 +99,13 @@ jobs:
           rm -rf website/playground
           cp -r web-playground/dist website/playground
 
+      - name: Build Topiary Book and decant it into website
+        run: |
+          mkdir website/book
+
+          nix build .#topiary-book
+          cp -r result/* website/book
+
           # DEBUG
           ls -lR website
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -50,7 +50,7 @@ jobs:
   build-website:
     name: Build website
     runs-on: ubuntu-latest
-    needs: [build-playground]
+    needs: build-playground
 
     steps:
       - name: Checkout
@@ -101,3 +101,27 @@ jobs:
 
           # DEBUG
           ls -lR website
+
+# TODO Commented for debugging
+#      - name: Upload GitHub Pages artefact
+#        uses: actions/upload-pages-artifact@v3
+#        with:
+#          path: website
+#
+#  deploy-website:
+#    name: Deploy website
+#    runs-on: ubuntu-latest
+#    needs: build-website
+#
+#    permissions:
+#      pages: write     # to deploy to Pages
+#      id-token: write  # to verify the deployment originates from an appropriate source
+#
+#    environment:
+#      name: github-pages
+#      url: ${{ steps.deployment.outputs.page_url }}
+#
+#    steps:
+#      - name: Deploy to GitHub Pages
+#        id: deployment
+#        uses: actions/deploy-pages@v4

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -22,22 +22,33 @@ jobs:
 
     steps:
       - name: Checkout
+        id: checkout-playground
         uses: actions/checkout@v4
         with:
           ref: playground
 
+      - name: Cache build artefacts
+        id: cache-artefacts
+        uses: actions/cache@v4
+        with:
+          path: result
+          key: playground-wasm-assets-${{ steps.checkout-playground.outputs.commit }}
+
       - name: Install Nix
         uses: cachix/install-nix-action@v31
+        if: steps.cache-artefacts.outputs.cache-hit != 'true'
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
       - name: Set up Nix cache
         uses: cachix/cachix-action@v16
+        if: steps.cache-artefacts.outputs.cache-hit != 'true'
         with:
           name: tweag-topiary
           authToken: "${{ secrets.CACHIX_TWEAG_TOPIARY_AUTH_TOKEN }}"
 
       - name: Build WASM assets
+        if: steps.cache-artefacts.outputs.cache-hit != 'true'
         run: |
           nix build .#topiary-playground
 
@@ -55,6 +66,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+
+      - name: Set up Nix cache
+        uses: cachix/cachix-action@v16
+        with:
+          name: tweag-topiary
+          authToken: "${{ secrets.CACHIX_TWEAG_TOPIARY_AUTH_TOKEN }}"
 
       - name: Prepare directories
         run: |

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -46,3 +46,58 @@ jobs:
         with:
           name: playground-wasm-assets
           path: result
+
+  build-website:
+    name: Build website
+    runs-on: ubuntu-latest
+    needs: [build-playground]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare directories
+        run: |
+          mkdir -p web-playground/src/wasm-app
+          mkdir -p web-playground/src/samples
+
+      - name: Download playground WASM artefacts
+        uses: actions/download-artifact@v4
+        with:
+          name: playground-wasm-assets
+          path: web-playground/src/wasm-app
+
+      - name: Move sample input and queries into frontend
+        run: |
+          mv web-playground/src/wasm-app/languages_export.ts \
+             web-playground/src/samples
+
+      # NOTE There are end-to-end tests for the web playground. Because
+      # of the playground's development status, we don't currently
+      # bother running them, to speed up the CI. Something like the
+      # following will do the trick, if that ever changes:
+      #
+      # ```yaml
+      # - name: Test playground
+      #   run: |
+      #     npm install --prefix web-playground
+      #     npm run dev --prefix web-playground &
+      #
+      #     # Loop until there's a response
+      #     while [[ "$(curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:5173/playground)" != "200" ]]; do
+      #       sleep 2
+      #     done
+      #
+      #     npm run e2e --prefix web-playground
+      # ```
+
+      - name: Build frontend and decant it into website
+        run: |
+          npm install --prefix web-playground
+          npm run build --prefix web-playground
+
+          rm -rf website/playground
+          cp -r web-playground/dist website/playground
+
+          # DEBUG
+          ls -lR website

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -27,22 +27,12 @@ jobs:
         with:
           ref: playground
 
-      - name: Prepare results directory (for cached assets)
-        run: |
-          rm -rf result
-          mkdir result
-
       - name: Cache build artefacts
         id: cache-artefacts
         uses: actions/cache@v4
         with:
-          path: result/**
+          path: wasm-assets
           key: playground-wasm-assets-${{ steps.checkout-playground.outputs.commit }}
-
-      - name: Remove results directory (when not cached)
-        if: steps.cache-artefacts.outputs.cache-hit != 'true'
-        run: |
-          rm -rf result
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -62,11 +52,14 @@ jobs:
         run: |
           nix build .#topiary-playground
 
+          mkdir wasm-assets
+          cp -r result/* wasm-assets
+
       - name: Upload assets as build artefacts
         uses: actions/upload-artifact@v4
         with:
           name: playground-wasm-assets
-          path: result
+          path: wasm-assets
 
   build-website:
     name: Build website

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -27,12 +27,22 @@ jobs:
         with:
           ref: playground
 
+      - name: Prepare results directory (for cached assets)
+        run: |
+          rm -rf result
+          mkdir result
+
       - name: Cache build artefacts
         id: cache-artefacts
         uses: actions/cache@v4
         with:
           path: result/**
           key: playground-wasm-assets-${{ steps.checkout-playground.outputs.commit }}
+
+      - name: Remove results directory (when not cached)
+        if: steps.cache-artefacts.outputs.cache-hit != 'true'
+        run: |
+          rm -rf result
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -4,12 +4,6 @@ on:
   push:
     # TODO Commented for debugging
     # branches: main
-    # TODO Trigger on files changed?
-
-  # TODO Do we need to trigger on PR?
-  # pull_request:
-    # TODO Commented for debugging
-    # branches: main
 
 jobs:
   # Build the WASM-based web playground's assets
@@ -35,14 +29,14 @@ jobs:
           key: playground-wasm-assets-${{ steps.checkout-playground.outputs.commit }}
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
         if: steps.cache-artefacts.outputs.cache-hit != 'true'
+        uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
       - name: Set up Nix cache
-        uses: cachix/cachix-action@v16
         if: steps.cache-artefacts.outputs.cache-hit != 'true'
+        uses: cachix/cachix-action@v16
         with:
           name: tweag-topiary
           authToken: "${{ secrets.CACHIX_TWEAG_TOPIARY_AUTH_TOKEN }}"
@@ -52,6 +46,8 @@ jobs:
         run: |
           nix build .#topiary-playground
 
+          # Copy the Nix build results into a new directory because the
+          # caching step doesn't like the `result` symlink to the store
           mkdir wasm-assets
           cp -r result/* wasm-assets
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -31,7 +31,7 @@ jobs:
         id: cache-artefacts
         uses: actions/cache@v4
         with:
-          path: result
+          path: result/**
           key: playground-wasm-assets-${{ steps.checkout-playground.outputs.commit }}
 
       - name: Install Nix

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,0 +1,48 @@
+name: Build and deploy website
+
+on:
+  push:
+    # TODO Commented for debugging
+    # branches: main
+    # TODO Trigger on files changed?
+
+  # TODO Do we need to trigger on PR?
+  # pull_request:
+    # TODO Commented for debugging
+    # branches: main
+
+jobs:
+  # Build the WASM-based web playground's assets
+  # NOTE The playground is currently not under active development, so we
+  # checkout from the `playground` branch, which diverged from `main`
+  # circa October 2024.
+  build-playground:
+    name: Build playground WASM assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: playground
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-unstable
+
+      - name: Set up Nix cache
+        uses: cachix/cachix-action@v16
+        with:
+          name: tweag-topiary
+          authToken: "${{ secrets.CACHIX_TWEAG_TOPIARY_AUTH_TOKEN }}"
+
+      - name: Build WASM assets
+        run: |
+          nix build .#topiary-playground
+
+      - name: Upload assets as build artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-wasm-assets
+          path: result

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -2,8 +2,7 @@ name: Build and deploy website
 
 on:
   push:
-    # TODO Commented for debugging
-    # branches: main
+    branches: main
 
 jobs:
   # Build the WASM-based web playground's assets
@@ -127,29 +126,25 @@ jobs:
           nix build .#topiary-book
           cp -r result/* website/book
 
-          # DEBUG
-          ls -lR website
+      - name: Upload GitHub Pages artefact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website
 
-# TODO Commented for debugging
-#      - name: Upload GitHub Pages artefact
-#        uses: actions/upload-pages-artifact@v3
-#        with:
-#          path: website
-#
-#  deploy-website:
-#    name: Deploy website
-#    runs-on: ubuntu-latest
-#    needs: build-website
-#
-#    permissions:
-#      pages: write     # to deploy to Pages
-#      id-token: write  # to verify the deployment originates from an appropriate source
-#
-#    environment:
-#      name: github-pages
-#      url: ${{ steps.deployment.outputs.page_url }}
-#
-#    steps:
-#      - name: Deploy to GitHub Pages
-#        id: deployment
-#        uses: actions/deploy-pages@v4
+  deploy-website:
+    name: Deploy website
+    runs-on: ubuntu-latest
+    needs: build-website
+
+    permissions:
+      pages: write     # to deploy to Pages
+      id-token: write  # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,12 @@
 , crane
 , rust-overlay
 , craneLib
-# tree-sitter-nickel is packaged in Nixpkgs, but it's an older version at the
-# time of writing. Since updating it seems non trivial, and we need Topiary to
-# be compatible with Nickel urgently (it is currently blocking for the CI), we
-# use the tree-sitter-nickel flake directly.
+  # tree-sitter-nickel is packaged in Nixpkgs, but it's an older version at the
+  # time of writing. Since updating it seems non trivial, and we need Topiary to
+  # be compatible with Nickel urgently (it is currently blocking for the CI), we
+  # use the tree-sitter-nickel flake directly.
 , tree-sitter-nickel
-# tree-sitter-openscad is not in nixpkgs so use flake directly
+  # tree-sitter-openscad is not in nixpkgs so use flake directly
 , tree-sitter-openscad
 }:
 let
@@ -192,4 +192,23 @@ in
       cp $LANGUAGES_EXPORT $out/
     '';
   });
+
+  # This was hacked together by a non-Nix person. Dragons be here.
+  topiary-book = pkgs.stdenv.mkDerivation {
+    pname = "topiary-book";
+    version = "1.0";
+
+    src = docs/book;
+
+    nativeBuildInputs = [ pkgs.mdbook ];
+
+    buildPhase = ''
+      mdbook build
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -r book/* $out
+    '';
+  };
 }

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -6,4 +6,5 @@ src = "src"
 title = "Topiary"
 
 [output.html]
+site-url = "/book/"
 git-repository-url = "https://github.com/tweag/topiary"

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,8 @@
         topiary-cli = topiaryPkgs.topiary-cli { };
         topiary-cli-nix = topiaryPkgs.topiary-cli { nixSupport = true; };
 
+        topiary-book = topiaryPkgs.topiary-book;
+
         inherit (binPkgs)
           # FIXME: Broken
           # generate-coverage

--- a/website/index.html
+++ b/website/index.html
@@ -15,6 +15,13 @@
                     d="M8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4.5a.5.5 0 0 0 .5-.5v-4h2v4a.5.5 0 0 0 .5.5H14a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293L8.354 1.146zM2.5 14V7.707l5.5-5.5 5.5 5.5V14H10v-4a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5v4H2.5z"
                 />
             </symbol>
+            <symbol id="book" viewBox="0 0 24 24" stroke="white" fill="none">
+                <path
+                    d="M12 6.90909C10.8999 5.50893 9.20406 4.10877 5.00119 4.00602C4.72513 3.99928 4.5 4.22351 4.5 4.49965C4.5 6.54813 4.5 14.3034 4.5 16.597C4.5 16.8731 4.72515 17.09 5.00114 17.099C9.20405 17.2364 10.8999 19.0998 12 20.5M12 6.90909C13.1001 5.50893 14.7959 4.10877 18.9988 4.00602C19.2749 3.99928 19.5 4.21847 19.5 4.49461C19.5 6.78447 19.5 14.3064 19.5 16.5963C19.5 16.8724 19.2749 17.09 18.9989 17.099C14.796 17.2364 13.1001 19.0998 12 20.5M12 6.90909L12 20.5"
+                /><path
+                    d="M19.2353 6H21.5C21.7761 6 22 6.22386 22 6.5V19.539C22 19.9436 21.5233 20.2124 21.1535 20.0481C20.3584 19.6948 19.0315 19.2632 17.2941 19.2632C14.3529 19.2632 12 21 12 21C12 21 9.64706 19.2632 6.70588 19.2632C4.96845 19.2632 3.64156 19.6948 2.84647 20.0481C2.47668 20.2124 2 19.9436 2 19.539V6.5C2 6.22386 2.22386 6 2.5 6H4.76471"
+                />
+            </symbol>
             <symbol id="playground" viewBox="50 50 600 550">
                 <path
                     xmlns="http://www.w3.org/2000/svg"
@@ -62,6 +69,18 @@
                                         <use xlink:href="#home" />
                                     </svg>
                                     Home
+                                </a>
+                            </li>
+                            <li>
+                                <a href="/book" class="nav-link text-white">
+                                    <svg
+                                        class="bi d-block mx-auto mb-1"
+                                        width="24"
+                                        height="24"
+                                    >
+                                        <use xlink:href="#book" />
+                                    </svg>
+                                    Book
                                 </a>
                             </li>
                             <li>
@@ -143,18 +162,20 @@
                             Topiary is written in Rust and developed by
                             <a href="https://tweag.io">Tweag</a>.
                         </p>
-                        <a
-                            href="https://github.com/tweag/topiary/releases/latest"
-                            class="no-underline"
-                        >
+                        <p>
+                            <a
+                                href="https://github.com/tweag/topiary/releases/latest"
+                                class="no-underline"
+                            ><img
+                                  src="https://img.shields.io/github/v/release/tweag/topiary?display_name=release&style=for-the-badge&logo=github"
+                                  alt="GitHub latest release"
+                            /></a>
+                        </p><p>
                             <img
-                                src="https://img.shields.io/github/v/release/tweag/topiary?display_name=release&logo=github"
-                                alt="GitHub latest release"
+                                src="https://img.shields.io/github/stars/tweag/topiary?style=for-the-badge&logo=github"
+                                alt="GitHub stars"
                             />
-                        </a><img
-                            src="https://img.shields.io/github/stars/tweag/topiary?logo=github"
-                            alt="GitHub stars"
-                        />
+                        </p>
                     </div>
                 </div>
             </div>
@@ -163,9 +184,10 @@
 
             <h2>Getting started</h2>
             <p>
-                See the
-                <a href="https://github.com/tweag/topiary">GitHub page</a> for
-                information on how to install and use Topiary.
+                See the <a href="/book">Topiary Book</a> for information
+                on how to install and use Topiary. Otherwise, check out
+                our <a href="https://github.com/tweag/topiary">GitHub
+                repository</a>.
             </p>
 
             <h2>Other useful links</h2>
@@ -173,13 +195,6 @@
                 <li>
                     <a href="https://github.com/tweag/topiary/releases/latest"
                         >Latest release</a
-                    >
-                </li>
-                <li><a href="/playground">Topiary Playground</a></li>
-                <li>
-                    <a
-                        href="https://discord.gg/FSnkvNyyzC"
-                        >Topiary channel on Tweag Discord</a
                     >
                 </li>
                 <li>
@@ -195,7 +210,7 @@
                     class="d-flex flex-column flex-sm-row justify-content-between py-4 my-4 border-top"
                 >
                     <p>
-                        &copy; 2023
+                        &copy; 2025
                         <a
                             href="https://github.com/tweag/topiary/graphs/contributors"
                             >Topiary Contributors</a


### PR DESCRIPTION
* Created a Nix output for the Topiary Book.
* Updated the website landing page to link to the book (and a few other misc updates).
* Remove the website building steps from `ci.yml`, replacing them with a dedicated `website.yaml` workflow, which:
  * Builds the playground specifically from the `playground` branch, while it is out of maintenance; with better caching to reduce build times (as it's not likely to change).
  * Builds the website as before, minus the end-to-end testing, but including building and incorporating the Topiary Book.
  * Deploys (as before).