### PR TITLE
feat(config): add support for prefetching a single language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This name should be decided amongst the team before the release.
 - [#884](https://github.com/tweag/topiary/pull/884) The Topiary Book
 - [#933](https://github.com/tweag/topiary/pull/933) Added support for WIT, thanks to @mkatychev
 - [#918](https://github.com/tweag/topiary/pull/918) Language prefetching utilities for Nix
+- [#987](https://github.com/tweag/topiary/pull/987) Support for prefetching a single language, thanks to @ErinvanderVeen
 
 ### Changed
 <!-- - <Changes in existing functionality> -->

--- a/docs/book/src/cli/usage/index.md
+++ b/docs/book/src/cli/usage/index.md
@@ -15,7 +15,7 @@ Commands:
   format      Format inputs
   visualise   Visualise the input's Tree-sitter parse tree
   config      Print the current configuration
-  prefetch    Prefetch all languages in the configuration
+  prefetch    Prefetch languages in the configuration
   coverage    Checks how much of the tree-sitter query is used
   completion  Generate shell completion script
   help        Print this message or the help of the given subcommand(s)

--- a/docs/book/src/cli/usage/prefetch.md
+++ b/docs/book/src/cli/usage/prefetch.md
@@ -7,9 +7,12 @@ time, the grammars can be prefetched and compiled.
 <!-- DO NOT REMOVE THE "usage:{start,end}" COMMENTS -->
 <!-- usage:start -->
 ```
-Prefetch all languages in the configuration
+Prefetch languages in the configuration
 
-Usage: topiary prefetch [OPTIONS]
+Usage: topiary prefetch [OPTIONS] [LANGUAGE]
+
+Arguments:
+  [LANGUAGE]  Fetch specified language (if not provided, all languages are prefetched)
 
 Options:
   -f, --force                          Re-fetch existing grammars if they already exist

--- a/topiary-cli/src/cli.rs
+++ b/topiary-cli/src/cli.rs
@@ -152,12 +152,15 @@ pub enum Commands {
     #[command(alias = "cfg", display_order = 3)]
     Config,
 
-    /// Prefetch all languages in the configuration
+    /// Prefetch languages in the configuration
     #[command(display_order = 4)]
     Prefetch {
         /// Re-fetch existing grammars if they already exist
         #[arg(short, long)]
         force: bool,
+
+        /// Fetch specified language (if not provided, all languages are prefetched)
+        language: Option<String>,
     },
 
     /// Checks how much of the tree-sitter query is used

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -158,9 +158,10 @@ async fn run() -> CLIResult<()> {
             println!("{nickel_config}")
         }
 
-        Commands::Prefetch { force } => {
-            config.prefetch_languages(force)?;
-        }
+        Commands::Prefetch { force, language } => match language {
+            Some(l) => config.prefetch_language(l, force)?,
+            _ => config.prefetch_languages(force)?,
+        },
 
         Commands::Coverage { input } => {
             // We are guaranteed (by clap) to have exactly one input, so it's safe to unwrap

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -141,6 +141,24 @@ impl Configuration {
         }
     }
 
+    /// Prefetches and builds the desired language.
+    /// This can be beneficial to speed up future startup time.
+    ///
+    /// # Errors
+    ///
+    /// If the language could not be found or the Grammar could not be build, a `TopiaryConfigError` is returned.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn prefetch_language<T>(&self, language: T, force: bool) -> TopiaryConfigResult<()>
+    where
+        T: AsRef<str> + fmt::Display,
+    {
+        let tmp_dir = tempdir()?;
+        let tmp_dir_path = tmp_dir.path().to_owned();
+        let l = self.get_language(language)?;
+        Configuration::fetch_language(l, force, &tmp_dir_path)?;
+        Ok(())
+    }
+
     /// Prefetches and builds all known languages.
     /// This can be beneficial to speed up future startup time.
     ///


### PR DESCRIPTION
# Prefetching a single language

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #895

## Description
Creates a simplified version of the `prefetch_languages` function that looks up a specific language and prefetches it. The tempdir creation can be abstracted, but I don't think it's worth it with it being only 2 lines of code.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
