### PR TITLE
Format Tree-sitter queries Lisp-style

### DIFF
--- a/topiary-cli/tests/samples/expected/tree_sitter_query.scm
+++ b/topiary-cli/tests/samples/expected/tree_sitter_query.scm
@@ -32,9 +32,7 @@
     (character)
     (quoted_string)
     (signed_number)
-    (string)
-  ]
-) @leaf
+    (string)]) @leaf
 
 ; line number directives must be alone on their line, and can't be indented
 (line_number_directive) @single_line_no_indent
@@ -50,8 +48,7 @@
   ; equivalence class
   [
     (include_module)
-    (include_module_type)
-  ]
+    (include_module_type)]
   (inheritance_definition)
   (inheritance_specification)
   (instance_variable_definition)
@@ -61,17 +58,14 @@
   (open_module)
   (type_definition)
   (value_definition)
-  (value_specification)
-] @allow_blank_line_before
+  (value_specification)] @allow_blank_line_before
 
 ; In a definition including several mutually recursive functions,
 ; one can skip a line before each of them.
 (value_definition
-  "and" @allow_blank_line_before
-)
+  "and" @allow_blank_line_before)
 (value_definition
-  (and_operator) @allow_blank_line_before
-)
+  (and_operator) @allow_blank_line_before)
 
 ; Append line breaks. If there is a comment following, we don't add anything,
 ; because the input softlines and spaces above will already have sorted out the
@@ -82,13 +76,11 @@
     (external)
     (module_definition)
     (module_type_definition)
-    (type_definition)
-  ] @append_hardline
+    (type_definition)] @append_hardline
   .
   "in"? @do_nothing
   .
-  (comment)* @do_nothing
-)
+  (comment)* @do_nothing)
 ; Also append line breaks after open_module, except when it's
 ; preceded by "let", because in this case it's in a let_open_expression.
 (
@@ -96,37 +88,31 @@
   .
   (open_module) @append_hardline
   .
-  (comment)* @do_nothing
-)
+  (comment)* @do_nothing)
 
 ; Append line break after module include, except if it's alone in a single-lined struct
 (
   [
     ; equivalence class
     (include_module)
-    (include_module_type)
-  ] @append_hardline
+    (include_module_type)] @append_hardline
   .
-  "end"? @do_nothing
-)
+  "end"? @do_nothing)
 (structure
   "struct"
   .
   [
     ; equivalence class
     (include_module)
-    (include_module_type)
-  ] @append_spaced_softline
+    (include_module_type)] @append_spaced_softline
   .
-  "end"
-)
+  "end")
 
 ; Consecutive definitions must be separated by line breaks
 (
   [
     (value_definition)
-    (value_specification)
-  ] @append_hardline
+    (value_specification)] @append_hardline
   .
   [
     (exception_definition)
@@ -136,9 +122,7 @@
     (open_module)
     (type_definition)
     (value_definition)
-    (value_specification)
-  ]
-)
+    (value_specification)])
 
 ; Surround spaces
 ; A space is put after, and before (except just after an open parenthesis).
@@ -199,11 +183,9 @@
     ":>"
     "::"
     "[>"
-    "[<"
-  ] @append_space
+    "[<"] @append_space
   .
-  "%"? @do_nothing
-)
+  "%"? @do_nothing)
 
 ; Those keywords are not expected to come right after an open parenthesis.
 [
@@ -228,8 +210,7 @@
   "+="
   ":="
   ":>"
-  "::"
-] @prepend_space
+  "::"] @prepend_space
 
 ; let-like and and-like operators are only followed by a closing parenthesis
 ; during their definition, in which case no space must be appended.
@@ -237,13 +218,11 @@
 (
   (and_operator) @append_space
   .
-  ")"* @do_nothing
-)
+  ")"* @do_nothing)
 (
   (let_operator) @append_space
   .
-  ")"* @do_nothing
-)
+  ")"* @do_nothing)
 
 ; For those queries, we should not have multiple queries,
 ; however, due to a known bug in tree-sitter queries
@@ -253,165 +232,133 @@
 (
   "("* @do_nothing
   .
-  "assert" @prepend_space
-)
+  "assert" @prepend_space)
 (
   "("* @do_nothing
   .
-  (attribute) @prepend_space
-)
+  (attribute) @prepend_space)
 (
   "("* @do_nothing
   .
-  "begin" @prepend_space
-)
+  "begin" @prepend_space)
 (
   "("* @do_nothing
   .
-  "class" @prepend_space
-)
+  "class" @prepend_space)
 (
   "("* @do_nothing
   .
-  "exception" @prepend_space
-)
+  "exception" @prepend_space)
 (
   "("* @do_nothing
   .
-  "external" @prepend_space
-)
+  "external" @prepend_space)
 (
   "("* @do_nothing
   .
-  (floating_attribute) @prepend_space
-)
+  (floating_attribute) @prepend_space)
 (
   "("* @do_nothing
   .
-  "for" @prepend_space
-)
+  "for" @prepend_space)
 (
   "("* @do_nothing
   .
-  "include" @prepend_space
-)
+  "include" @prepend_space)
 (
   "("* @do_nothing
   .
-  (infix_operator) @prepend_space
-)
+  (infix_operator) @prepend_space)
 (
   "("* @do_nothing
   .
-  "inherit" @prepend_space
-)
+  "inherit" @prepend_space)
 (
   "("* @do_nothing
   .
-  (item_attribute) @prepend_space
-)
+  (item_attribute) @prepend_space)
 (
   "("* @do_nothing
   .
-  "let" @prepend_space
-)
+  "let" @prepend_space)
 (
   "("* @do_nothing
   .
-  "method" @prepend_space
-)
+  "method" @prepend_space)
 (
   "("* @do_nothing
   .
-  "module" @prepend_space
-)
+  "module" @prepend_space)
 (
   "("* @do_nothing
   .
-  (module_parameter) @prepend_space
-)
+  (module_parameter) @prepend_space)
 (
   "("* @do_nothing
   .
-  "mutable" @prepend_space
-)
+  "mutable" @prepend_space)
 (
   "("* @do_nothing
   .
-  "new" @prepend_space
-)
+  "new" @prepend_space)
 (
   "("* @do_nothing
   .
-  "object" @prepend_space
-)
+  "object" @prepend_space)
 (
   "("* @do_nothing
   .
-  "open" @prepend_space
-)
+  "open" @prepend_space)
 (
   "("* @do_nothing
   .
-  (parameter) @prepend_space
-)
+  (parameter) @prepend_space)
 (
   "("* @do_nothing
   .
-  "private" @prepend_space
-)
+  "private" @prepend_space)
 (
   "("* @do_nothing
   .
-  "sig" @prepend_space
-)
+  "sig" @prepend_space)
 (
   "("* @do_nothing
   .
-  "try" @prepend_space
-)
+  "try" @prepend_space)
 (
   "("* @do_nothing
   .
-  "type" @prepend_space
-)
+  "type" @prepend_space)
 (
   "("* @do_nothing
   .
-  "val" @prepend_space
-)
+  "val" @prepend_space)
 (
   "("* @do_nothing
   .
-  "while" @prepend_space
-)
+  "while" @prepend_space)
 (
   "("* @do_nothing
   .
-  "*" @prepend_space
-)
+  "*" @prepend_space)
 (
   "("* @do_nothing
   .
-  "=" @prepend_space
-)
+  "=" @prepend_space)
 (
   "("* @do_nothing
   .
-  "||" @prepend_space
-)
+  "||" @prepend_space)
 (
   "("* @do_nothing
   .
-  "}" @prepend_space
-)
+  "}" @prepend_space)
 
 ; Put a space after commas, except the last one.
 (
   "," @append_space
   .
-  (_)
-)
+  (_))
 
 ; Put a space after the dot in polymorphic function types
 ;
@@ -419,8 +366,7 @@
 ;   type a b. a: a -> b: b -> a =
 ;   fun ~a ~b -> a
 (polymorphic_type
-  "." @append_space
-)
+  "." @append_space)
 
 ; Certain elements must be separated by spaces.
 (
@@ -439,8 +385,7 @@
     [
       (extended_module_path)
       (module_path)
-      (module_type_path)
-    ]
+      (module_type_path)]
     (number)
     (parenthesized_expression)
     (parenthesized_pattern)
@@ -456,8 +401,7 @@
     (value_path)
     (value_pattern)
     ")"
-    "]"
-  ] @append_space
+    "]"] @append_space
   .
   [
     ; Don't add any space just before these.
@@ -466,8 +410,7 @@
     "."
     ".."
     ")"
-    "]"
-  ]* @do_nothing
+    "]"]* @do_nothing
   .
   [
     (abstract_type)
@@ -487,8 +430,7 @@
     [
       (extended_module_path)
       (module_path)
-      (module_type_path)
-    ]
+      (module_type_path)]
     (number)
     (parenthesized_expression)
     (parenthesized_pattern)
@@ -506,9 +448,7 @@
     (value_path)
     (value_pattern)
     "("
-    "{"
-  ]
-)
+    "{"])
 
 ; When one uses a language extension, we always put a space after the extension name,
 ; if this name ends by the '?' or ':' token, the space comes after it.
@@ -519,16 +459,11 @@
   (attribute_payload
     [
       "?"
-      ":"
-    ]
-  )* @do_nothing
-)
+      ":"])* @do_nothing)
 (attribute_payload
   [
     "?"
-    ":"
-  ] @append_space
-)
+    ":"] @append_space)
 
 ; Some kinds of colons should have a space in front.
 (
@@ -537,11 +472,9 @@
     (fun_expression)
     (parenthesized_expression)
     (value_name)
-    (value_pattern)
-  ] @append_space
+    (value_pattern)] @append_space
   .
-  ":"
-)
+  ":")
 
 ; Keep spacing between pointy brackets when used in object types.
 ;
@@ -551,8 +484,7 @@
 ;   let obj_id (obj : <..>) = obj
 (object_type
   "<" @append_space
-  ">" @prepend_space
-)
+  ">" @prepend_space)
 
 ; Softlines. These become either a space or a newline, depending on whether we
 ; format their node as single-line or multi-line. If there is a comment
@@ -571,15 +503,12 @@
     "then"
     "with"
     "{"
-    ";"
-  ] @append_spaced_softline
+    ";"] @append_spaced_softline
   .
   [
     (attribute)
     (comment)
-    "%"
-  ]* @do_nothing
-)
+    "%"]* @do_nothing)
 
 (
   [
@@ -591,19 +520,16 @@
     "then"
     "with"
     "{"
-    ";"
-  ]
+    ";"]
   .
   "%"
   .
   (attribute_id) @append_spaced_softline
   .
-  (comment)* @do_nothing
-)
+  (comment)* @do_nothing)
 
 (type_binding
-  (type_constraint) @prepend_spaced_softline
-)
+  (type_constraint) @prepend_spaced_softline)
 
 ; only add softlines after "else" if it's not part of an "else if" construction
 (
@@ -612,9 +538,7 @@
   [
     (comment)
     (if_expression)
-    "%"
-  ]? @do_nothing
-)
+    "%"]? @do_nothing)
 
 (
   "else"
@@ -625,39 +549,29 @@
   .
   [
     (comment)
-    (if_expression)
-  ]? @do_nothing
-)
+    (if_expression)]? @do_nothing)
 
 ; ":" must not always be followed by a softline, we explicitly enumerate
 ; the contexts where it must happen
 (value_specification
-  ":" @append_spaced_softline
-)
+  ":" @append_spaced_softline)
 (module_binding
-  ":" @append_input_softline
-)
+  ":" @append_input_softline)
 (field_declaration
-  ":" @append_spaced_softline
-)
+  ":" @append_spaced_softline)
 (typed_label
-  ":" @append_spaced_softline
-)
+  ":" @append_spaced_softline)
 (constructor_declaration
-  ":" @append_spaced_softline
-)
+  ":" @append_spaced_softline)
 
 ; "->" must not always be followed by a softline, we explicitly enumerate
 ; the contexts where it must happen
 (fun_expression
-  "->" @append_spaced_softline
-)
+  "->" @append_spaced_softline)
 (match_case
-  "->" @append_spaced_softline
-)
+  "->" @append_spaced_softline)
 (constructor_declaration
-  "->" @append_spaced_softline
-)
+  "->" @append_spaced_softline)
 
 ; Always put softlines before these:
 [
@@ -669,12 +583,10 @@
   (item_attribute)
   "*"
   "|"
-  "}"
-] @prepend_spaced_softline
+  "}"] @prepend_spaced_softline
 
 [
-  (match_expression)
-] @prepend_empty_softline
+  (match_expression)] @prepend_empty_softline
 
 ; Softline before the first match case
 ;
@@ -685,8 +597,7 @@
 (
   "|"* @do_nothing
   .
-  (match_case) @prepend_spaced_softline
-)
+  (match_case) @prepend_spaced_softline)
 
 ; Multi-line definitions must have a linebreak after "=" and before "in":
 ;
@@ -698,11 +609,9 @@
 (
   (value_definition
     (_) @append_spaced_softline
-    .
-  )
+    .)
   .
-  "in"
-)
+  "in")
 ; There are special cases however. We do not want to break lines after "=" when writing
 ;
 ; let f = function
@@ -718,9 +627,7 @@
   .
   [
     (function_expression)
-    (fun_expression)
-  ]* @do_nothing
-)
+    (fun_expression)]* @do_nothing)
 
 ; We chose not to add a line break between `=` and the
 ; `fun` or `function` keywords, but in order to keep the multi-lined-ness
@@ -744,10 +651,8 @@
   "=" @prepend_begin_scope
   .
   (fun_expression
-    "->" @append_spaced_scoped_softline
-  ) @append_end_scope
-  (#scope_id! "fun_definition")
-)
+    "->" @append_spaced_scoped_softline) @append_end_scope
+  (#scope_id! "fun_definition"))
 
 ; The same as above holds for single-line `function`.
 ;
@@ -768,30 +673,24 @@
   "=" @prepend_begin_scope
   .
   (function_expression
-    "function" @append_spaced_scoped_softline
-  ) @append_end_scope
-  (#scope_id! "function_definition")
-)
+    "function" @append_spaced_scoped_softline) @append_end_scope
+  (#scope_id! "function_definition"))
 (parenthesized_expression
   (function_expression) @prepend_begin_scope @append_end_scope
-  (#scope_id! "function_definition")
-)
+  (#scope_id! "function_definition"))
 (function_expression
   "|"* @do_nothing
   .
   (match_case) @prepend_spaced_scoped_softline
-  (#scope_id! "function_definition")
-)
+  (#scope_id! "function_definition"))
 (function_expression
   "|"* @prepend_spaced_scoped_softline
   .
   (match_case)
-  (#scope_id! "function_definition")
-)
+  (#scope_id! "function_definition"))
 
 (value_definition
-  (and_operator) @prepend_spaced_softline
-)
+  (and_operator) @prepend_spaced_softline)
 
 ; There is a large class of terms which should be separated from "=" by a soft line break.
 (
@@ -811,9 +710,7 @@
     (set_expression)
     (typed_expression)
     (value_path)
-    (variant_declaration)
-  ]
-)
+    (variant_declaration)])
 
 ; In module signature, each symbol declaration is separated by a softline.
 ;
@@ -830,10 +727,7 @@
     ; equivalence class
     [
       (include_module)
-      (include_module_type)
-    ]
-  ] @append_spaced_softline
-)
+      (include_module_type)]] @append_spaced_softline)
 
 ; In class definitions and class type definitions, each declaration is separated
 ; by a softline.
@@ -850,18 +744,14 @@
   [
     (inheritance_definition)
     (instance_variable_definition)
-    (method_definition)
-  ] @append_spaced_softline @prepend_spaced_softline
-)
+    (method_definition)] @append_spaced_softline @prepend_spaced_softline)
 
 (class_body_type
   "object"
   [
     (inheritance_specification)
     (instance_variable_definition)
-    (method_definition)
-  ] @append_spaced_softline @prepend_spaced_softline
-)
+    (method_definition)] @append_spaced_softline @prepend_spaced_softline)
 
 ; Move semicolon delimiters just after field declarations,
 ; before any attributes and comments.
@@ -882,16 +772,13 @@
   .
   [
     (comment)
-    (attribute)
-  ]*
+    (attribute)]*
   .
   ";" @delete
-  (#delimiter! ";")
-)
+  (#delimiter! ";"))
 
 (record_declaration
-  (field_declaration) @prepend_spaced_softline
-)
+  (field_declaration) @prepend_spaced_softline)
 
 ; Allow multi-line attributes after field declaratioms, such as:
 ; type t = {
@@ -907,25 +794,20 @@
   [
     (field_declaration)
     (attribute)
-    (comment)
-  ]? @append_end_scope
+    (comment)]? @append_end_scope
   .
