### PR TITLE
Revert CI back to `macos-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-14  # TODO Revert to macos-latest; see #1043
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
# Revert CI back to `macos-latest`

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #1043
References https://github.com/actions/runner-images/issues/12588

## Description

Reverts the main CI's macOS run to use GitHub's `macos-latest` runner, rather than `macos-14`, as this has been fixed upstream.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] ~Updated regression tests~
