### PR TITLE
Clarification of how multilineness is determined for softlines

### DIFF
--- a/docs/book/src/reference/capture-names/vertical-spacing.md
+++ b/docs/book/src/reference/capture-names/vertical-spacing.md
@@ -10,15 +10,14 @@ In particular, Topiary goes through the CST nodes and detects all that
 span more than one line. This is interpreted as an indication from the
 programmer who wrote the input that the node in question should be
 formatted as multi-line; while any other nodes will be formatted as
-single-line. Whenever a query match has inserted a softline, it will be
-expanded to a line break if the node is multi-line (otherwise it will be
-formatted depending on the capture name used).
+single-line.
 
-At the capture name level, a node marked with a softline capture name
-will be considered multi-line based on the multi-line-ness of its
-immediate parent node in the CST. Another way to look at this is that
-these capture names are a "convenience" over their [scoped](scopes.md)
-equivalent, with the scope implicitly set to the parent node.
+Whenever a query match inserts a softline, the softline will be expanded
+to a line break if the **immediate parent of the node marked with the
+softline capture** spans more than one line. Another way to look at this
+is that these capture names are a convenience over their
+[scoped](scopes.md) equivalent, with the scope implicitly set to the
+parent node.
 
 See:
 

--- a/docs/book/src/reference/capture-names/vertical-spacing.md
+++ b/docs/book/src/reference/capture-names/vertical-spacing.md
@@ -12,7 +12,15 @@ programmer who wrote the input that the node in question should be
 formatted as multi-line; while any other nodes will be formatted as
 single-line. Whenever a query match has inserted a softline, it will be
 expanded to a line break if the node is multi-line (otherwise it will be
-formatted depending on the capture name used). See:
+formatted depending on the capture name used).
+
+At the capture name level, a node marked with a softline capture name
+will be considered multi-line based on the multi-line-ness of its
+immediate parent node in the CST. Another way to look at this is that
+these capture names are a "convenience" over their [scoped](scopes.md)
+equivalent, with the scope implicitly set to the parent node.
+
+See:
 
 - [`@append_hardline` / `@prepend_hardline`](#append_hardline--prepend_hardline)
 - [`@append_empty_softline` / `@prepend_empty_softline`](#append_empty_softline--prepend_empty_softline)


### PR DESCRIPTION
# Topiary Book: Clarification of how multilineness is determined for softlines

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #1048

## Description

Explicitly explain that nodes marked with a softline capture are determined to be multiline by virtue of the multilineness of their immediate parent. Also made scope analogue.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] ~Updated regression tests~