-  (field_declaration) @prepend_begin_scope
-)
+  (field_declaration) @prepend_begin_scope)
 (record_declaration
   (#scope_id! "field_declaration")
   [
     (field_declaration)
     (attribute)
-    (comment)
-  ] @append_end_scope
+    (comment)] @append_end_scope
   .
-  "}"
-)
+  "}")
 (record_declaration
   (attribute) @prepend_indent_start @prepend_spaced_scoped_softline @append_indent_end
-  (#scope_id! "field_declaration")
-)
+  (#scope_id! "field_declaration"))
 
 ; Duplicate the same logic as above for record *expressions*
 (record_expression
@@ -933,41 +815,33 @@
   .
   [
     (comment)
-    (attribute)
-  ]*
+    (attribute)]*
   .
   ";" @delete
-  (#delimiter! ";")
-)
+  (#delimiter! ";"))
 
 (record_expression
-  (field_expression) @prepend_spaced_softline
-)
+  (field_expression) @prepend_spaced_softline)
 
 (record_expression
   (#scope_id! "field_expression")
   [
     (field_expression)
     (attribute)
-    (comment)
-  ]? @append_end_scope
+    (comment)]? @append_end_scope
   .
-  (field_expression) @prepend_begin_scope
-)
+  (field_expression) @prepend_begin_scope)
 (record_expression
   (#scope_id! "field_expression")
   [
     (field_expression)
     (attribute)
-    (comment)
-  ] @append_end_scope
+    (comment)] @append_end_scope
   .
-  "}"
-)
+  "}")
 (record_expression
   (attribute) @prepend_indent_start @prepend_spaced_scoped_softline @append_indent_end
-  (#scope_id! "field_expression")
-)
+  (#scope_id! "field_expression"))
 
 ; Start an indented block after these
 [
@@ -976,43 +850,35 @@
   "object"
   "sig"
   "struct"
-  "then"
-] @append_indent_start
+  "then"] @append_indent_start
 
 ; "{" can be used to start quoted strings. Don't indent in that case
 (
   "{" @append_indent_start
   .
-  (quoted_string_content)* @do_nothing
-)
+  (quoted_string_content)* @do_nothing)
 
 ; End the indented block before these
 (
   [
     "done"
-    "end"
-  ] @prepend_indent_end
-)
+    "end"] @prepend_indent_end)
 
 ; "}" can be used to end quoted strings. Don't indent in that case
 (
   (quoted_string_content)* @do_nothing
   .
-  "}" @prepend_indent_end
-)
+  "}" @prepend_indent_end)
 
 ; Only indent after "else" if it's not an "else if" construction
 (
   (else_clause
     "else" @append_indent_start
-    (if_expression)? @do_nothing
-  ) @append_indent_end
-)
+    (if_expression)? @do_nothing) @append_indent_end)
 
 ; End the indented block after these
 (
-  (then_clause) @append_indent_end
-)
+  (then_clause) @append_indent_end)
 
 ; Make an indented block after ":" in typed expressions
 ;
@@ -1030,8 +896,7 @@
 (value_specification
   ":" @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Make an indented block after "=" in
 ; * class bindings
@@ -1042,31 +907,26 @@
 
 (class_binding
   "=" @append_indent_start
-  (_) @append_indent_end
-)
+  (_) @append_indent_end)
 
 (class_type_binding
   "=" @append_indent_start
-  (_) @append_indent_end
-)
+  (_) @append_indent_end)
 
 (instance_variable_definition
   "=" @append_indent_start
-  (_) @append_indent_end
-)
+  (_) @append_indent_end)
 
 (method_definition
   "=" @append_indent_start
-  (_) @append_indent_end
-)
+  (_) @append_indent_end)
 
 ; Don't indent for record types nor polymorphic variant types:
 ; they are already indented, and we don't process double indentation well enough
 (type_binding
   [
     "="
-    "+="
-  ] @append_indent_start
+    "+="] @append_indent_start
   .
   [
     (constructed_type)
@@ -1077,16 +937,13 @@
     (tuple_type)
     (type_constructor_path)
     (type_variable)
-    (variant_declaration)
-  ] @append_indent_end
+    (variant_declaration)] @append_indent_end
   .
-  (type_constraint)? @do_nothing
-)
+  (type_constraint)? @do_nothing)
 (type_binding
   [
     "="
-    "+="
-  ] @append_indent_start
+    "+="] @append_indent_start
   .
   [
     (constructed_type)
@@ -1097,11 +954,9 @@
     (tuple_type)
     (type_constructor_path)
     (type_variable)
-    (variant_declaration)
-  ]
+    (variant_declaration)]
   .
-  (type_constraint) @append_indent_end
-)
+  (type_constraint) @append_indent_end)
 
 ; Make an indented block after "of" or ":" in constructor declarations
 ;
@@ -1113,11 +968,9 @@
 (constructor_declaration
   [
     "of"
-    ":"
-  ] @append_indent_start
+    ":"] @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Make an indented block after the first term in a long if expression
 ;
@@ -1130,9 +983,7 @@
     .
     (_) @append_indent_start
     (_) @append_indent_end
-    .
-  )
-)
+    .))
 
 ; Make an indented block after match arrows.
 ;
@@ -1143,8 +994,7 @@
 (match_case
   "->" @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Make an indented block after constructor declaration arrows.
 ;
@@ -1154,8 +1004,7 @@
 (constructor_declaration
   "->" @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Make an indented block where a function type arrow starts. Only for the root
 ; level, not for each arrow.
@@ -1168,15 +1017,12 @@
   (function_type
     "->" @append_indent_start
     (_) @append_indent_end
-    .
-  )
-)
+    .))
 
 ; Make an indented block where a function/match starts in PPX syntax.
 (extension
   "[%" @append_indent_start
-  "]" @prepend_indent_end @prepend_empty_softline
-)
+  "]" @prepend_indent_end @prepend_empty_softline)
 
 ; Indent and add softlines in multiline application expressions, such as
 ; let _ =
@@ -1189,13 +1035,11 @@
   .
   (_) @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 (application_expression
   (_) @append_spaced_softline
   .
-  (_)
-)
+  (_))
 
 ; Indent and allow softlines in multiline function definitions, such as
 ; let long_function
@@ -1211,23 +1055,19 @@
   (_) @append_indent_start @append_indent_start
   "=" @prepend_indent_end
   (_) @append_indent_end
-  .
-)
+  .)
 (let_binding
   .
   (_) @prepend_begin_scope
   "=" @append_end_scope
-  (#scope_id! "let_binding_before_equal")
-)
+  (#scope_id! "let_binding_before_equal"))
 (let_binding
   (parameter) @prepend_spaced_scoped_softline
-  (#scope_id! "let_binding_before_equal")
-)
+  (#scope_id! "let_binding_before_equal"))
 (let_binding
   ":"? @prepend_spaced_scoped_softline
   "=" @prepend_spaced_scoped_softline
-  (#scope_id! "let_binding_before_equal")
-)
+  (#scope_id! "let_binding_before_equal"))
 
 ; Indent and allow softlines in anonymous function definitions, such as
 ; fun
@@ -1241,23 +1081,19 @@
   "fun" @append_indent_start @append_indent_start
   "->" @prepend_indent_end
   (_) @append_indent_end
-  .
-)
+  .)
 (fun_expression
   .
   "fun" @prepend_begin_scope
   "->" @append_end_scope
-  (#scope_id! "fun_expr_before_arrow")
-)
+  (#scope_id! "fun_expr_before_arrow"))
 (fun_expression
   (parameter) @prepend_spaced_scoped_softline
-  (#scope_id! "fun_expr_before_arrow")
-)
+  (#scope_id! "fun_expr_before_arrow"))
 (fun_expression
   ":"? @prepend_spaced_scoped_softline
   "->" @prepend_spaced_scoped_softline
-  (#scope_id! "fun_expr_before_arrow")
-)
+  (#scope_id! "fun_expr_before_arrow"))
 
 ; Indent and allow softlines in tuples, such as
 ; let _ =
@@ -1270,8 +1106,7 @@
   .
   "(" @append_empty_softline @append_indent_start
   ")" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 ; Parenthesis are optional when using tuples, so scopes must be tied
 ; to the `product_expression` inside.
 ; Product expressions are nested grammar elements, which means that the syntax tree of
@@ -1290,12 +1125,10 @@
   (product_expression) @prepend_begin_scope @append_end_scope
   .
   ","? @do_nothing
-  (#scope_id! "tuple")
-)
+  (#scope_id! "tuple"))
 (product_expression
   "," @append_spaced_scoped_softline
-  (#scope_id! "tuple")
-)
+  (#scope_id! "tuple"))
 
 ; Allow softlines in function types, such as
 ; type t =
@@ -1322,12 +1155,10 @@
   "->"? @do_nothing
   .
   (function_type) @prepend_begin_scope @append_end_scope
-  (#scope_id! "function_type")
-)
+  (#scope_id! "function_type"))
 (function_type
   "->" @append_spaced_scoped_softline
-  (#scope_id! "function_type")
-)
+  (#scope_id! "function_type"))
 
 ; Allow softlines in infix expressions, such as
 ; let b =
@@ -1342,22 +1173,16 @@
   (infix_operator
     [
       "||"
-      "&&"
-    ]
-  )? @do_nothing
+      "&&"])? @do_nothing
   .
   (infix_expression) @prepend_begin_scope @append_end_scope
-  (#scope_id! "infix_expression")
-)
+  (#scope_id! "infix_expression"))
 (infix_expression
   (infix_operator
     [
       "||"
-      "&&"
-    ]
-  ) @prepend_spaced_scoped_softline
-  (#scope_id! "infix_expression")
-)
+      "&&"]) @prepend_spaced_scoped_softline
+  (#scope_id! "infix_expression"))
 
 ; Allow softlines in sequences and ppx sequences, such as
 ; let b =
@@ -1375,14 +1200,11 @@
     .
     ";"
     .
-    "%"? @do_nothing
-  ) @prepend_begin_scope @append_end_scope
-  (#scope_id! "sequence_expression")
-)
+    "%"? @do_nothing) @prepend_begin_scope @append_end_scope
+  (#scope_id! "sequence_expression"))
 (sequence_expression
   ";" @append_spaced_scoped_softline
-  (#scope_id! "sequence_expression")
-)
+  (#scope_id! "sequence_expression"))
 
 (
   ";"?
@@ -1397,18 +1219,15 @@
     .
     ";"
     .
-    "%"
-  ) @prepend_begin_scope @append_end_scope
-  (#scope_id! "ppx_sequence_expression")
-)
+    "%") @prepend_begin_scope @append_end_scope
+  (#scope_id! "ppx_sequence_expression"))
 (sequence_expression
   ";"
   .
   "%"
   .
   (attribute_id) @append_spaced_scoped_softline
-  (#scope_id! "ppx_sequence_expression")
-)
+  (#scope_id! "ppx_sequence_expression"))
 
 ; Indent and add softlines in lists and arrays, such as
 ; let _ =
@@ -1421,29 +1240,25 @@
   .
   "[" @append_indent_start @append_empty_softline
   "]" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 
 (list_pattern
   .
   "[" @append_indent_start @append_empty_softline
   "]" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 
 (array_expression
   .
   "[|" @append_indent_start @append_empty_softline
   "|]" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 
 (array_pattern
   .
   "[|" @append_indent_start @append_empty_softline
   "|]" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 
 ; Allow softlines and indentation in functor definitions with many arguments, such as
 ; module Lift
@@ -1457,45 +1272,38 @@
 (module_binding
   (module_name) @append_indent_start @prepend_begin_scope
   "=" @prepend_empty_scoped_softline @prepend_indent_end @append_end_scope
-  (#scope_id! "module_binding_before_equal")
-)
+  (#scope_id! "module_binding_before_equal"))
 ; if a module binding has no equal sign and isn't just a signature, everything enters the scope
 (module_binding
   (#scope_id! "module_binding_before_equal")
   (module_name) @append_indent_start @prepend_begin_scope
   "="? @do_nothing
-  (signature)? @do_nothing
-) @append_indent_end @append_end_scope
+  (signature)? @do_nothing) @append_indent_end @append_end_scope
 (module_binding
   (module_name) @append_empty_scoped_softline
   (module_parameter) @prepend_spaced_scoped_softline
-  (#scope_id! "module_binding_before_equal")
-)
+  (#scope_id! "module_binding_before_equal"))
 
 ; Try block formatting
 ; A soft linebreak after the "try" (potentially "try%ppx") and one after the "with".
 (try_expression
   "try" @append_spaced_softline @append_indent_start
   .
-  "%"* @do_nothing
-)
+  "%"* @do_nothing)
 (try_expression
   "try"
   .
   "%"
   .
-  (attribute_id) @append_spaced_softline @append_indent_start
-)
+  (attribute_id) @append_spaced_softline @append_indent_start)
 (try_expression
   "with" @prepend_indent_end @prepend_spaced_softline @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Formatting set expressions
 (set_expression
-  "<-" @append_spaced_softline @append_indent_start
-) @append_indent_end
+  "<-" @append_spaced_softline @append_indent_start) @append_indent_end
 
 ; Input softlines before and after all comments. This means that the input
 ; decides if a comment should have line breaks before or after. But don't put a
@@ -1506,8 +1314,7 @@
 (
   (comment) @append_input_softline
   .
-  ["," ";"]* @do_nothing
-)
+  ["," ";"]* @do_nothing)
 
 ; ================================================================================
 ; Predicate parameter newline separatation and indentation

--- a/topiary-queries/queries/bash.scm
+++ b/topiary-queries/queries/bash.scm
@@ -9,18 +9,15 @@
   (expansion)
   (heredoc_redirect)
   (string)
-  (word)
-] @leaf
+  (word)] @leaf
 
 (simple_expansion
   "$"
   .
-  (_) @leaf
-)
+  (_) @leaf)
 
 (subscript
-  index: (_) @leaf
-)
+  index: (_) @leaf)
 
 ;; Spacing
 
@@ -41,8 +38,7 @@
   (redirected_statement)
   (subshell)
   (variable_assignment)
-  (while_statement)
-] @allow_blank_line_before
+  (while_statement)] @allow_blank_line_before
 
 ; Insert a new line before multi-line syntactic blocks, regardless of
 ; context
@@ -52,8 +48,7 @@
   (for_statement)
   (function_definition)
   (if_statement)
-  (while_statement)
-] @prepend_hardline
+  (while_statement)] @prepend_hardline
 
 ; Subshells and compound statements should have a new line inserted
 ; before them when they are top-level constructs. Beyond that level, the
@@ -64,9 +59,7 @@
 (program
   [
     (compound_statement)
-    (subshell)
-  ] @prepend_hardline
-)
+    (subshell)] @prepend_hardline)
 
 ; A run of "units of execution" (see Commands section, below; sans
 ; variables which are special) should be interposed by a new line, after
@@ -80,12 +73,10 @@
     (function_definition)
     (if_statement)
     (variable_assignment)
-    (while_statement)
-  ]
+    (while_statement)]
   .
   ; Commands (sans variables)
-  [(command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement)] @prepend_hardline
-)
+  [(command) (list) (pipeline) (subshell) (compound_statement) (redirected_statement)] @prepend_hardline)
 
 ; A run of variable declarations and assignments should be interposed by
 ; a new line, after almost anything else. This makes them stand out.
@@ -102,14 +93,11 @@
     (pipeline)
     (redirected_statement)
     (subshell)
-    (while_statement)
-  ]
+    (while_statement)]
   .
   [
     (declaration_command)
-    (variable_assignment)
-  ] @prepend_hardline
-)
+    (variable_assignment)] @prepend_hardline)
 
 ; Append a space to the following keywords and delimiters
 [
@@ -128,15 +116,13 @@
   "then"
   "typeset"
   "until"
-  "while"
-] @append_space
+  "while"] @append_space
 
 ";" @prepend_antispace
 
 ; Prepend a space to intra-statement keywords
 [
-  "in"
-] @prepend_space
+  "in"] @prepend_space
 
 ;; Comments
 
@@ -194,16 +180,14 @@
   "{" @append_spaced_softline @append_indent_start
   _
   "}" @prepend_spaced_softline @prepend_indent_end
-  .
-)
+  .)
 
 (subshell
   .
   "(" @append_spaced_softline @append_indent_start
   _
   ")" @prepend_spaced_softline @prepend_indent_end
-  .
-)
+  .)
 
 ;; Commands
 
@@ -265,12 +249,10 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "program_line_break")
-)
+  (#scope_id! "program_line_break"))
 
 (compound_statement
   [
@@ -280,12 +262,10 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "compound_statement_line_break")
-)
+  (#scope_id! "compound_statement_line_break"))
 
 (subshell
   [
@@ -295,12 +275,10 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "subshell_line_break")
-)
+  (#scope_id! "subshell_line_break"))
 
 (if_statement
   .
@@ -313,12 +291,10 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "(if_statement_line_break")
-)
+  (#scope_id! "(if_statement_line_break"))
 
 (elif_clause
   .
@@ -331,12 +307,10 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "elif_clause_line_break")
-)
+  (#scope_id! "elif_clause_line_break"))
 
 (else_clause
   .
@@ -348,12 +322,10 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "else_clause_line_break")
-)
+  (#scope_id! "else_clause_line_break"))
 
 (case_item
   .
@@ -366,12 +338,10 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "case_item_line_break")
-)
+  (#scope_id! "case_item_line_break"))
 
 (do_group
   .
@@ -383,12 +353,10 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "do_group_line_break")
-)
+  (#scope_id! "do_group_line_break"))
 
 (command_substitution
   [
@@ -398,30 +366,25 @@
     (subshell)
     (compound_statement)
     (redirected_statement)
-    (variable_assignment)
-  ] @append_begin_scope @append_empty_scoped_softline
+    (variable_assignment)] @append_begin_scope @append_empty_scoped_softline
   .
   _ @prepend_end_scope
-  (#scope_id! "command_substitution_line_break")
-)
+  (#scope_id! "command_substitution_line_break"))
 
 ; Spaces between named nodes and command list/pipeline delimiters
 (list
   [(_) "&&" "||"] @append_space
   .
-  _
-)
+  _)
 
 (pipeline
-  ["|" "|&"] @prepend_space @append_spaced_softline
-)
+  ["|" "|&"] @prepend_space @append_spaced_softline)
 
 (pipeline
   .
   (_)
   .
-  ["|" "|&"] @append_indent_start
-) @append_indent_end
+  ["|" "|&"] @append_indent_start) @append_indent_end
 
 ; Prepend the asynchronous operator with a space
 ; NOTE This can interpose two "commands", but it's rare to see it in the
@@ -429,8 +392,7 @@
 (_
   [(command) (list) (pipeline) (compound_statement) (subshell) (redirected_statement)]
   .
-  "&" @prepend_space @append_spaced_softline
-)
+  "&" @prepend_space @append_spaced_softline)
 
 ; Spaces between command and its arguments
 ; NOTE If we treat (command) as a leaf node, then commands are formatted
