### PR TITLE
Renovate: Ease off a bit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,10 @@
   prConcurrentLimit: 1,
   prCreation: "not-pending",
 
+  // This is probably the best we can do for now!
+  dependencyDashboardHeader: "This issue lists Renovate updates to detected dependencies. Use these as a signal to perform a manual update; especially in the cases where Renovate fails.",
+  prHeader: "This PR is meant as a signal to perform a manual update on dependencies; especially in the case where Renovate fails.",
+
   // Only create PRs for minor and major updates; ignore patches
   bumpVersion: "minor",
 


### PR DESCRIPTION
# Renovate: Ease off a bit

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
References #924 

## Description

Our original Renovate configuration was a bit aggressive with updates. This new configuration:

- Only notifies minor/major dependency updates (not patches)
- PRs are only created after the checks have run (but not necessarily succeeded)
- Adds a note on the Dependency Dashboard (#925) and the generated PRs to nudge us to make manual updates, rather than relying on Renovate. (Of course, if the checks pass, then it's fine to wave it through.)

> [!NOTE]
> Nix support, enabled in #931, does not appear to work.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
