### PR TITLE
Update tree-sitter OCaml grammar and fix ensuing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This name should be decided amongst the team before the release.
 <!-- - <Bug fixes> -->
 - [#867](https://github.com/tweag/topiary/pull/867) Enable coverage check and add code samples for OpenSCAD
 - [#869](https://github.com/tweag/topiary/pull/869) Disable parallel grammar building on Windows
+- [#908](https://github.com/tweag/topiary/pull/908) Various OCaml issues and improvements
 
 <!-- ### Security -->
 <!-- - <Vulnerabilities> -->

--- a/topiary-cli/tests/samples/expected/ocaml.ml
+++ b/topiary-cli/tests/samples/expected/ocaml.ml
@@ -1313,3 +1313,10 @@ let _ =
 let _ =
   somefun @@ fun x ->
   body
+
+(* #882 Effect handling syntax *)
+let _ =
+  try
+    comp1 ()
+  with
+    | effect (Xchg n), k -> continue k (n + 1)

--- a/topiary-cli/tests/samples/expected/ocaml_interface.mli
+++ b/topiary-cli/tests/samples/expected/ocaml_interface.mli
@@ -132,9 +132,9 @@ module Tez : sig
 
   val (+?): tez -> tez -> tez tzresult
 
-  val (*?): tez -> int64 -> tez tzresult
+  val ( *? ): tez -> int64 -> tez tzresult
 
-  val (/?): tez -> int64 -> tez tzresult
+  val ( /? ): tez -> int64 -> tez tzresult
 
   val of_string : string -> tez option
 
@@ -513,7 +513,7 @@ module Gas : sig
 
   (** Multiply a cost by a factor. Both arguments are saturated arithmetic values,
     so no negative numbers are involved. *)
-  val (*@): _ Saturation_repr.t -> cost -> cost
+  val ( *@ ): _ Saturation_repr.t -> cost -> cost
 
   (** Add two costs together. *)
   val (+@): cost -> cost -> cost

--- a/topiary-cli/tests/samples/input/ocaml.ml
+++ b/topiary-cli/tests/samples/input/ocaml.ml
@@ -1254,3 +1254,8 @@ let _ =
 let _ =
   somefun @@
     fun x -> body
+
+(* #882 Effect handling syntax *)
+let _ =
+  try comp1 () with
+  | effect (Xchg n), k -> continue k (n+1)

--- a/topiary-config/languages.ncl
+++ b/topiary-config/languages.ncl
@@ -51,8 +51,8 @@
       extensions = ["ml"],
       grammar.source.git = {
         git = "https://github.com/tree-sitter/tree-sitter-ocaml.git",
-        rev = "9965d208337d88bbf1a38ad0b0fe49e5f5ec9677",
-        subdir = "ocaml",
+        rev = "a45fda5fe73cda92f2593d16340b3f6bd46674b8",
+        subdir = "grammars/ocaml",
       },
     },
 
@@ -60,8 +60,8 @@
       extensions = ["mli"],
       grammar.source.git = {
         git = "https://github.com/tree-sitter/tree-sitter-ocaml.git",
-        rev = "9965d208337d88bbf1a38ad0b0fe49e5f5ec9677",
-        subdir = "interface",
+        rev = "a45fda5fe73cda92f2593d16340b3f6bd46674b8",
+        subdir = "grammars/interface",
       },
     },
 

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -1764,7 +1764,6 @@
 ; Antispaces for brackets and parentheses
 (
   [
-    "("
     "["
     "[|"
     "{"
@@ -1772,11 +1771,24 @@
 )
 (
   [
-    ")"
     "]"
     "|]"
     "}"
   ] @prepend_antispace
+)
+
+; We must be cautious when surrounding `mult_operator` with parentheses, lest we mess
+; with comments:
+; `val ( * ): x -> y -> x` must not be formatted into `val (*): x -> y -> x`
+(
+  "(" @append_antispace
+  .
+  (mult_operator)? @do_nothing
+)
+(
+  (mult_operator)? @do_nothing
+  .
+  ")" @prepend_antispace
 )
 
 ; Formatting typed patterns in function arguments, e.g.

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -163,6 +163,7 @@
     "class"
     "constraint"
     "downto"
+    "effect"
     "else"
     "exception"
     "external"


### PR DESCRIPTION
Closes #882 
Closes #904 

## Description

The initial goal of this PR was just to fix #882, but in the process of updating the tree-sitter grammar, #904 became apparent. So this PR fixes both.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] [`CHANGELOG.md`](/CHANGELOG.md) updated
- [x] [`README.md`](/README.md) up-to-date