@@ -440,49 +402,42 @@
 (command
   (_) @append_space
   .
-  (_)
-)
+  (_))
 
 ; Ensure the negation operator is surrounded by spaces
 ; NOTE This is a syntactic requirement
 (negated_command
   .
-  "!" @prepend_space @append_space
-)
+  "!" @prepend_space @append_space)
 
 (command_substitution
   .
   "`" @delete @append_delimiter
   .
   _ @prepend_empty_softline @prepend_indent_start
-  (#delimiter! "$(")
-)
+  (#delimiter! "$("))
 
 (command_substitution
   _ @append_empty_softline @append_indent_end
   .
   "`" @delete @append_delimiter
   .
-  (#delimiter! ")")
-)
+  (#delimiter! ")"))
 
 ; Multi-line command substitutions become an indent block
 (command_substitution
   "$(" @append_empty_softline @append_indent_start
-  ")" @prepend_empty_softline @prepend_indent_end
-)
+  ")" @prepend_empty_softline @prepend_indent_end)
 
 ; Ensure a space interposes command substitutions containing subshells
 ; This is to remove the ambiguity with $(( ... ))
 (command_substitution
   .
-  (subshell) @prepend_space
-)
+  (subshell) @prepend_space)
 
 (command_substitution
   (subshell) @append_space
-  .
-)
+  .)
 
 ;; Redirections
 
@@ -491,8 +446,7 @@
 (redirected_statement
   (_) @append_space
   .
-  (_)
-)
+  (_))
 
 ; ...with the exceptions of herestrings, that are spaced
 (herestring_redirect (_) @prepend_space)
@@ -503,30 +457,25 @@
 [
   (if_statement)
   (elif_clause)
-  (else_clause)
-] @append_hardline
+  (else_clause)] @append_hardline
 
 ; New line after "then" and start indent block
 [
   (if_statement)
-  (elif_clause)
-]
+  (elif_clause)]
 "then" @append_hardline @append_indent_start
 
 ; New line after "else" and start indent block
 (else_clause
   .
-  "else" @append_hardline @append_indent_start
-)
+  "else" @append_hardline @append_indent_start)
 
 ; Finish indent block at "fi", "else" or "elif"
 (if_statement
   [
     "fi"
     (else_clause)
-    (elif_clause)
-  ] @prepend_indent_end @prepend_hardline
-)
+    (elif_clause)] @prepend_indent_end @prepend_hardline)
 
 ; Keep the "if"/"elif" and the "then" on the same line,
 ; inserting a spaced delimiter when necessary
@@ -534,8 +483,7 @@
   ";"* @do_nothing
   .
   "then" @prepend_delimiter
-  (#delimiter! "; ")
-)
+  (#delimiter! "; "))
 
 ;; Test Commands
 
@@ -543,18 +491,15 @@
 ; FIXME This breaks _sometimes_, but I don't know why :(
 (test_command
   "[" @append_delimiter
-  (#delimiter! "[ ")
-)
+  (#delimiter! "[ "))
 
 (test_command
   "]" @prepend_delimiter
-  (#delimiter! " ]")
-)
+  (#delimiter! " ]"))
 
 (test_command
   "[[" @append_space
-  "]]" @prepend_space
-)
+  "]]" @prepend_space)
 
 ; NOTE (arithmetic_expansion) seems to take higher priority
 ; (test_command
@@ -564,31 +509,25 @@
 
 (arithmetic_expansion
   "$[" @delete @append_delimiter
-  (#delimiter! "$(( ")
-)
+  (#delimiter! "$(( "))
 
 (arithmetic_expansion
   "]" @delete @append_delimiter
-  (#delimiter! " ))")
-)
+  (#delimiter! " ))"))
 
 (arithmetic_expansion
   ["$((" "(("] @append_space
-  ["))"] @prepend_space
-)
+  ["))"] @prepend_space)
 
 (unary_expression
-  "!" @append_space
-)
+  "!" @append_space)
 
 (unary_expression
-  (test_operator) @append_space
-)
+  (test_operator) @append_space)
 
 (binary_expression
   left: (_) @append_space
-  right: (_) @prepend_space
-)
+  right: (_) @prepend_space)
 
 ;; Case Statements
 
@@ -602,14 +541,12 @@
   "in" @append_hardline @append_indent_start
   _
   "esac" @prepend_hardline @prepend_indent_end
-  .
-) @append_hardline
+  .) @append_hardline
 
 ; New (soft)line after branch, which starts an indentation block up
 ; until its end
 (case_item
-  ")" @append_spaced_softline @append_indent_start
-) @append_indent_end
+  ")" @append_spaced_softline @append_indent_start) @append_indent_end
 
 ; Ensure case branch terminators appear on their own line, in a
 ; multi-line context; or, at least, push the next case branch on to a
@@ -620,10 +557,8 @@
   [
     ";;"
     ";;&"
-    ";&"
-  ] @append_hardline
-  .
-)
+    ";&"] @append_hardline
+  .)
 
 ;; Loops
 
@@ -633,19 +568,16 @@
   "do" @append_hardline @append_indent_start
   _
   "done" @prepend_hardline @prepend_indent_end
-  .
-) @append_hardline
+  .) @append_hardline
 
 ; Ensure the word list is delimited by spaces in classic for loops
 (for_statement
-  value: _* @prepend_space
-)
+  value: _* @prepend_space)
 
 ; Surround the loop condition with spaces in C-style for loops
 (c_style_for_statement
   initializer: _ @prepend_space
-  update: _ @append_space
-)
+  update: _ @append_space)
 
 ; Keep the loop construct and the "do" on the same line,
 ; inserting a spaced delimiter when necessary
@@ -653,8 +585,7 @@
   ";"* @do_nothing
   .
   (do_group) @prepend_delimiter
-  (#delimiter! "; ")
-)
+  (#delimiter! "; "))
 
 ;; Function Definitions
 
@@ -674,8 +605,7 @@
 ; statements and test commands as function bodies.
 
 (function_definition
-  body: (_) @prepend_space @append_hardline
-)
+  body: (_) @prepend_space @append_hardline)
 
 (function_definition
   .
@@ -683,18 +613,15 @@
   .
   (
     "("
-    ")"
-  )? @do_nothing
+    ")")? @do_nothing
 
-  (#delimiter! "()")
-)
+  (#delimiter! "()"))
 
 ; NOTE This rule must appear after the above, where the "()" are
 ; appended, if necessary
 (function_definition
   .
-  "function" @delete
-)
+  "function" @delete)
 
 ;; Variable Declaration, Assignment and Expansion
 
@@ -707,45 +634,37 @@
 (
   (declaration_command)
   .
-  (_) @prepend_hardline
-)
+  (_) @prepend_hardline)
 
 ; All declaration arguments must be separated by whitespace
 (declaration_command
-  (word) @append_space
-)
+  (word) @append_space)
 
 ; Multiple variables can be declared (and assigned) at once
 (declaration_command
   [
     (variable_name)
-    (variable_assignment)
-  ] @prepend_space
-)
+    (variable_assignment)] @prepend_space)
 
 (declaration_command
   (variable_name)? @do_nothing
   .
-  (concatenation) @prepend_space
-)
+  (concatenation) @prepend_space)
 
 ; Environment variables assigned to commands inline need to be spaced
 (command
-  (variable_assignment) @append_space
-)
+  (variable_assignment) @append_space)
 
 ; Multi-line arrays start an indentation block
 (array
   "(" @append_empty_softline @append_indent_start
-  ")" @prepend_empty_softline @prepend_indent_end
-)
+  ")" @prepend_empty_softline @prepend_indent_end)
 
 ; Array elements need to be spaced
 (array
   (_) @append_spaced_softline
   .
-  (_)
-)
+  (_))
 
 ; Convert (simple_expansion) into (expansion)s
 ; NOTE Only convert $word, not special forms like $0, $@, etc.
@@ -754,13 +673,11 @@
   "$"
   .
   (variable_name) @prepend_delimiter
-  (#not-match? @prepend_delimiter "[0-9]")
-)
+  (#not-match? @prepend_delimiter "[0-9]"))
 
 (simple_expansion
   (#delimiter! "}")
   "$"
   .
   (variable_name) @append_delimiter
-  (#not-match? @append_delimiter "[0-9]")
-)
+  (#not-match? @append_delimiter "[0-9]"))

--- a/topiary-queries/queries/css.scm
+++ b/topiary-queries/queries/css.scm
@@ -7,14 +7,12 @@
   (string_value)
   (color_value)
   (float_value)
-  (grid_value)
-] @leaf
+  (grid_value)] @leaf
 
 ; Append space after colons
 (declaration ":" @append_space)
 (feature_query
-  ":" @append_space
-)
+  ":" @append_space)
 
 ; Append space after import
 (import_statement "@import" @append_space)
@@ -37,12 +35,10 @@
 
 ; Space around and in binary queries
 (binary_query
-  "and" @prepend_space @append_space
-)
+  "and" @prepend_space @append_space)
 ; Space around not in unary queries
 (unary_query
-  "not" @append_space
-)
+  "not" @append_space)
 
 ; Add space before any !important declarations
 (important) @prepend_space
@@ -61,23 +57,19 @@
 (descendant_selector
   (_) @append_space
   .
-  (_)
-)
+  (_))
 (sibling_selector
   (_) @append_space
   "~" @append_space
-  (_)
-)
+  (_))
 (adjacent_sibling_selector
   (_) @append_space
   "+" @append_space
-  (_)
-)
+  (_))
 (child_selector
   (_) @append_space
   ">" @append_space
-  (_)
-)
+  (_))
 
 ; Indent the declarations in the block
 (block
@@ -85,8 +77,7 @@
   "{" @append_hardline @append_indent_start @prepend_space
   (_)
   "}" @prepend_hardline @prepend_indent_end @append_hardline
-  .
-)
+  .)
 
 ; Indent the declarations in the keyframe_block_list
 (keyframe_block_list
@@ -94,45 +85,37 @@
   "{" @append_hardline @append_indent_start @prepend_space
   (_)
   "}" @prepend_hardline @prepend_indent_end @append_hardline
-  .
-)
+  .)
 
 ; Always have semicolon after declarations
 (
   (declaration) @append_delimiter
   (#delimiter! ";")
-  (#not-match? @append_delimiter ";$")
-)
+  (#not-match? @append_delimiter ";$"))
 
 ; Appends hardline between declaration
 (declaration
-  ";" @append_hardline
-)
+  ";" @append_hardline)
 
 ; Add space between values after a property name
 (declaration
   (property_name)
   ":" @append_space
-  (_) @append_space
-)
+  (_) @append_space)
 
 ; Do not add a space between the last value and the ending semicolon
 (declaration
-  ";" @prepend_antispace
-)
+  ";" @prepend_antispace)
 
 (declaration
-  "," @prepend_antispace @append_space
-)
+  "," @prepend_antispace @append_space)
 
 (arguments
-  "," @append_space
-)
+  "," @append_space)
 
 ; Newline between selectors
 (selectors
-  "," @append_hardline
-)
+  "," @append_hardline)
 
 ; Space between operators in binary expressions
 (binary_expression ["+" "*" "-" "/"] @append_space @prepend_space)
@@ -142,6 +125,4 @@
   (arguments
     (_) @append_space
     .
-    ["," ")"]* @do_nothing
-  )
-)
+    ["," ")"]* @do_nothing))

--- a/topiary-queries/queries/json.scm
+++ b/topiary-queries/queries/json.scm
@@ -18,26 +18,22 @@
   "{" @append_spaced_softline @append_indent_start
   (pair)
   "}" @prepend_spaced_softline @prepend_indent_end
-  .
-)
+  .)
 
 (array
   .
   "[" @append_spaced_softline @append_indent_start
   (_value)
   "]" @prepend_spaced_softline @prepend_indent_end
-  .
-)
+  .)
 
 ; Pairs should always end with a softline.
 ; Pairs come in two kinds, ones with a trailing comma, and those without.
 ; Those without are the last pair of an object,
 ; and the line is already added by the closing curly brace of the object.
 (object
-  "," @append_spaced_softline
-)
+  "," @append_spaced_softline)
 
 ; Items in an array must have a softline after. See also the pairs above.
 (array
-  "," @append_spaced_softline
-)
+  "," @append_spaced_softline)

--- a/topiary-queries/queries/nickel.scm
+++ b/topiary-queries/queries/nickel.scm
@@ -6,22 +6,19 @@
   (str_chunks_single)
   (str_chunks_multi)
   (builtin)
-  (quoted_enum_tag)
-] @leaf
+  (quoted_enum_tag)] @leaf
 
 ; Allow a blank line before the following nodes
 [
   (comment)
   (record_field)
-  (record_last_field)
-] @allow_blank_line_before
+  (record_last_field)] @allow_blank_line_before
 
 ; Allow blank lines to appear between a let bind and its result
 (let_expr
   (let_in_block)
   .
-  (term) @allow_blank_line_before
-)
+  (term) @allow_blank_line_before)
 
 ; Surround with spaces: keywords, operators, annotation markers
 (
@@ -74,9 +71,7 @@
     "=="
     "!="
     "&&"
-    "||"
-  ] @prepend_space @append_space
-)
+    "||"] @prepend_space @append_space)
 
 ; Don't insert spaces before the following delimiters
 ;
@@ -91,8 +86,7 @@
 ; formatting rules.
 [
   ","
-  ";"
-] @prepend_antispace
+  ";"] @prepend_antispace
 
 ; Parentheses
 ;
@@ -138,31 +132,25 @@
       (infix_expr . (applicative . (match_expr)))
 
       ; Multi-line and symbolic strings
-      (infix_expr . (applicative . (record_operand . (atom . (str_chunks)))))
-    ]
-  )? @do_nothing
+      (infix_expr . (applicative . (record_operand . (atom . (str_chunks)))))])? @do_nothing
   ")" @prepend_indent_end
-  .
-)
+  .)
 
 (atom
   .
   "(" @append_antispace
   ")" @prepend_antispace @prepend_empty_softline
-  .
-)
+  .)
 
 ; Don't insert spaces between infix operators and their operand
 (infix_expr
   .
   [
     "-"
-    (infix_u_op_5 "!")
-  ] @append_antispace
+    (infix_u_op_5 "!")] @append_antispace
   .
   (infix_expr)
-  .
-)
+  .)
 
 ; Flow a chain of infix expressions over new lines, in a multi-line
 ; context. Note that we _don't_ want this to happen for comparison
@@ -171,9 +159,7 @@
   (#scope_id! "infix_chain")
   [
     (infix_expr)
-    (annotated_infix_expr)
-  ] @prepend_begin_scope
-) @append_end_scope
+    (annotated_infix_expr)] @prepend_begin_scope) @append_end_scope
 
 (infix_expr
   (#scope_id! "infix_chain")
@@ -188,25 +174,21 @@
     (infix_lazy_b_op_10) ; ||
   ] @prepend_spaced_scoped_softline
   .
-  (infix_expr)
-)
+  (infix_expr))
 
 ; Surround all polymorphic type variables with spaces
 (forall
-  (ident) @prepend_space
-)
+  (ident) @prepend_space)
 
 ; Insert a space between the enum tag and the argument of an enum variant
 (enum_variant
-  (enum_tag) @append_space
-)
+  (enum_tag) @append_space)
 
 ; Insert a space between the enum tag and the argument of an enum variant
 ; pattern
 (enum_variant_pattern
   (enum_tag) @append_space
-  (pattern_fun)
-)
+  (pattern_fun))
 
 ;; Comments
 
@@ -239,9 +221,7 @@
   .
   [
     (term)
-    (pattern)
-  ] @append_end_scope
-)
+    (pattern)] @append_end_scope)
 
 (_
   (#scope_id! "bound_rhs")
@@ -275,11 +255,7 @@
         (infix_expr . (applicative . (match_expr)))
 
         ; Multi-line and symbolic strings
-        (infix_expr . (applicative . (record_operand . (atom . (str_chunks)))))
-      ]? @do_nothing
-    )
-  ) @append_indent_end
-)
+        (infix_expr . (applicative . (record_operand . (atom . (str_chunks)))))]? @do_nothing)) @append_indent_end)
 
 ; If the RHS starts with a comment, which itself is followed by a hard
 ; line, then we apply the normal indent block formatting in a multi-line
@@ -288,8 +264,7 @@
   "=" @append_indent_start
   .
   (comment)
-  (term) @append_indent_end
-)
+  (term) @append_indent_end)
 
 ; A let expression looks like:
 ;
@@ -322,10 +297,8 @@
     ; so that in the case of a "let rec" the line break goes after the "rec".
     (let_binding) @prepend_spaced_softline @prepend_indent_start
     (let_binding)
