### PR TITLE
Remove `@multi_line_indent_all` from OpenSCAD rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ This name should be decided amongst the team before the release.
 - [#953](https://github.com/tweag/topiary/pull/953) Coverage output when there are zero queries
 - [#974](https://github.com/tweag/topiary/pull/974) No longer remove trailing spaces after pretty-printing
 - [#867](https://github.com/tweag/topiary/pull/972) Fixed [#969](https://github.com/tweag/topiary/issues/969) unhandled trailing comment in multiline list for OpenSCAD, thanks to @mkatychev
+- [#999](https://github.com/tweag/topiary/pull/999) Fixed [#997](https://github.com/tweag/topiary/issues/997) erroneous spacing of block comments in OpenSCAD
 
 <!-- ### Security -->
 <!-- - <Vulnerabilities> -->

--- a/topiary-queries/queries/openscad.scm
+++ b/topiary-queries/queries/openscad.scm
@@ -100,8 +100,6 @@
 
 (line_comment) @append_hardline
 
-(block_comment) @multi_line_indent_all
-
 ; Allow line break after block comments
 (
   (block_comment)


### PR DESCRIPTION
# Remove `@multi_line_indent_all` from OpenSCAD rules

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #997
References #998

## Description

The `@multi_line_indent_all` query in the OpenSCAD formatting queries appears to be redundant and causing idempotency issues.

CC @mkatychev

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
