### PR TITLE
Correct documentation of formatting query search paths

### DIFF
--- a/docs/book/src/cli/dialogue.md
+++ b/docs/book/src/cli/dialogue.md
@@ -3,15 +3,23 @@
 ## Environment variables
 
 Topiary needs to find [language query files](../getting-started/on-tree-sitter.md)
-(`*.scm`) to function properly. By default, Topiary looks for a
-`languages` directory in the current working directory.
+(`*.scm`) to function properly. By default, Topiary looks for these
+under the following search paths, from highest to lowest priority:
 
-This won't work if you are running Topiary from a directory other than
-its repository. In order to use Topiary without this restriction, **you
-must set the environment variable `TOPIARY_LANGUAGE_DIR` to point to the
-directory where Topiary's language query files are located**.
+<!-- This probably should change: see Issue #1003 -->
+1. Per the `TOPIARY_LANGUAGE_DIR` environment variable, as set at
+   runtime.
+2. A built-in value, which was set by the `TOPIARY_LANGUAGE_DIR`
+   environment variable at build time.
+3. `topiary-queries/queries` in the current working directory.
+4. `topiary-queries/queries` in the parent of the current directory.
 
-By default, you should set it to `<local path of the topiary
+That is to say, if you are running Topiary from a directory other than
+its repository, **you must set the environment variable
+`TOPIARY_LANGUAGE_DIR` to point to the directory where Topiary's
+language query files are located**.
+
+By default, you should set it to `<local path of the Topiary
 repository>/topiary-queries/queries`, for example:
 
 ```sh

--- a/docs/book/src/reference/capture-names/general.md
+++ b/docs/book/src/reference/capture-names/general.md
@@ -230,7 +230,7 @@ counter-intuitive. Consider, for instance, the following query:
 ```
 
 One might assume that this query only matches the final element in the
-list but this is not true. Since we did not explicitly march a parent
+list but this is not true. Since we did not explicitly match a parent
 node, the engine will match on every `list_entry`. After all, when
 looking only at the nodes in the query, the `list_entry` is indeed the
 last node.


### PR DESCRIPTION
# Correct documentation of formatting query search paths

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #1002
Also see #1003

## Description

Corrects the Topiary CLI documentation, in the Topiary Book, with the correct search path priority for formatting query files.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] ~Updated regression tests~