### PR TITLE
Remind committers to add regression tests when relevant

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,3 +35,10 @@ Checklist before merging, wherever relevant:
 
 - [ ] `CHANGELOG.md` updated
 - [ ] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
+<!----------------------------------------------------------------------
+If the PR solves a formatting issue for a supported language,
+or generally improves formatting, please make sure to include a
+regression test showcasing the fix/improvement to:
+`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
+----------------------------------------------------------------------->
+- [ ] Updated regression tests


### PR DESCRIPTION
## Description

This PR modifies the Github PR template to remind committers to add regression tests when they fix or improve Topiary's formatting capacities for a supported language.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- ~[ ] `CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
