### PR TITLE
Remove "All rights reserved" from website footer

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -214,7 +214,7 @@
                         <a
                             href="https://github.com/tweag/topiary/graphs/contributors"
                             >Topiary Contributors</a
-                        >. All rights reserved.
+                        >.
                     </p>
                     <ul class="list-unstyled d-flex">
                         <li class="ms-3">


### PR DESCRIPTION
# Remove "All rights reserved" text from website footer

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->

## Description

It was pointed out on Discord that the "All rights reserved" text in the website's footer is at odds with the MIT licence that applies to the rest of the repo. Moreover, it appears as though the use of this phrase is [obsolete](https://en.wikipedia.org/wiki/All_rights_reserved#Obsolescence) nowadays.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