-    "in" @prepend_indent_end @prepend_begin_scope @prepend_spaced_softline
-  )
-  (term) @append_end_scope
-)
+    "in" @prepend_indent_end @prepend_begin_scope @prepend_spaced_softline)
+  (term) @append_end_scope)
 
 ; A let with a single binding. The binding should be on the same line as the "let".
 (let_expr
@@ -335,23 +308,18 @@
     .
     (let_binding)
     .
-    "in" @prepend_begin_scope @prepend_spaced_softline
-  )
-  (term) @append_end_scope
-)
+    "in" @prepend_begin_scope @prepend_spaced_softline)
+  (term) @append_end_scope)
 
 ; When binding multiple values in a let block, allow new lines between the bindings.
 (let_expr
   (#scope_id! "let_result")
   (let_in_block
-    ("," @append_spaced_softline)
-  )
-)
+    ("," @append_spaced_softline)))
 
 (let_expr
   (#scope_id! "let_result")
-  (term) @prepend_spaced_scoped_softline
-)
+  (term) @prepend_spaced_scoped_softline)
 
 ;; Annotations
 
@@ -370,14 +338,12 @@
   (#scope_id! "annotations")
   (_) @append_begin_scope
   .
-  (annot) @append_end_scope
-)
+  (annot) @append_end_scope)
 
 ; Put each annotation on a new line, in a multi-line context.
 (annot
   (#scope_id! "annotations")
-  (annot_atom) @prepend_spaced_scoped_softline
-)
+  (annot_atom) @prepend_spaced_scoped_softline)
 
 ; Start a new scope for annotations, used to properly indent any content coming
 ; after the annotations. We use Topiary's measuring scope feature: the
@@ -390,8 +356,7 @@
   .
   (annot) @append_end_measuring_scope
   "="
-  (term) @append_end_scope
-)
+  (term) @append_end_scope)
 
 ; Add a new line before the last annotation and the following equal sign, when
 ; the annotations are multi-line.
@@ -418,13 +383,11 @@
   (#scope_id! "annotations_with_content")
   (annot) @append_spaced_scoped_softline
   .
-  "="
-)
+  "=")
 
 ; Indent the annotations with respect to the identifier they annotate.
 (
-  (annot) @prepend_indent_start @append_indent_end
-)
+  (annot) @prepend_indent_start @append_indent_end)
 
 ; Indent the bound expression of a let-binding (or a field definition) in
 ; presence of multi-line annotations. That's where we use the measuring scope of
@@ -434,14 +397,12 @@
   (#multi_line_scope_only! "annotations_with_content")
   (annot) @append_indent_start
   "="
-  (term) @append_indent_end
-)
+  (term) @append_indent_end)
 
 ; Break a multi-line polymorphic type annotation after the type
 ; variables, starting an indentation block
 (forall
-  "." @append_spaced_softline @append_indent_start
-) @append_indent_end
+  "." @append_spaced_softline @append_indent_start) @append_indent_end
 
 ;; Functions
 
@@ -449,17 +410,14 @@
 ; This also defines an indentation block.
 (fun_expr
   (#scope_id! "function_definition")
-  "=>" @prepend_begin_scope @append_indent_start
-) @append_indent_end @append_end_scope
+  "=>" @prepend_begin_scope @append_indent_start) @append_indent_end @append_end_scope
 
 (fun_expr
   (#scope_id! "function_definition")
-  (term) @prepend_spaced_scoped_softline
-)
+  (term) @prepend_spaced_scoped_softline)
 
 (fun_expr
-  (pattern_fun) @append_space
-)
+  (pattern_fun) @append_space)
 
 ; Function application (and similar: type applications, enum variants, etc.)
 
@@ -478,8 +436,7 @@
 ; each argument, so we crate a scope accordingly.
 (infix_expr
   (#scope_id! "applicative_chain")
-  (applicative) @prepend_begin_scope
-) @append_end_scope
+  (applicative) @prepend_begin_scope) @append_end_scope
 
 ; In the the multi-ary application case, we add a softline before each argument,
 ; and we indent it.
@@ -491,11 +448,8 @@
   (applicative
     t1: (applicative
       t1: (applicative)
-      t2: (_) @prepend_indent_start @prepend_spaced_scoped_softline @append_indent_end
-    )
-    t2: (_)
-  )
-)
+      t2: (_) @prepend_indent_start @prepend_spaced_scoped_softline @append_indent_end)
+    t2: (_)))
 
 ; Missing case of the previous rule to indent the very last argument of a
 ; multi-ary application
@@ -504,11 +458,8 @@
   (applicative
     t1: (applicative
       t1: _
-      t2: _
-    )
-    t2: (_) @prepend_indent_start @prepend_spaced_scoped_softline @append_indent_end
-  )
-)
+      t2: _)
+    t2: (_) @prepend_indent_start @prepend_spaced_scoped_softline @append_indent_end))
 
 ; This adds a space before any argument of an application.
 ;
@@ -522,8 +473,7 @@
 ; additional effect in that case.
 (applicative
   t1: _
-  t2: (_) @prepend_space
-)
+  t2: (_) @prepend_space)
 
 ;; Patterns and match branches
 
@@ -534,22 +484,18 @@
   (#scope_id! "branch_body")
   (pattern)
   "=>" @prepend_begin_scope
-  (term) @append_end_scope
-)
+  (term) @append_end_scope)
 
 ; Flow multi-line match cases into an indented block after the =>
 (match_branch
   (#scope_id! "branch_body")
-  "=>" @append_spaced_scoped_softline @append_indent_start
-) @append_indent_end
+  "=>" @append_spaced_scoped_softline @append_indent_start) @append_indent_end
 
 ; Add indentation to the condition of pattern guards
 (match_branch
   (pattern_guard
     "if" @append_indent_start
-    (term) @append_indent_end
-  )
-)
+    (term) @append_indent_end))
 
 ; Flow each or-branch of an or-pattern on a separate line when they're the
 ; top-level construct of the pattern
@@ -557,11 +503,7 @@
   (pattern
     (or_pattern
       (or_pattern_unparens
-        "or" @prepend_spaced_softline
-      )
-    )
-  )
-)
+        "or" @prepend_spaced_softline))))
 
 ;; Conditionals
 
@@ -588,16 +530,13 @@
 ; alternative style is to give the "then" token its own line.)
 (ite_expr
   "then" @append_spaced_softline @append_indent_start
-  "else" @prepend_indent_end @prepend_spaced_softline
-)
+  "else" @prepend_indent_end @prepend_spaced_softline)
 
 (ite_expr
   "else" @append_spaced_softline @append_indent_start
   t2: (term
     ; Don't apply formatting if an "else" is followed by an "if"
-    (uni_term (ite_expr))? @do_nothing
-  ) @append_indent_end
-)
+    (uni_term (ite_expr))? @do_nothing) @append_indent_end)
 
 ;; Container Types
 ; i.e., Arrays, records (and dictionaries, vicariously) and enums
@@ -611,8 +550,7 @@
   "{" @append_spaced_softline @append_indent_start @prepend_begin_scope
   (_)
   "}" @prepend_indent_end @prepend_spaced_softline @append_end_scope
-  .
-)
+  .)
 
 ; Unlike records, arrays should never have internal spacing, similar to
 ; parentheticals. (This is a conscious choice by the Nickel team; see
@@ -624,8 +562,7 @@
   "[" @append_empty_softline @append_indent_start @prepend_begin_scope
   (_)
   "]" @prepend_indent_end @prepend_empty_softline @append_end_scope
-  .
-)
+  .)
 
 ; It doesn't really make sense for an enum to
 ; have no members, so we ignore that case
@@ -634,8 +571,7 @@
   .
   "[|" @append_spaced_softline @append_indent_start @prepend_begin_scope
   "|]" @prepend_indent_end @prepend_spaced_softline @append_end_scope
-  .
-)
+  .)
 
 ; Allow newlines after the comma (or semicolon) following a container
 ; element.
@@ -650,13 +586,11 @@
     (term)
     (pattern)
     (last_elem_pat)
-    (enum)
-  ]
+    (enum)]
   .
   ["," ";"] @append_spaced_scoped_softline
   .
-  (comment)? @do_nothing
-)
+  (comment)? @do_nothing)
 
 ; Enums and records can have a `;` at the very beginning; allow spaces after
 ; these ones also.
@@ -665,5 +599,4 @@
   .
   ";" @append_spaced_scoped_softline
   .
-  (comment)? @do_nothing
-)
+  (comment)? @do_nothing)

--- a/topiary-queries/queries/ocaml.scm
+++ b/topiary-queries/queries/ocaml.scm
@@ -27,9 +27,7 @@
     (character)
     (quoted_string)
     (signed_number)
-    (string)
-  ]
-) @leaf
+    (string)]) @leaf
 
 (comment) @multi_line_indent_all
 
@@ -58,31 +56,26 @@
   (open_module)
   (type_definition)
   (value_definition)
-  (value_specification)
-] @allow_blank_line_before
+  (value_specification)] @allow_blank_line_before
 
 ; The `;;` top-level operator should be alone on its line,
 ; possibly separated by blank lines above and below.
 (
   ";;" @allow_blank_line_before @prepend_hardline @append_hardline
   .
-  _ @allow_blank_line_before
-)
+  _ @allow_blank_line_before)
 
 ; In a definition including several mutually recursive functions,
 ; one can skip a line before each of them.
 (value_definition
-  "and" @allow_blank_line_before
-)
+  "and" @allow_blank_line_before)
 (value_definition
-  (let_and_operator) @allow_blank_line_before
-)
+  (let_and_operator) @allow_blank_line_before)
 
 ; In a definition including several mutually recursive types,
 ; one can skip a line before each of them.
 (type_definition
-  "and" @allow_blank_line_before
-)
+  "and" @allow_blank_line_before)
 
 ; Append line breaks. If there is a comment following, we don't add anything,
 ; because the input softlines and spaces above will already have sorted out the
@@ -93,13 +86,11 @@
     (external)
     (module_definition)
     (module_type_definition)
-    (type_definition)
-  ] @append_spaced_softline
+    (type_definition)] @append_spaced_softline
   .
   "in"? @do_nothing
   .
-  (comment)* @do_nothing
-)
+  (comment)* @do_nothing)
 ; Also append line breaks after open_module, except when it's
 ; preceded by "let", because in this case it's in a let_open_expression.
 (
@@ -107,8 +98,7 @@
   .
   (open_module) @append_hardline
   .
-  (comment)* @do_nothing
-)
+  (comment)* @do_nothing)
 
 ; Append line break after module include, except if it's alone in a single-lined struct
 (
@@ -119,8 +109,7 @@
     ; end equivalence class
   ] @append_hardline
   .
-  "end"? @do_nothing
-)
+  "end"? @do_nothing)
 (structure
   "struct"
   .
@@ -131,15 +120,13 @@
     ; end equivalence class
   ] @append_spaced_softline
   .
-  "end"
-)
+  "end")
 
 ; Consecutive definitions must be separated by line breaks
 (
   [
     (value_definition)
-    (value_specification)
-  ] @append_spaced_softline
+    (value_specification)] @append_spaced_softline
   .
   [
     (exception_definition)
@@ -149,9 +136,7 @@
     (open_module)
     (type_definition)
     (value_definition)
-    (value_specification)
-  ]
-)
+    (value_specification)])
 
 ; Surround spaces
 ; A space is put after, except when followed by a PPX "%".
@@ -222,11 +207,9 @@
     ":>"
     "::"
     "[>"
-    "[<"
-  ] @append_space
+    "[<"] @append_space
   .
-  "%"? @do_nothing
-)
+  "%"? @do_nothing)
 
 ; Prepend a space. Note that these nodes are not expected to come after an open parenthesis,
 ; or if they do, we still want a space before.
@@ -266,8 +249,7 @@
   "+="
   ":="
   ":>"
-  "::"
-] @prepend_space
+  "::"] @prepend_space
 
 ; let-like and and-like operators are only followed by a closing parenthesis
 ; during their definition, in which case no space must be appended.
@@ -275,20 +257,17 @@
 (
   (let_and_operator) @append_space
   .
-  ")"* @do_nothing
-)
+  ")"* @do_nothing)
 (
   (let_operator) @append_space
   .
-  ")"* @do_nothing
-)
+  ")"* @do_nothing)
 
 ; Put a space after commas, except the last one.
 (
   "," @append_space
   .
-  (_)
-)
+  (_))
 
 ; Put a space after the dot in polymorphic function types
 ;
@@ -296,8 +275,7 @@
 ;   type a b. a: a -> b: b -> a =
 ;   fun ~a ~b -> a
 (polymorphic_type
-  "." @append_space
-)
+  "." @append_space)
 
 ; Certain elements must be separated by spaces.
 (
@@ -332,8 +310,7 @@
     (value_path)
     (value_pattern)
     ")"
-    "]"
-  ] @append_space
+    "]"] @append_space
   .
   [
     ; Don't add any space just before these.
@@ -342,8 +319,7 @@
     "."
     ".."
     ")"
-    "]"
-  ]* @do_nothing
+    "]"]* @do_nothing
   .
   [
     (abstract_type)
@@ -383,9 +359,7 @@
     (value_path)
     (value_pattern)
     "("
-    "{"
-  ]
-)
+    "{"])
 
 ; When one uses a language extension, we always put a space after the extension name,
 ; if this name ends by the '?' or ':' token, the space comes after it.
@@ -396,16 +370,11 @@
   (attribute_payload
     [
       "?"
-      ":"
-    ]
-  )* @do_nothing
-)
+      ":"])* @do_nothing)
 (attribute_payload
   [
     "?"
-    ":"
-  ] @append_space
-)
+    ":"] @append_space)
 
 ; Some kinds of colons should have a space in front.
 (
@@ -415,11 +384,9 @@
     (module_name)
     (parenthesized_expression)
     (value_name)
-    (value_pattern)
-  ] @append_space
+    (value_pattern)] @append_space
   .
-  ":"
-)
+  ":")
 
 ; Keep spacing between pointy brackets when used in object types.
 ;
@@ -429,8 +396,7 @@
 ;   let obj_id (obj : <..>) = obj
 (object_type
   "<" @append_space
-  ">" @prepend_space
-)
+  ">" @prepend_space)
 
 ; Softlines. These become either a space or a newline, depending on whether we
 ; format their node as single-line or multi-line. If there is a comment
@@ -446,15 +412,12 @@
     "struct"
     "then"
     "with"
-    ";"
-  ] @append_spaced_softline
+    ";"] @append_spaced_softline
   .
   [
     (attribute)
     (comment)
-    "%"
-  ]* @do_nothing
-)
+    "%"]* @do_nothing)
 
 (
   [
@@ -463,15 +426,13 @@
     "struct"
     "then"
     "with"
-    ";"
-  ]
+    ";"]
   .
   "%"
   .
   (attribute_id) @append_spaced_softline
   .
-  (comment)* @do_nothing
-)
+  (comment)* @do_nothing)
 
 ; only add softlines after "else" if it's not part of an "else if" construction
 (
@@ -479,18 +440,14 @@
   .
   [
     (comment)
-    (if_expression)
-  ]? @do_nothing
-)
+    (if_expression)]? @do_nothing)
 
 ; ":" must not always be followed by a softline, we explicitly enumerate
 ; the contexts where it must happen
 (value_specification
-  ":" @append_spaced_softline
-)
+  ":" @append_spaced_softline)
 (module_binding
-  ":" @append_input_softline
-)
+  ":" @append_input_softline)
 (field_declaration
   ":" @append_spaced_softline
   [
@@ -499,13 +456,9 @@
       [
         "("
         (polymorphic_variant_type)
-        (record_declaration)
-      ]
-    )
+        (record_declaration)])
     (polymorphic_variant_type)
-    (record_declaration)
-  ]? @do_nothing
-)
+    (record_declaration)]? @do_nothing)
 ; We also want to add the softline when the following list-like structure is single-line
 (field_declaration
   ":" @append_spaced_softline
@@ -515,32 +468,23 @@
       [
         "("
         (polymorphic_variant_type)
-        (record_declaration)
-      ]
-    )
+        (record_declaration)])
     (polymorphic_variant_type)
-    (record_declaration)
-  ]
-  (#single_line_scope_only! "dangling_list_like")
-)
+    (record_declaration)]
+  (#single_line_scope_only! "dangling_list_like"))
 (typed_label
-  ":" @append_spaced_softline
-)
+  ":" @append_spaced_softline)
 (constructor_declaration
-  ":" @append_spaced_softline
-)
+  ":" @append_spaced_softline)
 
 ; "->" must not always be followed by a softline, we explicitly enumerate
 ; the contexts where it must happen
 (fun_expression
-  "->" @append_spaced_softline
-)
+  "->" @append_spaced_softline)
 (match_case
-  "->" @append_spaced_softline
-)
+  "->" @append_spaced_softline)
 (constructor_declaration
-  "->" @append_spaced_softline
-)
+  "->" @append_spaced_softline)
 
 ; Always put softlines before these:
 [
@@ -550,12 +494,10 @@
   (else_clause)
   (item_attribute)
   "*"
-  "|"
-] @prepend_spaced_softline
+  "|"] @prepend_spaced_softline
 
 [
-  (match_expression)
-] @prepend_empty_softline
+  (match_expression)] @prepend_empty_softline
 
 ; Softline before the first match case
 ;
@@ -566,12 +508,10 @@
 (match_expression
   "|"* @do_nothing
   .
-  (match_case) @prepend_spaced_softline
-)
+  (match_case) @prepend_spaced_softline)
 
 (match_expression
-  "|" @prepend_empty_softline
-)
+  "|" @prepend_empty_softline)
 
 ; Allow (and enforce) the optional "|" before the first match case
 ; if and only if the context is multi-line
