### PR TITLE
Expand blank line tip in Topiary Book

### DIFF
--- a/docs/book/src/reference/capture-names/vertical-spacing.md
+++ b/docs/book/src/reference/capture-names/vertical-spacing.md
@@ -283,17 +283,6 @@ removed.
 The matched nodes will have a line break appended (or, respectively,
 prepended) to them.
 
-### Example
-
-```scheme
-; Consecutive definitions must be separated by line breaks
-(
-  (value_definition) @append_hardline
-  .
-  (value_definition)
-)
-```
-
 > **Note**\
 > If you wish to insert empty lines -- that is, two line breaks --
 > between nodes, this can be emulated with [`@append_delimiter` /
@@ -309,6 +298,21 @@ prepended) to them.
 >   (#delimiter! "\n\n")
 > )
 > ```
+>
+> However, bear in mind that Topiary's normal [post-processing](../formatting-pipeline.md#atom-processing)
+> that squashes runs of whitespace will not apply, so queries must be
+> written with care to avoid extra, unintended line breaks.
+
+### Example
+
+```scheme
+; Consecutive definitions must be separated by line breaks
+(
+  (value_definition) @append_hardline
+  .
+  (value_definition)
+)
+```
 
 ## `@append_empty_softline` / `@prepend_empty_softline`
 


### PR DESCRIPTION
# Expand blank line tip in Topiary Book

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
References #1008
References #1001
References #993

## Description

Add a note to the `\n\n`-delimiter tip regarding its opacity to the run-of-whitespace post-processing step.

(Also moved the tip out of the example for `@{append,prepend}_hardline`.)

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] ~Updated regression tests~
