### PR TITLE
fix(openscad): handle `transform_chain` in newline separation

### DIFF
--- a/topiary-cli/tests/samples/expected/openscad.scad
+++ b/topiary-cli/tests/samples/expected/openscad.scad
@@ -46,7 +46,8 @@ translate([1, 0, 0]) {
   difference() {
     translate([0, 1, 0])
       translate([1, 0, 0]) rotate([0, 90, 0])
-          cylinder(); cube();
+          cylinder();
+    cube();
   }
 }
 
@@ -157,6 +158,7 @@ translate(1) #!cube();
 rotate([90]) %translate()
     #cube();
 
+
 // ================================================================================
 // Assertions/Echoes
 // ================================================================================
@@ -242,3 +244,12 @@ let_each = [for (i = [0:1]) let (a = 90) each arc(angle=a)];
 let_for = [let (i = [0:1]) for (i = i) let (a = 90) each arc(angle=a)];
 let_if = [for (i = [0:1]) let (a = 360) if (is_def(isect)) isect];
 fn_list = [each function() 10];
+
+// ================================================================================
+// ISSUES
+// ================================================================================
+
+// https://github.com/Leathong/openscad-LSP/issues/48
+echo(bisector_angle_offset=bisector_angle_offset);
+prev_angle = atan2((prev - point).y, (prev - point).x);
+echo(prev_angle=prev_angle);

--- a/topiary-cli/tests/samples/input/openscad.scad
+++ b/topiary-cli/tests/samples/input/openscad.scad
@@ -206,3 +206,12 @@ let_for = [let (i=[0:1]) for(i = i) let(a=90) each arc(angle=a)];
 let_if = [for(i = [0:1]) let(a=360) if (is_def(isect)) isect];
 fn_list = [each function ()10];
 
+// ================================================================================
+// ISSUES
+// ================================================================================
+
+// https://github.com/Leathong/openscad-LSP/issues/48
+echo(bisector_angle_offset=bisector_angle_offset);
+prev_angle = atan2((prev - point).y, (prev - point).x);
+echo(prev_angle=prev_angle);
+

--- a/topiary-cli/tests/samples/input/openscad.scad
+++ b/topiary-cli/tests/samples/input/openscad.scad
@@ -214,4 +214,3 @@ fn_list = [each function ()10];
 echo(bisector_angle_offset=bisector_angle_offset);
 prev_angle = atan2((prev - point).y, (prev - point).x);
 echo(prev_angle=prev_angle);
-

--- a/topiary-queries/queries/openscad.scm
+++ b/topiary-queries/queries/openscad.scm
@@ -76,6 +76,7 @@
 ; formatting.
 (
   [
+   (transform_chain)
     (var_declaration)
     (function_item)
     (module_item)
@@ -99,6 +100,11 @@
 )
 
 (line_comment) @append_hardline
+(
+ ";" @append_hardline
+ [(line_comment) (block_comment)] @do_nothing
+)
+
 
 (block_comment) @multi_line_indent_all
 
@@ -144,6 +150,7 @@
 [
   ","
   ";"
+  "."
 ] @prepend_antispace
 
 ; Don't insert spaces between the operator and their expression operand


### PR DESCRIPTION
# [PR Name]

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves https://github.com/Leathong/openscad-LSP/issues/48
References #YYY
Depends on #ZZZ

## Description
* Transform chain was missing from line break list previously, now handled:
  https://github.com/tweag/topiary/blob/02c18835c69db33cd43da1f6069a66fd6c83b4fb/topiary-queries/queries/openscad.scm#L74-L100
* Object property periods (`foo.x`) now apply an antispace


[PR Description]

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