@@ -581,8 +521,7 @@
   "|" @delete
   .
   (match_case)
-  (#single_line_only!)
-)
+  (#single_line_only!))
 
 (
   "with"
@@ -591,16 +530,14 @@
   .
   (match_case) @prepend_delimiter
   (#delimiter! "| ") ; sic
-  (#multi_line_only!)
-)
+  (#multi_line_only!))
 
 ; Same as above, with polymorphic variant type, only in the contexts where
 ; `dangling_list_like` can be defined.
 (
   [
     ":"
-    "="
-  ]
+    "="]
   .
   (polymorphic_variant_type
     "["
@@ -608,14 +545,11 @@
     "|" @delete
     .
     (tag_specification)
-    (#single_line_scope_only! "dangling_list_like")
-  )
-)
+    (#single_line_scope_only! "dangling_list_like")))
 (
   [
     ":"
-    "="
-  ]
+    "="]
   .
   (polymorphic_variant_type
     "["
@@ -624,26 +558,20 @@
     .
     (tag_specification) @prepend_delimiter
     (#delimiter! "| ") ; sic
-    (#multi_line_scope_only! "dangling_list_like")
-  )
-)
+    (#multi_line_scope_only! "dangling_list_like")))
 (
   [
     ":"
-    "="
-  ]
+    "="]
   .
   (polymorphic_variant_type
     (tag_specification) @append_empty_scoped_softline
-    (#scope_id! "dangling_list_like")
-  )
-)
+    (#scope_id! "dangling_list_like")))
 ; Default version relying on local scope only
 (
   [
     ":"
-    "="
-  ]? @do_nothing
+    "="]? @do_nothing
   .
   (polymorphic_variant_type
     "["
@@ -651,14 +579,11 @@
     "|" @delete
     .
     (tag_specification)
-    (#single_line_only!)
-  )
-)
+    (#single_line_only!)))
 (
   [
     ":"
-    "="
-  ]? @do_nothing
+    "="]? @do_nothing
   .
   (polymorphic_variant_type
     "["
@@ -667,33 +592,24 @@
     .
     (tag_specification) @prepend_delimiter
     (#delimiter! "| ") ; sic
-    (#multi_line_only!)
-  )
-)
+    (#multi_line_only!)))
 (
   [
     ":"
-    "="
-  ]? @do_nothing
+    "="]? @do_nothing
   .
   (polymorphic_variant_type
     [
       "["
-      (tag_specification)
-    ] @append_empty_softline
-  )
-)
+      (tag_specification)] @append_empty_softline))
 (
   [
     ":"
-    "="
-  ]? @do_nothing
+    "="]? @do_nothing
   .
   (polymorphic_variant_type
     "[" @append_indent_start
-    "]" @prepend_indent_end
-  )
-)
+    "]" @prepend_indent_end))
 
 ; Multi-line definitions must have a linebreak after "=" and before "in":
 ;
@@ -705,21 +621,17 @@
 (let_expression
   (value_definition
     (_) @append_spaced_softline
-    .
-  )
+    .)
   .
-  "in" @append_spaced_softline
-)
+  "in" @append_spaced_softline)
 (let_module_expression
   (module_definition)
   .
-  "in" @append_spaced_softline
-)
+  "in" @append_spaced_softline)
 (let_open_expression
   (open_module)
   .
-  "in" @append_spaced_softline
-)
+  "in" @append_spaced_softline)
 ; There are special cases however. We do not want to break lines after "=" when writing
 ;
 ; let f = function
@@ -739,16 +651,12 @@
       .
       [
         "("
-        "["
-      ]
-    )
+        "["])
     (list_expression)
     (record_expression)
     (array_expression)
     (function_expression)
-    (fun_expression)
-  ]* @do_nothing
-)
+    (fun_expression)]* @do_nothing)
 
 ; We want to write multi-line list-like bindings as:
 ;
@@ -772,8 +680,7 @@
     "::"
     "<-"
     "->"
-    "*"
-  ] @append_begin_scope
+    "*"] @append_begin_scope
   .
   (comment)*
   .
@@ -783,17 +690,13 @@
       .
       [
         "("
-        "["
-      ]
-    )
+        "["])
     (list_expression)
     (record_expression)
     (array_expression)
     ; types
     (polymorphic_variant_type)
-    (record_declaration)
-  ] @append_end_scope @prepend_begin_measuring_scope @append_end_measuring_scope
-)
+    (record_declaration)] @append_end_scope @prepend_begin_measuring_scope @append_end_measuring_scope)
 (application_expression
   (#scope_id! "dangling_list_like")
   (_) @append_begin_scope
@@ -804,14 +707,10 @@
       .
       [
         "("
-        "["
-      ]
-    )
+        "["])
     (list_expression)
     (record_expression)
-    (array_expression)
-  ] @append_end_scope @prepend_begin_measuring_scope @append_end_measuring_scope
-)
+    (array_expression)] @append_end_scope @prepend_begin_measuring_scope @append_end_measuring_scope)
 (_
   (#scope_id! "dangling_list_like")
   "let" @append_begin_scope
@@ -820,10 +719,7 @@
     [
       (array_pattern)
       (list_pattern)
-      (record_pattern)
-    ] @append_end_scope @prepend_begin_measuring_scope @append_end_measuring_scope
-  )
-)
+      (record_pattern)] @append_end_scope @prepend_begin_measuring_scope @append_end_measuring_scope))
 (constructor_pattern
   (#scope_id! "dangling_list_like")
   (_) @append_begin_scope
@@ -831,9 +727,7 @@
   [
     (array_pattern)
     (list_pattern)
-    (record_pattern)
-  ] @append_end_scope @prepend_begin_measuring_scope @append_end_measuring_scope
-)
+    (record_pattern)] @append_end_scope @prepend_begin_measuring_scope @append_end_measuring_scope)
 
 ; We want to add a line when the regular scope is multi-line,
 ; But only if the (measured) custom scope is single-line.
@@ -858,8 +752,7 @@
     ":"
     "::"
     "<-"
-    "*"
-  ] @append_spaced_softline @append_indent_start
+    "*"] @append_spaced_softline @append_indent_start
   .
   (comment)*
   .
@@ -870,43 +763,35 @@
       .
       [
         "("
-        "["
-      ]
+        "["]
       _
       [
         ")"
-        "]"
-      ]
-      .
-    )
+        "]"]
+      .)
     (list_expression)
     (record_expression)
     (array_expression)
     ; types
     (polymorphic_variant_type)
-    (record_declaration)
-  ] @append_indent_end
+    (record_declaration)] @append_indent_end
   .
   "="? @do_nothing ; Abort if we're in a let binding before the `=`
-  (#single_line_scope_only! "dangling_list_like")
-)
+  (#single_line_scope_only! "dangling_list_like"))
 ; Do not indent `in` and `->`, because we want to be able to chain them while
 ; keeping alignment
 (_
   [
     "in"
-    "->"
-  ] @append_spaced_softline
+    "->"] @append_spaced_softline
   .
   [
     ; expressions
     (parenthesized_expression)
     (list_expression)
     (record_expression)
-    (array_expression)
-  ]
-  (#single_line_scope_only! "dangling_list_like")
-)
+    (array_expression)]
+  (#single_line_scope_only! "dangling_list_like"))
 
 ; We chose not to add a line break between `=` and the
 ; `fun` or `function` keywords, but in order to keep the multi-lined-ness
@@ -930,10 +815,8 @@
   "=" @prepend_begin_scope
   .
   (fun_expression
-    "->" @append_spaced_scoped_softline
-  ) @append_end_scope
-  (#scope_id! "fun_definition")
-)
+    "->" @append_spaced_scoped_softline) @append_end_scope
+  (#scope_id! "fun_definition"))
 
 ; The same as above holds for single-line `function`.
 ;
@@ -954,27 +837,22 @@
   "=" @prepend_begin_scope
   .
   (function_expression
-    "function" @append_spaced_scoped_softline
-  ) @append_end_scope
-  (#scope_id! "function_definition")
-)
+    "function" @append_spaced_scoped_softline) @append_end_scope
+  (#scope_id! "function_definition"))
 ; The following is the general case, which should happen anywhere except in let bindings
 (
   "="? @do_nothing
   .
   (function_expression
-    "function" @append_spaced_scoped_softline
-  ) @prepend_begin_scope @append_end_scope
-  (#scope_id! "function_definition")
-)
+    "function" @append_spaced_scoped_softline) @prepend_begin_scope @append_end_scope
+  (#scope_id! "function_definition"))
 (function_expression
   (match_case)? @do_nothing
   .
   "|" @delete
   .
   (match_case)
-  (#single_line_scope_only! "function_definition")
-)
+  (#single_line_scope_only! "function_definition"))
 (function_expression
   "|"? @do_nothing
   .
@@ -986,12 +864,10 @@
   "|" @prepend_spaced_scoped_softline
   .
   (match_case)
-  (#scope_id! "function_definition")
-)
+  (#scope_id! "function_definition"))
 
 (value_definition
-  (let_and_operator) @prepend_spaced_softline
-)
+  (let_and_operator) @prepend_spaced_softline)
 
 ; There is a large class of terms which should be separated from "=" by a soft line break.
 (
@@ -1010,9 +886,7 @@
     (typed_expression)
     (unit)
     (value_path)
-    (variant_declaration)
-  ]
-)
+    (variant_declaration)])
 
 ; In module signature, each symbol declaration is separated by a softline.
 ;
@@ -1031,8 +905,7 @@
     (include_module)
     (include_module_type)
     ; end equivalence class
-  ] @append_spaced_softline
-)
+  ] @append_spaced_softline)
 
 ; In class definitions and class type definitions, each declaration is separated
 ; by a softline.
@@ -1050,9 +923,7 @@
     (inheritance_definition)
     (instance_variable_definition)
     (method_definition)
-    (class_initializer)
-  ] @append_spaced_softline @prepend_spaced_softline
-)
+    (class_initializer)] @append_spaced_softline @prepend_spaced_softline)
 
 (class_body_type
   "object"
@@ -1060,9 +931,7 @@
     (inheritance_specification)
     (instance_variable_definition)
     (method_definition)
-    (class_initializer)
-  ] @append_spaced_softline @prepend_spaced_softline
-)
+    (class_initializer)] @append_spaced_softline @prepend_spaced_softline)
 
 ; Move semicolon delimiters just after field declarations,
 ; before any attributes and comments.
@@ -1083,12 +952,10 @@
   .
   [
     (comment)
-    (attribute)
-  ]*
+    (attribute)]*
   .
   ";" @delete
-  (#delimiter! ";")
-)
+  (#delimiter! ";"))
 
 ; Unfortunately, we can't process all record declarations:
 ; some are arbitrarily nested within (constructed_type) or (function_type),
@@ -1097,24 +964,18 @@
   [
     ":"
     "="
-    "of"
-  ]
+    "of"]
   (record_declaration
     (field_declaration) @prepend_empty_scoped_softline
-    (#scope_id! "dangling_list_like")
-  )
-)
+    (#scope_id! "dangling_list_like")))
 (
   [
     ":"
     "="
-    "of"
-  ]
+    "of"]
   (record_declaration
     "}" @prepend_empty_scoped_softline
-    (#scope_id! "dangling_list_like")
-  )
-)
+    (#scope_id! "dangling_list_like")))
 
 ; Allow multi-line attributes after field declaratioms, such as:
 ; type t = {
@@ -1130,25 +991,20 @@
   [
     (field_declaration)
     (attribute)
-    (comment)
-  ]? @append_end_scope
+    (comment)]? @append_end_scope
   .
-  (field_declaration) @prepend_begin_scope
-)
+  (field_declaration) @prepend_begin_scope)
 (record_declaration
   (#scope_id! "field_declaration")
   [
     (field_declaration)
     (attribute)
-    (comment)
-  ] @append_end_scope
+    (comment)] @append_end_scope
   .
-  "}"
-)
+  "}")
 (record_declaration
   (attribute) @prepend_indent_start @prepend_spaced_scoped_softline @append_indent_end
-  (#scope_id! "field_declaration")
-)
+  (#scope_id! "field_declaration"))
 
 ; Duplicate the same logic as above for record *expressions*
 (record_expression
@@ -1156,64 +1012,52 @@
   .
   [
     (comment)
-    (attribute)
-  ]*
+    (attribute)]*
   .
   ";" @delete
-  (#delimiter! ";")
-)
+  (#delimiter! ";"))
 
 (record_expression
   (field_expression) @prepend_empty_scoped_softline
-  (#scope_id! "dangling_list_like")
-)
+  (#scope_id! "dangling_list_like"))
 
 (record_expression
   "}" @prepend_empty_scoped_softline
-  (#scope_id! "dangling_list_like")
-)
+  (#scope_id! "dangling_list_like"))
 
 (record_expression
   .
   "{" @append_begin_scope
-  (#scope_id! "field_expression")
-)
+  (#scope_id! "field_expression"))
 (record_expression
   (#scope_id! "field_expression")
   [
     (field_expression)
     (attribute)
-    (comment)
-  ] @append_end_scope
+    (comment)] @append_end_scope
   .
-  (field_expression) @prepend_begin_scope
-)
+  (field_expression) @prepend_begin_scope)
 (record_expression
   (#scope_id! "field_expression")
   [
     (field_expression)
     (attribute)
-    (comment)
-  ] @append_end_scope
+    (comment)] @append_end_scope
   .
-  "}"
-)
+  "}")
 (record_expression
   (attribute) @prepend_indent_start @prepend_spaced_scoped_softline @append_indent_end
-  (#scope_id! "field_expression")
-)
+  (#scope_id! "field_expression"))
 
 ; Minimized version of the above for list expressions and array expressions
 
 (list_expression
   ";" @append_empty_scoped_softline
-  (#scope_id! "dangling_list_like")
-)
+  (#scope_id! "dangling_list_like"))
 
 (array_expression
   ";" @append_empty_scoped_softline
-  (#scope_id! "dangling_list_like")
-)
+  (#scope_id! "dangling_list_like"))
 
 ; Start an indented block after these
 [
@@ -1222,43 +1066,35 @@
   "object"
   "sig"
   "struct"
-  "then"
-] @append_indent_start
+  "then"] @append_indent_start
 
 ; "{" can be used to start quoted strings. Don't indent in that case
 (
   "{" @append_indent_start
   .
-  (quoted_string_content)* @do_nothing
-)
+  (quoted_string_content)* @do_nothing)
 
 ; End the indented block before these
 (
   [
     "done"
-    "end"
-  ] @prepend_indent_end
-)
+    "end"] @prepend_indent_end)
 
 ; "}" can be used to end quoted strings. Don't indent in that case
 (
   (quoted_string_content)* @do_nothing
   .
-  "}" @prepend_indent_end
-)
+  "}" @prepend_indent_end)
 
 ; Only indent after "else" if it's not an "else if" construction
 (
   (else_clause
     "else" @append_indent_start
-    (if_expression)? @do_nothing
-  ) @append_indent_end
-)
+    (if_expression)? @do_nothing) @append_indent_end)
 
 ; End the indented block after these
 (
-  (then_clause) @append_indent_end
-)
+  (then_clause) @append_indent_end)
 
 ; Make an indented block after ":" in typed expressions
 ;
@@ -1276,8 +1112,7 @@
 (value_specification
   ":" @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Make an indented block after "=" in
 ; * class bindings
@@ -1288,23 +1123,19 @@
 
 (class_binding
   "=" @append_indent_start
-  (_) @append_indent_end
-)
+  (_) @append_indent_end)
 
 (class_type_binding
   "=" @append_indent_start
-  (_) @append_indent_end
-)
+  (_) @append_indent_end)
 
 (instance_variable_definition
   "=" @append_indent_start
-  (_) @append_indent_end
-)
+  (_) @append_indent_end)
 
 (method_definition
   "=" @append_indent_start
-  (_) @append_indent_end
-)
+  (_) @append_indent_end)
 
 ; Some more rules for type bindings:
 ; Don't indent for record types nor polymorphic variant types:
@@ -1312,14 +1143,12 @@
 (type_binding
   [
     "="
-    "+="
-  ] @append_indent_start
+    "+="] @append_indent_start
   .
   [
     (constructed_type
       ; We don't want to capture constructed types that add their own indentation
-      "("? @do_nothing
-    )
+      "("? @do_nothing)
     (function_type)
     (hash_type)
     (object_type)
@@ -1328,17 +1157,14 @@
     (tuple_type)
     (type_constructor_path)
     (type_variable)
-    (variant_declaration)
-  ] @append_indent_end
+    (variant_declaration)] @append_indent_end
   .
-  (type_constraint)? @do_nothing
-)
+  (type_constraint)? @do_nothing)
 
 (type_binding
   [
     "="
-    "+="
-  ] @append_indent_start
+    "+="] @append_indent_start
   .
   [
     (constructed_type)
@@ -1350,20 +1176,16 @@
     (tuple_type)
     (type_constructor_path)
     (type_variable)
-    (variant_declaration)
-  ]
+    (variant_declaration)]
   .
-  (type_constraint) @append_indent_end
-)
+  (type_constraint) @append_indent_end)
 
 (type_binding
   (package_type
     .
     "(" @append_empty_softline @append_indent_start
     ")" @prepend_empty_softline @prepend_indent_end
-    .
-  ) @prepend_spaced_softline
-)
+    .) @prepend_spaced_softline)
 
 ; Consider type constraints to be "out of the block" when deciding
 ; whether to add a newline between "=" and a constructed type.
