### PR TITLE
Coverage: Account for empty query file

### DIFF
--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -301,7 +301,11 @@ pub fn coverage(
     let res = tree_sitter::check_query_coverage(&content, &language.query, &language.grammar)?;
 
     let queries_string = if res.missing_patterns.is_empty() {
-        "All queries are matched".into()
+        if res.cover_percentage == 0.0 {
+            "No queries found".into()
+        } else {
+            "All queries are matched".into()
+        }
     } else {
         format!(
             "Unmatched queries:\n{}",

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -540,6 +540,16 @@ pub fn check_query_coverage(
     let pattern_count = original_query.query.pattern_count();
     let query_content = &original_query.query_content;
 
+    // If there are no queries at all (e.g., when debugging) return early
+    // rather than dividing by zero
+    if pattern_count == 0 {
+        let cover_percentage = 0.0;
+        return Ok(CoverageData {
+            cover_percentage,
+            missing_patterns,
+        });
+    }
+
     // This particular test avoids a SIGSEGV error that occurs when trying
     // to count the matches of an empty query (see #481)
     if pattern_count == 1 {


### PR DESCRIPTION
# Account for empty query file in coverage

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #952 

## Description

When there are zero queries, the coverage output now reports 0% coverage and states that there were no queries found.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
