### PR TITLE
Document tip for inserting blank lines between nodes

### DIFF
--- a/docs/book/src/reference/capture-names/vertical-spacing.md
+++ b/docs/book/src/reference/capture-names/vertical-spacing.md
@@ -294,6 +294,22 @@ prepended) to them.
 )
 ```
 
+> **Note**\
+> If you wish to insert empty lines -- that is, two line breaks --
+> between nodes, this can be emulated with [`@append_delimiter` /
+> `@prepend_delimiter`](insertion-and-deletion.md#append_delimiter--prepend_delimiter).
+> For example:
+>
+> ```scheme
+> (
+>   (block) @append_delimiter
+>   .
+>   (_)
+>
+>   (#delimiter! "\n\n")
+> )
+> ```
+
 ## `@append_empty_softline` / `@prepend_empty_softline`
 
 The matched nodes will have an empty softline appended (or,


### PR DESCRIPTION
# Document tip for inserting blank lines between nodes

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
References #993

## Description

Documented @nbacquey's tip to insert blank lines between nodes in the Topiary Book.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] ~Updated regression tests~