@@ -1374,8 +1196,7 @@
 (type_binding
   [
     "="
-    "+="
-  ] @prepend_begin_scope
+    "+="] @prepend_begin_scope
   .
   [
     (constructed_type)
@@ -1387,21 +1208,17 @@
     (tuple_type)
     (type_constructor_path)
     (type_variable)
-    (variant_declaration)
-  ] @append_end_scope
-  (#scope_id! "type_binding_before_constraint")
-)
+    (variant_declaration)] @append_end_scope
+  (#scope_id! "type_binding_before_constraint"))
 
 (type_binding
   [
     "="
-    "+="
-  ] @append_spaced_scoped_softline
+    "+="] @append_spaced_scoped_softline
   .
   [
     (constructed_type
-      "("? @do_nothing
-    )
+      "("? @do_nothing)
     (function_type)
     (hash_type)
     (object_type)
@@ -1410,14 +1227,11 @@
     (tuple_type)
     (type_constructor_path)
     (type_variable)
-    (variant_declaration)
-  ]
-  (#scope_id! "type_binding_before_constraint")
-)
+    (variant_declaration)]
+  (#scope_id! "type_binding_before_constraint"))
 
 (type_binding
-  (type_constraint) @prepend_spaced_softline
-)
+  (type_constraint) @prepend_spaced_softline)
 
 ; Make an indented block after "of" or ":" in constructor declarations
 ;
@@ -1429,11 +1243,9 @@
 (constructor_declaration
   [
     "of"
-    ":"
-  ] @append_indent_start
+    ":"] @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Make an indented block after the first term in a long if expression
 ;
@@ -1446,9 +1258,7 @@
     .
     (_) @append_indent_start
     (_) @append_indent_end
-    .
-  )
-)
+    .))
 
 ; Make an indented block after match arrows.
 ;
@@ -1459,8 +1269,7 @@
 (match_case
   "->" @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Make an indented block after constructor declaration arrows.
 ;
@@ -1470,8 +1279,7 @@
 (constructor_declaration
   "->" @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Make an indented block where a function/match starts in PPX syntax.
 ; The special case about function expressions allows the following to be formatted
@@ -1491,17 +1299,12 @@
     (expression_item
       [
         (function_expression)
-        (fun_expression)
-      ]? @do_nothing
-    )?
-  )
+        (fun_expression)]? @do_nothing)?)
   "]" @prepend_indent_end
-  .
-)
+  .)
 (extension
   "]" @prepend_empty_softline
-  .
-)
+  .)
 
 ; Indent and add softlines in multiline application expressions, such as
 ; let _ =
@@ -1533,8 +1336,7 @@
   (_) @append_indent_start @prepend_begin_scope @prepend_begin_measuring_scope
   (#scope_id! "function_application")
   (_) @append_end_scope
-  .
-)
+  .)
 ; The end of the measuring scope depends on the last argument: if it's a node that
 ; adds its own indentation, end it before the argument. Otherwise end it after the
 ; last argument. In that case, it's the same as the regular scope.
@@ -1547,11 +1349,8 @@
       "{"
       (fun_expression)
       (function_expression)
-      (parenthesized_expression)
-    ]? @do_nothing
-  ) @append_end_measuring_scope
-  .
-)
+      (parenthesized_expression)]? @do_nothing) @append_end_measuring_scope
+  .)
 (application_expression
   (#scope_id! "function_application")
   (_
@@ -1561,31 +1360,25 @@
       "{"
       (fun_expression)
       (function_expression)
-      (parenthesized_expression)
-    ] @prepend_end_measuring_scope
-  )
-  .
-)
+      (parenthesized_expression)] @prepend_end_measuring_scope)
+  .)
 ; If the measuring scope is single-line, end indentation _before_ the last node.
 ; Otherwise, end the indentation after the last node.
 (application_expression
   (#multi_line_scope_only! "function_application")
   (_) @append_indent_end
-  .
-)
+  .)
 (application_expression
   (#single_line_scope_only! "function_application")
   (_) @prepend_indent_end
-  .
-)
+  .)
 ; The node to which we apply append_spaced_scoped_softline will always
 ; be in both scopes, regular and measuring.
 (application_expression
   (_) @append_spaced_scoped_softline
   .
   (_)
-  (#scope_id! "function_application")
-)
+  (#scope_id! "function_application"))
 
 ; Indent and allow softlines in multiline function definitions, such as
 ; let long_function
@@ -1615,10 +1408,8 @@
       "[|" ; array_expression
       "{" ; record_expression. Unfortunately this also captures quoted strings
       "(" ; parenthesized_expression. Unfortunately this also captures unit
-    ]? @do_nothing
-  ) @append_indent_end
-  .
-)
+    ]? @do_nothing) @append_indent_end
+  .)
 ; Special case to still indent quoted strings and unit, despite the rule above
 (let_binding
   .
@@ -1626,31 +1417,25 @@
   "="
   [
     (quoted_string)
-    (unit)
-  ] @append_indent_end
-  .
-)
+    (unit)] @append_indent_end
+  .)
 
 (let_binding
   .
   (_) @append_indent_start
-  "=" @prepend_indent_end
-)
+  "=" @prepend_indent_end)
 (let_binding
   .
   (_) @prepend_begin_scope
   "=" @append_end_scope
-  (#scope_id! "let_binding_before_equal")
-)
+  (#scope_id! "let_binding_before_equal"))
 (let_binding
   (parameter) @prepend_spaced_scoped_softline
-  (#scope_id! "let_binding_before_equal")
-)
+  (#scope_id! "let_binding_before_equal"))
 (let_binding
   ":"? @prepend_spaced_scoped_softline
   "=" @prepend_spaced_scoped_softline
-  (#scope_id! "let_binding_before_equal")
-)
+  (#scope_id! "let_binding_before_equal"))
 
 ; Indent and allow softlines in anonymous function definitions, such as
 ; fun
@@ -1665,49 +1450,39 @@
 (
   [
     (concat_operator)
-    (rel_operator)
-  ]? @do_nothing
+    (rel_operator)]? @do_nothing
   .
   (fun_expression
     .
     "fun" @append_indent_start
     (_) @append_indent_end
-    .
-  )
-)
+    .))
 (fun_expression
   .
   "fun" @append_indent_start
-  "->" @prepend_indent_end
-)
+  "->" @prepend_indent_end)
 (fun_expression
   .
   "fun" @prepend_begin_scope
   "->" @append_end_scope
-  (#scope_id! "fun_expr_before_arrow")
-)
+  (#scope_id! "fun_expr_before_arrow"))
 (fun_expression
   (parameter) @prepend_spaced_scoped_softline
-  (#scope_id! "fun_expr_before_arrow")
-)
+  (#scope_id! "fun_expr_before_arrow"))
 (fun_expression
   ":"? @prepend_spaced_scoped_softline
   "->" @prepend_spaced_scoped_softline
-  (#scope_id! "fun_expr_before_arrow")
-)
+  (#scope_id! "fun_expr_before_arrow"))
 (
   [
     (concat_operator)
-    (rel_operator)
-  ]? @do_nothing
+    (rel_operator)]? @do_nothing
   .
   (function_expression
     .
     "function" @append_indent_start
     (_) @append_indent_end
-    .
-  )
-)
+    .))
 
 ; Indent and allow softlines in tuples and local opens, such as
 ; let _ =
@@ -1724,22 +1499,18 @@
   "(" @append_empty_softline @append_indent_start
   [
     (fun_expression)
-    (function_expression)
-  ]? @do_nothing
+    (function_expression)]? @do_nothing
   ")" @prepend_indent_end
-  .
-)
+  .)
 (parenthesized_expression
   ")" @prepend_empty_softline
-  .
-)
+  .)
 (local_open_expression
   "."
   .
   "(" @append_empty_softline @append_indent_start
   ")" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 ; Parenthesis are optional when using tuples, so scopes must be tied
 ; to the `product_expression` inside.
 ; Product expressions are nested grammar elements, which means that the syntax tree of
@@ -1758,12 +1529,10 @@
   (product_expression) @prepend_begin_scope @append_end_scope
   .
   ","? @do_nothing
-  (#scope_id! "tuple")
-)
+  (#scope_id! "tuple"))
 (product_expression
   "," @append_spaced_scoped_softline
-  (#scope_id! "tuple")
-)
+  (#scope_id! "tuple"))
 
 ; Allow softlines in function and functor types, such as
 ; type t =
@@ -1790,23 +1559,19 @@
   "->"? @do_nothing
   .
   (function_type) @prepend_begin_scope @append_end_scope
-  (#scope_id! "function_type")
-)
+  (#scope_id! "function_type"))
 (function_type
   "->" @append_spaced_scoped_softline
-  (#scope_id! "function_type")
-)
+  (#scope_id! "function_type"))
 
 (
   "->"? @do_nothing
   .
   (functor_type) @prepend_begin_scope @append_end_scope
-  (#scope_id! "functor_type")
-)
+  (#scope_id! "functor_type"))
 (functor_type
   "->" @append_spaced_scoped_softline
-  (#scope_id! "functor_type")
-)
+  (#scope_id! "functor_type"))
 
 ; Allow softlines in boolean infix expressions, such as
 ; let b =
@@ -1820,27 +1585,21 @@
   (and_operator)? @do_nothing
   .
   (infix_expression
-    (and_operator)
-  ) @prepend_begin_scope @append_end_scope
-  (#scope_id! "and_infix_expression")
-)
+    (and_operator)) @prepend_begin_scope @append_end_scope
+  (#scope_id! "and_infix_expression"))
 (infix_expression
   (and_operator) @prepend_spaced_scoped_softline
-  (#scope_id! "and_infix_expression")
-)
+  (#scope_id! "and_infix_expression"))
 
 (
   (or_operator)? @do_nothing
   .
   (infix_expression
-    (or_operator)
-  ) @prepend_begin_scope @append_end_scope
-  (#scope_id! "or_infix_expression")
-)
+    (or_operator)) @prepend_begin_scope @append_end_scope
+  (#scope_id! "or_infix_expression"))
 (infix_expression
   (or_operator) @prepend_spaced_scoped_softline
-  (#scope_id! "or_infix_expression")
-)
+  (#scope_id! "or_infix_expression"))
 
 ; When a "rel_operator" (like ">>=") is followed by a function definition,
 ; do not add a newline
@@ -1848,16 +1607,13 @@
   (rel_operator)? @do_nothing
   .
   (infix_expression
-    (rel_operator)
-  ) @prepend_begin_scope @append_end_scope
-  (#scope_id! "rel_infix_expression")
-)
+    (rel_operator)) @prepend_begin_scope @append_end_scope
+  (#scope_id! "rel_infix_expression"))
 (infix_expression
   (rel_operator) @prepend_spaced_scoped_softline
   (fun_expression)? @do_nothing
   (function_expression)? @do_nothing
-  (#scope_id! "rel_infix_expression")
-)
+  (#scope_id! "rel_infix_expression"))
 
 ; Put softline and indented blocks after all other infix operators
 (infix_expression
@@ -1865,10 +1621,8 @@
     (pow_operator)
     (mult_operator)
     (add_operator)
-    (assign_operator)
-  ] @append_spaced_softline @append_indent_start
-  right: (_) @append_indent_end
-)
+    (assign_operator)] @append_spaced_softline @append_indent_start
+  right: (_) @append_indent_end)
 
 ; After concat_operator, we want to place a spaced_softline,
 ; except when a function definition or a list-like structure follows.
@@ -1880,8 +1634,7 @@
   (parenthesized_expression)? @do_nothing
   (record_expression)? @do_nothing
   (fun_expression)? @do_nothing
-  (function_expression)? @do_nothing
-)
+  (function_expression)? @do_nothing)
 
 ; Then, we want to indent the expression after a concat_operator
 ; (with the exception of concat_operator chains, and nodes that add their
@@ -1910,15 +1663,12 @@
   (infix_expression
     operator: (concat_operator) @append_indent_start
     (infix_expression
-      operator: (concat_operator)
-    )? @do_nothing
+      operator: (concat_operator))? @do_nothing
     (array_expression)? @do_nothing
     (fun_expression)? @do_nothing
     (list_expression)? @do_nothing
     (parenthesized_expression)? @do_nothing
-    (record_expression)? @do_nothing
-  ) @append_indent_end
-)
+    (record_expression)? @do_nothing) @append_indent_end)
 
 ; The same holds for rel_operator, such as `>>=`
 (_
@@ -1927,11 +1677,8 @@
   (infix_expression
     operator: (rel_operator) @append_indent_start
     (infix_expression
-      operator: (rel_operator)
-    )? @do_nothing
-    (fun_expression)? @do_nothing
-  ) @append_indent_end
-)
+      operator: (rel_operator))? @do_nothing
+    (fun_expression)? @do_nothing) @append_indent_end)
 
 ; The following bit of scope sorcery allows the following to be formatted as such:
 ;
@@ -1955,9 +1702,7 @@
   (#scope_id! "dangling_multiline_function")
   [
     (fun_expression)
-    (function_expression)
-  ] @append_end_scope
-)
+    (function_expression)] @append_end_scope)
 (infix_expression
   (application_expression)
   .
@@ -1966,9 +1711,7 @@
   (#multi_line_scope_only! "dangling_multiline_function")
   [
     (fun_expression)
-    (function_expression)
-  ] @append_indent_end
-)
+    (function_expression)] @append_indent_end)
 
 ; The following allows
 ;
@@ -1985,17 +1728,13 @@
   .
   (fun_expression
     "fun" @prepend_end_measuring_scope
-    "->" @append_end_scope
-  )
-)
+    "->" @append_end_scope))
 (infix_expression
   (#multi_line_scope_only! "relocate_dangling_function_line_break")
   (concat_operator)
   .
   (fun_expression
-    "->" @append_hardline
-  )
-)
+    "->" @append_hardline))
 
 ; Allow softlines in sequences and ppx sequences, such as
 ; let b =
@@ -2007,24 +1746,20 @@
 (
   ";"? @do_nothing
   (sequence_expression
-    ";"
-  ) @prepend_begin_scope @append_end_scope
-  (#scope_id! "sequence_expression")
-)
+    ";") @prepend_begin_scope @append_end_scope
+  (#scope_id! "sequence_expression"))
 (sequence_expression
   ";" @append_spaced_scoped_softline
   .
   "%"? @do_nothing
-  (#scope_id! "sequence_expression")
-)
+  (#scope_id! "sequence_expression"))
 (sequence_expression
   ";"
   .
   "%"
   .
   (attribute_id) @append_spaced_scoped_softline
-  (#scope_id! "sequence_expression")
-)
+  (#scope_id! "sequence_expression"))
 
 ; Allow softlines in or patterns in matches, such as
 ; match foo with
@@ -2035,17 +1770,14 @@
 
 (match_case
   (or_pattern) @prepend_begin_scope @append_end_scope
-  (#scope_id! "top_level_or_pattern")
-)
+  (#scope_id! "top_level_or_pattern"))
 (match_case
   (alias_pattern) @prepend_begin_scope @append_end_scope
-  (#scope_id! "top_level_or_pattern")
-)
+  (#scope_id! "top_level_or_pattern"))
 
 (or_pattern
   "|" @prepend_hardline
-  (#multi_line_scope_only! "top_level_or_pattern")
-)
+  (#multi_line_scope_only! "top_level_or_pattern"))
 
 ; Indent and add softlines in lists and arrays, such as
 ; let _ = [
@@ -2058,16 +1790,14 @@
   "[" @append_indent_start @append_empty_scoped_softline
   (#scope_id! "dangling_list_like")
   "]" @prepend_indent_end @prepend_empty_scoped_softline
-  .
-)
+  .)
 
 (list_pattern
   .
   "[" @append_indent_start @append_empty_scoped_softline
   (#scope_id! "dangling_list_like")
   "]" @prepend_indent_end @prepend_empty_scoped_softline
-  .
-)
+  .)
 
 ; Unfortunately, we can't process all polymorphic variant types:
 ; some are arbitrarily nested within (constructed_type) or (function_type),
@@ -2075,69 +1805,55 @@
 (
   [
     "="
-    ":"
-  ]
+    ":"]
   (polymorphic_variant_type
     .
     "[" @append_indent_start @append_empty_scoped_softline
     (#scope_id! "dangling_list_like")
     "]" @prepend_indent_end @prepend_empty_scoped_softline
-    .
-  )
-)
+    .))
 ; Same for parenthesized constructed types, and record declarations.
 ; This is a best effort situation.
 (
   [
     "="
-    ":"
-  ]
+    ":"]
   (constructed_type
     .
     "(" @append_indent_start @append_empty_scoped_softline
     (#scope_id! "dangling_list_like")
-    ")" @prepend_indent_end @prepend_empty_scoped_softline
-  )
-)
+    ")" @prepend_indent_end @prepend_empty_scoped_softline))
 (
   [
     "="
-    ":"
-  ]
+    ":"]
   (constructed_type
     .
     "("
     "," @append_spaced_scoped_softline
     ")"
-    (#scope_id! "dangling_list_like")
-  )
-)
+    (#scope_id! "dangling_list_like")))
 (
   [
     "="
-    ":"
-  ] @append_empty_softline
+    ":"] @append_empty_softline
   (constructed_type
     "("
-    ")"
-  )
-  (#single_line_scope_only! "dangling_list_like")
-)
+    ")")
+  (#single_line_scope_only! "dangling_list_like"))
 
 (array_expression
   .
   "[|" @append_indent_start @append_empty_scoped_softline
   (#scope_id! "dangling_list_like")
   "|]" @prepend_indent_end @prepend_empty_scoped_softline
-  .
-)
+  .)
 
 (array_pattern
   .
   "[|" @append_indent_start @append_empty_softline
   "|]" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 
 ; Allow softlines and indentation in functor definitions with many arguments, such as
 ; module Lift
@@ -2152,63 +1868,51 @@
   (module_name) @append_indent_start @prepend_begin_scope
   [
     "="
-    ":"
-  ] @prepend_empty_scoped_softline @prepend_indent_end @append_end_scope
-  (#scope_id! "module_binding_before_equal")
-)
+    ":"] @prepend_empty_scoped_softline @prepend_indent_end @append_end_scope
+  (#scope_id! "module_binding_before_equal"))
 ; if a module binding has no equal sign and isn't just a signature, everything enters the scope
 (module_binding
   (#scope_id! "module_binding_before_equal")
   (module_name) @append_indent_start @prepend_begin_scope
   "="? @do_nothing
-  (signature)? @do_nothing
-) @append_indent_end @append_end_scope
+  (signature)? @do_nothing) @append_indent_end @append_end_scope
 (module_binding
   (module_name) @append_empty_scoped_softline
   (module_parameter) @prepend_spaced_scoped_softline
-  (#scope_id! "module_binding_before_equal")
-)
+  (#scope_id! "module_binding_before_equal"))
 
 ; Try block formatting
 ; A soft linebreak after the "try" (potentially "try%ppx") and one after the "with".
 (try_expression
   "try" @append_spaced_softline @append_indent_start
   .
-  "%"* @do_nothing
-)
+  "%"* @do_nothing)
 (try_expression
   "try"
   .
   "%"
   .
-  (attribute_id) @append_spaced_softline @append_indent_start
-)
+  (attribute_id) @append_spaced_softline @append_indent_start)
 (try_expression
   "with" @prepend_indent_end @prepend_spaced_softline @append_indent_start
   (_) @append_indent_end
-  .
-)
+  .)
 
 ; Formatting set expressions
 (set_expression
-  "<-" @append_spaced_softline @append_indent_start
-) @append_indent_end
+  "<-" @append_spaced_softline @append_indent_start) @append_indent_end
 
 ; Antispaces for brackets and parentheses
 (
   [
     "["
     "[|"
-    "{"
-  ] @append_antispace
-)
+    "{"] @append_antispace)
 (
   [
     "]"
     "|]"
-    "}"
-  ] @prepend_antispace
-)
+    "}"] @prepend_antispace)
 
 ; We must be cautious when surrounding `mult_operator` with parentheses, lest we mess
 ; with comments:
@@ -2216,13 +1920,11 @@
 (
   "(" @append_antispace
   .
-  (mult_operator)? @do_nothing
-)
+  (mult_operator)? @do_nothing)
 (
   (mult_operator)? @do_nothing
   .
-  ")" @prepend_antispace
-)
+  ")" @prepend_antispace)
 
 ; Formatting typed patterns in function arguments, e.g.
 ; let foo
@@ -2243,16 +1945,14 @@
   "("
   ":" @append_spaced_softline @append_indent_start
   ")" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 (parameter
   "~"
   .
   "("
   ":" @append_spaced_softline @append_indent_start
   ")" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 
 ; Input softlines before and after all comments. This means that the input
 ; decides if a comment should have line breaks before or after. But don't put a
@@ -2263,5 +1963,4 @@
 (
   (comment) @append_input_softline
   .
-  ["," ";"]* @do_nothing
-)
+  ["," ";"]* @do_nothing)

--- a/topiary-queries/queries/ocamllex.scm
+++ b/topiary-queries/queries/ocamllex.scm
@@ -5,8 +5,7 @@
 
 (
   (#scope_id! "action")
-  (action) @prepend_begin_scope @append_end_scope
-)
+  (action) @prepend_begin_scope @append_end_scope)
 
 ; If the action spanned multiple lines, add newlines
 (action
@@ -30,8 +29,7 @@
 ; Actual regex rules
 [
   (character)
-  (string)
-] @leaf
+  (string)] @leaf
 
 (string) @prepend_spaced_softline @append_spaced_softline
 
@@ -42,50 +40,41 @@
   ; Do not append spaces to the last element, then only place a newline
   (_) @append_empty_scoped_softline
   .
-  "]" @prepend_indent_end @prepend_antispace
-) @prepend_begin_scope @append_end_scope
+  "]" @prepend_indent_end @prepend_antispace) @prepend_begin_scope @append_end_scope
 
 (aliased_regexp
-  "as" @prepend_space @append_space
-)
+  "as" @prepend_space @append_space)
 
 (parenthesized_regexp
   (#scope_id! "parenthesized_regexp")
   "(" @append_empty_scoped_softline @append_indent_start
-  ")" @prepend_empty_scoped_softline @prepend_indent_end
-) @prepend_begin_scope @append_end_scope @prepend_spaced_softline @append_spaced_softline
+  ")" @prepend_empty_scoped_softline @prepend_indent_end) @prepend_begin_scope @append_end_scope @prepend_spaced_softline @append_spaced_softline
 
 (
   (#scope_id! "regexp_alternative")
-  (regexp_alternative) @prepend_begin_scope @append_end_scope
-)
+  (regexp_alternative) @prepend_begin_scope @append_end_scope)
 
 (regexp_alternative
   (#scope_id! "regexp_alternative")
-  "|" @prepend_spaced_scoped_softline @append_space
-)
+  "|" @prepend_spaced_scoped_softline @append_space)
 
 (regexp_concatenation
   (_) @append_spaced_softline
   ; Prevent appending to the last child
   (_)
-  .
-)
+  .)
 
 ; Lexer related rules
 (lexer_definition
-  ["rule" "and"] @allow_blank_line_before @append_space @prepend_input_softline
-)
+  ["rule" "and"] @allow_blank_line_before @append_space @prepend_input_softline)
 
 (lexer_entry
   (#scope_id! "lexer_entry")
   "=" @prepend_space @append_space
-  ["parse" "shortest"] @append_spaced_scoped_softline @append_indent_start
-) @prepend_begin_scope @append_end_scope
+  ["parse" "shortest"] @append_spaced_scoped_softline @append_indent_start) @prepend_begin_scope @append_end_scope
 
 (lexer_entry
-  (lexer_argument) @prepend_space @append_space
-)
+  (lexer_argument) @prepend_space @append_space)
 
 (lexer_entry
   (#scope_id! "lexer_entry")
@@ -97,11 +86,9 @@
 (lexer_entry
   ; End indentation after the last child node
   (_) @append_indent_end
-  .
-)
+  .)
 
 (lexer_case
   ; The anonymous child of the lexer_case is the regexp
   (_) @prepend_space @append_space
-  (action) @prepend_space @prepend_indent_start @append_indent_end
-)
+  (action) @prepend_space @prepend_indent_start @append_indent_end)

