### PR TITLE
Fixed unhandled trailing comment in multiline list for OpenSCAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ This name should be decided amongst the team before the release.
 - [#869](https://github.com/tweag/topiary/pull/869) Disable parallel grammar building on Windows
 - [#908](https://github.com/tweag/topiary/pull/908) [#907](https://github.com/tweag/topiary/pull/907) [#939](https://github.com/tweag/topiary/pull/939) [#955](https://github.com/tweag/topiary/pull/955) [#964](https://github.com/tweag/topiary/pull/964) [#967](https://github.com/tweag/topiary/pull/967) Various OCaml issues and improvements
 - [#953](https://github.com/tweag/topiary/pull/953) Coverage output when there are zero queries
+- [#867](https://github.com/tweag/topiary/pull/867) Fixed [#969](https://github.com/tweag/topiary/issues/969) unhandled trailing comment in multiline list for OpenSCAD, thanks to @mkatychev
 
 <!-- ### Security -->
 <!-- - <Vulnerabilities> -->

--- a/topiary-cli/tests/samples/expected/openscad.scad
+++ b/topiary-cli/tests/samples/expected/openscad.scad
@@ -172,7 +172,7 @@ my_fn = fn1(
   [
     1,
     2,
-    3,
+    3, // comment
   ],
   true,
 );

--- a/topiary-cli/tests/samples/input/openscad.scad
+++ b/topiary-cli/tests/samples/input/openscad.scad
@@ -140,7 +140,7 @@ echo(function(y) y ? "first" : "second");
   my_fn = fn1([
       1,
       2,
-      3,
+      3, // comment
     ],
     true
   );

--- a/topiary-queries/queries/openscad.scm
+++ b/topiary-queries/queries/openscad.scm
@@ -268,6 +268,8 @@
   .
   ","? @do_nothing
   .
+  (line_comment)*
+  .
   "]"
   .
   (#multi_line_only!)


### PR DESCRIPTION
# Fixed unhandled trailing comment in multiline list for OpenSCAD

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves https://github.com/tweag/topiary/issues/969

## Description

An extraneous trailing comma was previously added to a list if the trailing comma of a list was followed by a comment:
```scad
foo = [
  1, // cmt
];
```

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [ ] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
