### PR TITLE
Updated versioning scheme for `topiary-{config,queries}`

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -65,6 +65,8 @@
 > [!IMPORTANT]
 > See [below](#releasing-new-configuration-and-queries) for details on
 > how to do interim releases of `topiary-config` or `topiary-queries`.
+> These subpackages are now versioned independently from Topiary (core,
+> etc.), so their versions will diverge.
 
 - Update lockfiles and the release workflow. Lockfiles should be kept up
   to date by the Renovate bot, but it's worth doing manually when
@@ -166,18 +168,10 @@ dissimilar from a usual release:
    `topiary-config` and/or `topiary-queries` will need to be updated in
    the root and their respective `Cargo.toml` files.
 
-   The versioning scheme that has been chosen for these subpackages
-   should be as follows:
-
-   - `MAJOR.MINOR.PATCH`, matching those of `topiary-core`, when doing a
-     full release. For example: `0.6.1`.
-
-   - `MAJOR.MINOR.PATCH-YYYYMMDD`, when doing an interim release. That
-     is, matching the `topiary-core` version, with the date appended.
-     For example: `0.6.1-20250925`.
-
-   There should be no need to update lockfiles, etc. so the above can
-   simply be pushed to follow the usual approval-and-merge process.
+   The version of these subpackages should bump their respective patch
+   version (e.g., `0.6.1` would become `0.6.2`), but not the workspace
+   version. As these are no longer tied to the Topiary version, they
+   will gradually diverge.
 
 2. Do not tag the release, as this will trigger `dist` into cutting a
    full release. However, importantly, the new version of the respective


### PR DESCRIPTION
# Updated versioning scheme for `topiary-{config,queries}`

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
See #1011
See #1015

## Description

Updated the maintainer guidance on interim versions of `topiary-{config,queries}`. The `-YYYYMMDD` suffix proved to be unworkable, so we decided to decouple these and allow them to diverge.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] ~Updated regression tests~