--- a/topiary-queries/queries/openscad.scm
+++ b/topiary-queries/queries/openscad.scm
@@ -4,8 +4,7 @@
 [
   (block_comment)
   (line_comment)
-  (string)
-] @leaf
+  (string)] @leaf
 
 ; Allow blank line before
 [
@@ -24,8 +23,7 @@
   (function_item)
   (module_item)
   (expression)
-  (var_declaration)
-] @allow_blank_line_before
+  (var_declaration)] @allow_blank_line_before
 
 ; Keywords
 
@@ -57,8 +55,7 @@
   "?"
   ":"
   (parenthesized_expression)
-  (assignments)
-] @prepend_space @append_space
+  (assignments)] @prepend_space @append_space
 
 ; Colon should have whitespace trimmed in a range delimiter
 (range ":" @prepend_antispace @append_antispace)
@@ -68,8 +65,7 @@
 ; always ends with a line break.
 [
   (block_comment)
-  (line_comment)
-] @prepend_input_softline
+  (line_comment)] @prepend_input_softline
 
 ; Append line breaks. If there is a comment following, we don't add anything,
 ; because the input softlines and spaces above will already have sorted out the
@@ -87,15 +83,12 @@
     (union_block)
     (use_statement)
     (include_statement)
-    (assert_statement)
-  ] @append_spaced_softline
+    (assert_statement)] @append_spaced_softline
   .
   [
     "else"
     (block_comment)
-    (line_comment)
-  ]* @do_nothing
-)
+    (line_comment)]* @do_nothing)
 
 (line_comment) @append_hardline
 
@@ -105,15 +98,13 @@
 (
   (block_comment)
   .
-  _ @prepend_input_softline
-)
+  _ @prepend_input_softline)
 
 ; Append softlines, unless followed by comments.
 ; When binding multiple values in a let block, allow new lines between the bindings.
 (list
   "[" @append_indent_start @append_empty_softline @append_antispace
-  "]" @prepend_indent_end @prepend_empty_softline @prepend_antispace
-)
+  "]" @prepend_indent_end @prepend_empty_softline @prepend_antispace)
 ; to avoid having a list that directly follows a let_expression look visually unindented,
 ; add another level of indentation:
 ; let (
@@ -127,14 +118,11 @@
 (let_expression
   (list
     "[" @append_indent_start
-    "]" @prepend_indent_end
-  )
-)
+    "]" @prepend_indent_end))
 
 (range
   "[" @append_antispace
-  "]" @prepend_antispace
-)
+  "]" @prepend_antispace)
 (list "," @append_spaced_softline . [(block_comment) (line_comment)]* @do_nothing)
 (assignments "," @append_spaced_softline . [(block_comment) (line_comment)]* @do_nothing)
 (parameters "," @append_spaced_softline . [(block_comment) (line_comment)]* @do_nothing)
@@ -159,8 +147,7 @@
   .
   "=" @append_spaced_softline @append_indent_start
   (expression)
-  ";" @prepend_indent_end
-)
+  ";" @prepend_indent_end)
 
 ; ===
 ; function literals
@@ -182,9 +169,7 @@
     (assign_block)
     (transform_chain)
     (include_statement)
-    (assert_statement)
-  ] @prepend_indent_start @append_indent_end
-)
+    (assert_statement)] @prepend_indent_start @append_indent_end)
 
 ; module calls in a transformation chain will follow each other
 ; sometimes staying on the same line and sometimes having a linebreak,
@@ -193,8 +178,7 @@
 (transform_chain
   (modifier)*
   (module_call) @append_indent_start
-  (transform_chain) @append_indent_end
-)
+  (transform_chain) @append_indent_end)
 
 ; ================================================================================
 ; blocks/expressions/statements
@@ -214,14 +198,12 @@
   .
   ")"
   .
-  (#multi_line_only!)
-)
+  (#multi_line_only!))
 (assignments
   .
   "(" @append_empty_softline @append_indent_start
   ")" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 (assignments "," @delete . ")" . (#single_line_only!))
 (assignments "," @append_spaced_softline)
 
@@ -231,8 +213,7 @@
   .
   "(" @append_empty_softline @append_indent_start @append_antispace
   ")" @prepend_indent_end @prepend_empty_softline @prepend_antispace
-  .
-)
+  .)
 (arguments
   (#delimiter! ",")
   (_) @append_delimiter
@@ -243,8 +224,7 @@
   .
   ")"
   .
-  (#multi_line_only!)
-)
+  (#multi_line_only!))
 
 (parameters "," @append_input_softline)
 (parameters "," @delete . ")" . (#single_line_only!))
@@ -252,15 +232,13 @@
   .
   "(" @append_empty_softline @append_indent_start
   ")" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 
 (parenthesized_expression
   .
   "(" @append_empty_softline @append_indent_start
   ")" @prepend_indent_end @prepend_empty_softline
-  .
-)
+  .)
 (list "," @delete . "]" . (#single_line_only!))
 (list
   (#delimiter! ",")
@@ -270,8 +248,7 @@
   .
   "]"
   .
-  (#multi_line_only!)
-)
+  (#multi_line_only!))
 
 ; differentiate parameter definitions from parameter invocation,
 ; module/function definitions have param separation while
@@ -279,17 +256,14 @@
 ; and provides visual distinction between definitions and calls
 (arguments
   (assignment
-    "=" @append_antispace @prepend_antispace
-  )
-)
+    "=" @append_antispace @prepend_antispace))
 
 (union_block
   .
   "{" @append_spaced_softline @append_indent_start @prepend_space
   _
   "}" @prepend_spaced_softline @prepend_indent_end
-  .
-)
+  .)
 
 ; everything except `union_block` after a for/if/else statement should be a spaced_softline
 (if_block
@@ -303,9 +277,7 @@
     (assign_block)
     (transform_chain)
     (include_statement)
-    (assert_statement)
-  ] @append_indent_end @append_spaced_softline
-)
+    (assert_statement)] @append_indent_end @append_spaced_softline)
 (
   "else" @append_spaced_softline @append_indent_start
   .
@@ -316,18 +288,14 @@
     (assign_block)
     (transform_chain)
     (include_statement)
-    (assert_statement)
-  ] @append_indent_end
-) @prepend_spaced_softline
+    (assert_statement)] @append_indent_end) @prepend_spaced_softline
 
 ; scope is triggered by the presence of a (union_block) consequce on the intersection_for_block;
 ; and extends to the "else if" and "else" portions
 (
   "else"? @do_nothing
   (if_block
-    (#scope_id! "if_union")
-  ) @prepend_begin_scope @append_end_scope
-)
+    (#scope_id! "if_union")) @prepend_begin_scope @append_end_scope)
 
 (if_block
   (#scope_id! "if_union")
@@ -335,9 +303,7 @@
     .
     "{" @append_spaced_scoped_softline
     "}" @prepend_spaced_scoped_softline
-    .
-  )
-)
+    .))
 
 (for_block
   (assignments) @append_spaced_softline @append_indent_start
@@ -350,9 +316,7 @@
     (assign_block)
     (transform_chain)
     (include_statement)
-    (assert_statement)
-  ] @append_indent_end @append_spaced_softline
-)
+    (assert_statement)] @append_indent_end @append_spaced_softline)
 ; modifiers
 (modifier) @append_antispace
 
@@ -363,12 +327,9 @@
     value: [
       (assert_expression)
       (echo_expression)
-      (ternary_expression)
-    ] @prepend_indent_start
-  )
+      (ternary_expression)] @prepend_indent_start)
   ";" @prepend_indent_end
-  .
-)
+  .)
 
 (assert_expression expression: (_) @prepend_spaced_softline)
 (assert_statement statement: (_) @prepend_spaced_softline)
@@ -376,10 +337,8 @@
 
 ; ternary expressions
 (ternary_expression
-  ":" @prepend_spaced_softline
-)
+  ":" @prepend_spaced_softline)
 ; Prettier style ternaries https://prettier.io/blog/2023/11/13/curious-ternaries
 (ternary_expression
   "?" @append_input_softline @append_indent_start
-  ":" @prepend_indent_end
-)
+  ":" @prepend_indent_end)

--- a/topiary-queries/queries/rust.scm
+++ b/topiary-queries/queries/rust.scm
@@ -4,8 +4,7 @@
 [
   (block_comment)
   (line_comment)
-  (string_literal)
-] @leaf
+  (string_literal)] @leaf
 
 ; Allow blank line before
 [
@@ -22,8 +21,7 @@
   (mod_item)
   (struct_item)
   (type_item)
-  (use_declaration)
-] @allow_blank_line_before
+  (use_declaration)] @allow_blank_line_before
 
 ; Surround spaces
 [
@@ -46,29 +44,25 @@
   "=="
   "-"
   "+"
-  "->"
-] @prepend_space @append_space
+  "->"] @prepend_space @append_space
 
 ; Append spaces
 [
-  ":"
-] @append_space
+  ":"] @append_space
 
 ; Input softlines before and after all comments. This means that the input
 ; decides if a comment should have line breaks before or after. A line comment
 ; always ends with a line break.
 [
   (block_comment)
-  (line_comment)
-] @prepend_input_softline
+  (line_comment)] @prepend_input_softline
 
 ; Input softline after block comments unless followed by comma or semicolon, as
 ; they are always put directly after.
 (
   (block_comment) @append_input_softline
   .
-  ["," ";"]* @do_nothing
-)
+  ["," ";"]* @do_nothing)
 
 ; Append line breaks. If there is a comment following, we don't add anything,
 ; because the input softlines and spaces above will already have sorted out the
@@ -85,14 +79,11 @@
     (mod_item)
     (struct_item)
     (type_item)
-    (use_declaration)
-  ] @append_spaced_softline
+    (use_declaration)] @append_spaced_softline
   .
   [
     (block_comment)
-    (line_comment)
-  ]* @do_nothing
-)
+    (line_comment)]* @do_nothing)
 
 (line_comment) @append_hardline
 
@@ -102,28 +93,23 @@
 (
   (block_comment)
   .
-  _ @prepend_input_softline
-)
+  _ @prepend_input_softline)
 
 ; Append softlines, unless followed by comments.
 (
   [
     ","
-    ";"
-  ] @append_spaced_softline
+    ";"] @append_spaced_softline
   .
-  [(block_comment) (line_comment)]* @do_nothing
-)
+  [(block_comment) (line_comment)]* @do_nothing)
 
 ; Prepend softlines before dots
 (_
-  "." @prepend_empty_softline
-)
+  "." @prepend_empty_softline)
 
 ; enum
 (enum_item
-  (type_identifier) @prepend_space
-)
+  (type_identifier) @prepend_space)
 
 ; This patterns is duplicated for all nodes that can contain curly braces.
 ; Hoping to be able to generalise them like this:
