### PR TITLE
feat(core): Allow formatting existing tree-sitter trees

### DIFF
--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -284,6 +284,23 @@ pub fn apply_query(
     tolerate_parsing_errors: bool,
 ) -> FormatterResult<AtomCollection> {
     let tree = parse(input_content, grammar, tolerate_parsing_errors)?;
+    apply_query_tree(tree, input_content, query)
+}
+
+/// Applies a query to a tree and returns a collection of atoms.
+///
+/// # Errors
+///
+/// This function can return an error if:
+/// - The query content cannot be parsed by the grammar.
+/// - The input exhaustivity check fails.
+/// - A found predicate could not be parsed or is malformed.
+/// - A unknown capture name was encountered in the query.
+pub fn apply_query_tree(
+    tree: Tree,
+    input_content: &str,
+    query: &TopiaryQuery,
+) -> FormatterResult<AtomCollection> {
     let root = tree.root_node();
     let source = input_content.as_bytes();
 


### PR DESCRIPTION
# Allow formatting existing tree-sitter trees

Resolves #1079

## Description

This PR adds two functions `formatter_tree` and `apply_query_tree` to allow users of `topiary-core` to format existing trees and avoid cost of parsing input twice

## Checklist

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