@@ -136,72 +122,60 @@
 
 (enum_variant_list
   .
-  "{" @prepend_space
-)
+  "{" @prepend_space)
 
 (enum_variant_list
   .
   "{" @append_spaced_softline @append_indent_start
   _
   "}" @prepend_spaced_softline @prepend_indent_end
-  .
-)
+  .)
 
 ; field
 (field_declaration_list
   .
-  "{" @prepend_space
-)
+  "{" @prepend_space)
 
 (field_declaration_list
   .
   "{" @append_spaced_softline @append_indent_start
   _
   "}" @prepend_spaced_softline @prepend_indent_end
-  .
-)
+  .)
 
 ; fn
 (function_item
-  (identifier) @prepend_space
-)
+  (identifier) @prepend_space)
 
 (block
   .
-  "{" @prepend_space
-)
+  "{" @prepend_space)
 
 (block
   .
   "{" @append_spaced_softline @append_indent_start
   "}" @prepend_spaced_softline @prepend_indent_end
-  .
-)
+  .)
 
 ; impl
 (impl_item
-  (type_identifier) @prepend_space
-)
+  (type_identifier) @prepend_space)
 
 (declaration_list
   .
-  "{" @prepend_space
-)
+  "{" @prepend_space)
 
 (declaration_list
   .
   "{" @append_empty_softline @append_indent_start
   "}" @prepend_empty_softline @prepend_indent_end
-  .
-)
+  .)
 
 ; PhantomData<&'a ()>
 (_
   (lifetime) @append_space
-  [(array_type) (generic_type) (primitive_type) (unit_type)]
-)
+  [(array_type) (generic_type) (primitive_type) (unit_type)])
 
 ; Never put a space before a comma
 (
-  "," @prepend_antispace
-)
+  "," @prepend_antispace)

--- a/topiary-queries/queries/sdml.scm
+++ b/topiary-queries/queries/sdml.scm
@@ -12,8 +12,7 @@
   base: (iri)? @append_space
   "version"? @append_space
   version_info: (quoted_string)? @append_space
-  version_uri: (iri)? @append_space
-)
+  version_uri: (iri)? @append_space)
 
 (module_body) @prepend_space
 
@@ -27,13 +26,11 @@
 ;; Imports
 ;; -----------------------------------------------------------------------------
 (import_statement
-  "import" @append_space
-) @allow_blank_line_before @append_hardline
+  "import" @append_space) @allow_blank_line_before @append_hardline
 
 (import_statement
   "[" @append_indent_start @append_spaced_softline
-  "]" @prepend_indent_end
-)
+  "]" @prepend_indent_end)
 
 [(member_import) (module_import)] @append_spaced_softline
 
@@ -66,8 +63,7 @@
 (formal_constraint "end" @prepend_hardline)
 
 (constraint_environment
-  "with" @append_indent_start @append_hardline
-) @append_indent_end
+  "with" @append_indent_start @append_hardline) @append_indent_end
 
 (equation "=" @prepend_space @append_space)
 
@@ -77,9 +73,7 @@
     (op_less_than)
     (op_greater_than)
     (op_less_than_or_equal)
-    (op_greater_than_or_equal)
-  ] @prepend_space @append_space
-)
+    (op_greater_than_or_equal)] @prepend_space @append_space)
 
 (binary_boolean_sentence
   [
@@ -87,9 +81,7 @@
     (logical_op_disjunction)
     (logical_op_exclusive_disjunction)
     (logical_op_implication)
-    (logical_op_biconditional)
-  ] @prepend_space @append_space
-)
+    (logical_op_biconditional)] @prepend_space @append_space)
 
 (logical_op_negation) @append_space
 
@@ -98,60 +90,48 @@
 (quantified_variable_binding
   [
     (logical_quantifier_universal)
-    (logical_quantifier_existential)
-  ] @append_space
-)
+    (logical_quantifier_existential)] @append_space)
 
 (quantified_variable (set_op_membership) @prepend_space @append_space)
 
 (actual_arguments
   [
     ((term) . ")" @do_nothing)
-    ((term) . (term) @prepend_space)
-  ]
-)
+    ((term) . (term) @prepend_space)])
 
 (function_def
 ) @allow_blank_line_before @append_hardline @prepend_spaced_softline
 (function_signature
   "def" @append_space
-  name: (identifier) @append_space
-)
+  name: (identifier) @append_space)
 
 (function_signature
   "(" @append_indent_start
   [
     ((function_parameter) . ")" @do_nothing)
-    ((function_parameter) . (function_parameter) @prepend_space)
-  ]
-  ")" @prepend_indent_end
-)
+    ((function_parameter) . (function_parameter) @prepend_space)]
+  ")" @prepend_indent_end)
 
 (function_signature
   ["->" "→"] @prepend_space @append_space
-  (function_type_reference) @append_space
-)
+  (function_type_reference) @append_space)
 
 (function_parameter
   name: (identifier) @append_space
-  ["->" "→"] @append_space
-)
+  ["->" "→"] @append_space)
 (function_body
-  (function_op_by_definition) @prepend_space @append_space
-) @prepend_hardline @prepend_indent_start @append_indent_end
+  (function_op_by_definition) @prepend_space @append_space) @prepend_hardline @prepend_indent_start @append_indent_end
 
 (function_cardinality_expression
   "{" @append_antispace
   ordering: (_)? @append_space
   uniqueness: (_)? @append_space
-  "}" @prepend_antispace
-) @append_space
+  "}" @prepend_antispace) @append_space
 
 (sequence_builder
   "{" @append_spaced_softline @append_indent_start
   (set_op_builder) @prepend_spaced_softline @prepend_indent_end @append_indent_start
-  "}" @prepend_indent_end @prepend_spaced_softline
-)
+  "}" @prepend_indent_end @prepend_spaced_softline)
 
 (sequence_builder (variable) @append_space)
 
@@ -167,8 +147,7 @@
 ;; -----------------------------------------------------------------------------
 (type_class_def
   "class" @append_space
-  name: (identifier) @append_space
-) @allow_blank_line_before
+  name: (identifier) @append_space) @allow_blank_line_before
 
 (method_def
 ) @allow_blank_line_before @append_hardline
@@ -176,8 +155,7 @@
 (method_def
   (function_body)
   .
-  (annotation_only_body) @prepend_space
-)
+  (annotation_only_body) @prepend_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> Datatype
@@ -187,8 +165,7 @@
   name: (identifier) @append_space
   ["<-" "←"] @append_space
   opaque: (opaque)? @append_space
-  base: (_) @append_space
-) @allow_blank_line_before
+  base: (_) @append_space) @allow_blank_line_before
 
 ;;(data_type_boolean_base
 ;; (boolean_connective) @append_space
@@ -199,8 +176,7 @@
 
 (datatype_def_restriction
   "{" @append_indent_start @append_hardline
-  "}" @prepend_indent_end
-)
+  "}" @prepend_indent_end)
 
 (length_restriction_facet "=" @prepend_space @append_space)
 (digit_restriction_facet "=" @prepend_space @append_space)
@@ -212,8 +188,7 @@
 (pattern_restriction_facet
   "[" @append_indent_start @append_spaced_softline
   (quoted_string)* @append_spaced_softline
-  "]" @prepend_indent_end
-)
+  "]" @prepend_indent_end)
 
 (datatype_def_restriction
   [
@@ -221,23 +196,19 @@
     (digit_restriction_facet)
     (value_restriction_facet)
     (tz_restriction_facet)
-    (pattern_restriction_facet)
-  ] @append_hardline
-)
+    (pattern_restriction_facet)] @append_hardline)
 
 (data_type_def
   (datatype_def_restriction)
   .
-  (annotation_only_body) @prepend_space
-)
+  (annotation_only_body) @prepend_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> Dimension
 ;; -----------------------------------------------------------------------------
 (dimension_def
   "dimension" @append_space
-  name: (identifier) @append_space
-)
+  name: (identifier) @append_space)
 
 (source_entity
   "source" @append_space
@@ -247,49 +218,41 @@
     (
       "[" @append_indent_start @append_spaced_softline
       (identifier)* @append_spaced_softline
-      "]" @prepend_indent_end
-    )?
-  )?
-) @append_hardline @allow_blank_line_before
+      "]" @prepend_indent_end)?)?) @append_hardline @allow_blank_line_before
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> Entity
 ;; -----------------------------------------------------------------------------
 (entity_def
   "entity" @append_space
-  name: (identifier) @append_space
-)
+  name: (identifier) @append_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> Enum
 ;; -----------------------------------------------------------------------------
 (enum_def
   "enum" @append_space
-  name: (identifier) @append_space
-)
+  name: (identifier) @append_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> Event
 ;; -----------------------------------------------------------------------------
 (event_def
   "event" @append_space
-  name: (identifier) @append_space
-)
+  name: (identifier) @append_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> Property [[ nothing required, uses member_def rules ]]
 ;; -----------------------------------------------------------------------------
 (property_def
-  "property" @append_space
-)
+  "property" @append_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> RDF
 ;; -----------------------------------------------------------------------------
 (rdf_def
   "rdf" @append_space
-  name: (identifier) @append_space
-)
+  name: (identifier) @append_space)
 
 (rdf_types
   "type" @append_space
@@ -297,27 +260,22 @@
     (
       "[" @append_indent_start @append_spaced_softline
       (identifier_reference)* @append_spaced_softline
-      "]" @prepend_indent_end @append_space
-    )
-    (identifier_reference) @append_space
-  ]
-)
+      "]" @prepend_indent_end @append_space)
+    (identifier_reference) @append_space])
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> Structure
 ;; -----------------------------------------------------------------------------
 (structure_def
   "structure" @append_space
-  name: (identifier) @append_space
-)
+  name: (identifier) @append_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Definitions >> Union
 ;; -----------------------------------------------------------------------------
 (union_def
   "union" @append_space
-  name: (identifier) @append_space
-)
+  name: (identifier) @append_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Members
@@ -330,15 +288,13 @@
   name: (identifier) @append_space
   ["->" "→"] @append_space
   cardinality: (cardinality_expression)? @append_space
-  target: (type_reference) @append_space
-)
+  target: (type_reference) @append_space)
 
 (cardinality_expression
   "{" @append_antispace
   ordering: (_)? @append_space
   uniqueness: (_)? @append_space
-  "}" @prepend_antispace
-)
+  "}" @prepend_antispace)
 
 (property_ref "ref" @append_space)
 
@@ -346,14 +302,12 @@
 ;; Variants
 ;; -----------------------------------------------------------------------------
 (value_variant
-  body: (annotation_only_body)? @prepend_space
-) @append_hardline @allow_blank_line_before
+  body: (annotation_only_body)? @prepend_space) @append_hardline @allow_blank_line_before
 
 (type_variant
   "as"? @prepend_space
   rename: (identifier)? @prepend_space
-  body: (annotation_only_body)? @prepend_space
-) @append_hardline @allow_blank_line_before
+  body: (annotation_only_body)? @prepend_space) @append_hardline @allow_blank_line_before
 
 ;; -----------------------------------------------------------------------------
 ;; Values
@@ -366,8 +320,7 @@
   (decimal)
   (double)
   (string)
-  (iri)
-] @leaf
+  (iri)] @leaf
 
 (binary "#[" @append_space (hex_byte)* @append_space)
 
@@ -376,12 +329,10 @@
     (sequence_ordering)? @append_space
     .
     (sequence_uniqueness)
-    "}" @append_space
-  )?
+    "}" @append_space)?
   "[" @append_indent_start @append_spaced_softline
   element: (_)* @append_spaced_softline
-  "]" @prepend_indent_end
-)
+  "]" @prepend_indent_end)
 
 (sequence_of_values
 )
@@ -391,28 +342,22 @@
     (sequence_ordering)? @append_space
     .
     (sequence_uniqueness)
-    "}" @append_space
-  )?
+    "}" @append_space)?
   (
     "[" @append_indent_start @append_spaced_softline
     element: (_)* @append_spaced_softline
-    "]" @prepend_indent_end
-  )
-)
+    "]" @prepend_indent_end))
 
 (value_constructor
   "(" @append_antispace
-  ")" @prepend_antispace
-)
+  ")" @prepend_antispace)
 
 (mapping_value
-  ["->" "→"] @prepend_space @append_space
-)
+  ["->" "→"] @prepend_space @append_space)
 
 ;; -----------------------------------------------------------------------------
 ;; Misc
 ;; -----------------------------------------------------------------------------
 
 (mapping_type
-  ["->" "→"] @prepend_space @append_space
-)
+  ["->" "→"] @prepend_space @append_space)

--- a/topiary-queries/queries/toml.scm
+++ b/topiary-queries/queries/toml.scm
@@ -3,52 +3,43 @@
 ; tool of this.
 [
   (string)
-  (quoted_key)
-] @leaf
+  (quoted_key)] @leaf
 
 ; Allow blank line before
 [
   (comment)
   (table)
   (table_array_element)
-  (pair)
-] @allow_blank_line_before
+  (pair)] @allow_blank_line_before
 
 ; Append line breaks
 [
-  (comment)
-] @append_hardline
+  (comment)] @append_hardline
 
 (document
-  (pair) @append_hardline
-)
+  (pair) @append_hardline)
 
 (table
-  (pair) @append_hardline
-)
+  (pair) @append_hardline)
 
 (table_array_element
-  (pair) @append_hardline
-)
+  (pair) @append_hardline)
 
 (table
   [(bare_key) (quoted_key) (dotted_key)]
   .
-  "]" @append_hardline
-)
+  "]" @append_hardline)
 
 (table_array_element
   [(bare_key) (quoted_key) (dotted_key)]
   .
-  "]]" @append_hardline
-)
+  "]]" @append_hardline)
 
 ; Surround spaces
 [
   "="
   "{"
-  "}"
-] @prepend_space @append_space
+  "}"] @prepend_space @append_space
 
 ; Input softlines before all comments. This means that the input decides if a
 ; comment should have line breaks in front of it.
@@ -61,29 +52,23 @@
   .
   [
     (comment)
-    "]"
-  ]? @do_nothing
-)
+    "]"]? @do_nothing)
 
 ; remove trailing comma from last element of single line array
 (array
   ("," @delete . "]")
-  (#single_line_only!)
-)
+  (#single_line_only!))
 
 ; add trailing comma if absent to last string of multiline array
 (array
   (((string) @append_delimiter) . ","* @do_nothing . (comment)? . "]")
   (#delimiter! ",")
-  (#multi_line_only!)
-)
+  (#multi_line_only!))
 
 ; Indent arrays. They will only be indented inmulti-line blocks.
 
 (array
-  "[" @append_empty_softline @append_indent_start
-)
+  "[" @append_empty_softline @append_indent_start)
 
 (array
-  "]" @prepend_empty_softline @prepend_indent_end
-)
+  "]" @prepend_empty_softline @prepend_indent_end)

--- a/topiary-queries/queries/tree_sitter_query.scm
+++ b/topiary-queries/queries/tree_sitter_query.scm
@@ -4,15 +4,13 @@
 [
   (capture)
   (identifier)
-  (string)
-] @leaf
+  (string)] @leaf
 
 (comment) @prepend_input_softline @append_hardline @allow_blank_line_before
 
 ; Elements at top-level must be alone on their line. Blank lines are allowed
 (program
-  _ @allow_blank_line_before @prepend_hardline
-)
+  _ @allow_blank_line_before @prepend_hardline)
 
 (predicate) @allow_blank_line_before
 
@@ -29,8 +27,7 @@
     ":"
     "."
     ")"
-    "]"
-  ] @append_space
+    "]"] @append_space
   .
   [")" "]" ":"]? @do_nothing
   .
@@ -44,13 +41,10 @@
     "."
     "("
     "["
-    "_"
-  ]
-)
+    "_"])
 
 (anonymous_node
-  (capture) @prepend_space
-)
+  (capture) @prepend_space)
 
 ; The grammar always includes a (parameters) child node under
 ; (predicate), even when there are none. Topiary will deal with the
@@ -60,42 +54,32 @@
   (parameters
     [(identifier) (capture)] @append_spaced_softline @append_indent_start
     .
-    (string)
-  ) @append_indent_end
-)
+    (string)) @append_indent_end)
 
 (predicate
   (parameters
-    (string) @append_empty_softline
-  )
-)
+    (string) @append_empty_softline))
 
 (predicate
   (parameters
-    (_) @prepend_space
-  )
-)
+    (_) @prepend_space))
 
 ; Line breaks and indentation in multi-line lists and nodes
 (list
   "[" @append_indent_start @append_empty_softline
-  "]" @prepend_indent_end @prepend_empty_softline
-)
+  "]" @prepend_indent_end)
 
 (grouping
   "(" @append_indent_start @append_empty_softline
-  ")" @prepend_indent_end @prepend_empty_softline
-)
+  ")" @prepend_indent_end)
 
 (named_node
   "("
   .
   [
     (identifier)
-    "_"
-  ] @append_indent_start @append_empty_softline
-  ")" @prepend_indent_end @prepend_empty_softline
-)
+    "_"] @append_indent_start @append_empty_softline
+  ")" @prepend_indent_end)
 
 (
   [
@@ -105,8 +89,7 @@
     (list)
     (named_node)
     (predicate)
-    "."
-  ] @append_spaced_softline
+    "."] @append_spaced_softline
   .
   [
     (anonymous_node)
@@ -115,6 +98,4 @@
     (list)
     (named_node)
     (predicate)
-    "."
-  ]
-)
+    "."])


### PR DESCRIPTION
# Description

This PR attempts to format Tree-sitter queries Lisp-style, so we can have a look at what It would look like.

Relates to #828 

Checklist before merging, wherever relevant:

- [ ] `CHANGELOG.md` updated
- [ ] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
