### PR TITLE
fix(cli): log early returns during formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ This name should be decided amongst the team before the release.
 ### Changed
 - [#1031](https://github.com/tweag/topiary/pull/1031) Removed the Bash rewrite rule for converting POSIX `[` to Bash's `[[`
 
+### Fixed
+- [#1092](https://github.com/tweag/topiary/pull/1092) Log early returns during formatting, thanks to @mkatychev
+
 <!--
 ### Deprecated
 - <Soon-to-be removed features>
@@ -63,8 +66,6 @@ This name should be decided amongst the team before the release.
 ### Removed
 - <Removed features>
 
-### Fixed
-- <Bug fixes>
 
 ### Security
 - <Vulnerabilities>
@@ -96,7 +97,7 @@ This name should be decided amongst the team before the release.
 - [#953](https://github.com/tweag/topiary/pull/953) Coverage output when there are zero queries
 - [#974](https://github.com/tweag/topiary/pull/974) No longer remove trailing spaces after pretty-printing
 - [#992](https://github.com/tweag/topiary/pull/992) Fixed [openscad-LSP#48](https://github.com/Leathong/openscad-LSP/issues/48): unhandled newline separation for transform chains, thanks to @mkatychev
-- [#999](https://github.com/tweag/topiary/pull/999) Fixed [#997](https://github.com/tweag/topiary/issues/997): erroneous spacing of block comments in OpenSCAD
+- [#999](https://github.com/tweag/topiary/pull/999) Fixed [#997](https://github.com/tweag/topiary/issues/997): erroneous spacing of block comments in OpenSCAD, thanks to @pinkfish
 
 ## v0.6.0 - Gilded Ginkgo - 2025-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ This name should be decided amongst the team before the release.
 - [#953](https://github.com/tweag/topiary/pull/953) Coverage output when there are zero queries
 - [#974](https://github.com/tweag/topiary/pull/974) No longer remove trailing spaces after pretty-printing
 - [#992](https://github.com/tweag/topiary/pull/992) Fixed [openscad-LSP#48](https://github.com/Leathong/openscad-LSP/issues/48): unhandled newline separation for transform chains, thanks to @mkatychev
-- [#999](https://github.com/tweag/topiary/pull/999) Fixed [#997](https://github.com/tweag/topiary/issues/997): erroneous spacing of block comments in OpenSCAD, thanks to @pinkfish
+- [#999](https://github.com/tweag/topiary/pull/999) Fixed [#997](https://github.com/tweag/topiary/issues/997): erroneous spacing of block comments in OpenSCAD
 
 ## v0.6.0 - Gilded Ginkgo - 2025-01-30
 

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -12,14 +12,14 @@ use std::{
 };
 
 use error::Benign;
-use tabled::{Table, settings::Style};
+use tabled::{settings::Style, Table};
 use topiary_config::source::Source;
-use topiary_core::{Operation, check_query_coverage, formatter};
+use topiary_core::{check_query_coverage, formatter, Operation};
 
 use crate::{
     cli::Commands,
     error::{CLIError, CLIResult, TopiaryError},
-    io::{Inputs, OutputFile, read_input},
+    io::{read_input, Inputs, OutputFile},
     language::LanguageDefinitionCache,
 };
 

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -107,10 +107,10 @@ async fn run() -> CLIResult<()> {
                 return results.swap_remove(0)?;
             }
 
+            // use `.count()` here to ensure eager evaluation of iterator
             let errs = results
                 .into_iter()
-                .map(|r| r.map_err(TopiaryError::from).and_then(|inner| inner))
-                .filter_map(|r| r.err())
+                .filter_map(|r| r.map_err(TopiaryError::from).and_then(|inner| inner).err())
                 .inspect(|e| print_error(&e))
                 .count();
 

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -109,11 +109,7 @@ async fn run() -> CLIResult<()> {
                 .iter()
                 .inspect(|r| match r {
                     Err(e) => print_error(&e),
-                    Ok(Err(e)) => {
-                        if !e.benign() {
-                            print_error(&e)
-                        }
-                    }
+                    Ok(Err(e)) if !e.benign() => print_error(&e),
                     _ => {}
                 })
                 .any(|result| matches!(result, Err(_) | Ok(Err(_))))

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -57,60 +57,47 @@ async fn run() -> CLIResult<()> {
             let (_, mut results) = async_scoped::TokioScope::scope_and_block(|scope| {
                 for input in inputs {
                     scope.spawn(async {
-                        let result: CLIResult<()> = match input {
-                            Ok(input) => {
-                                let language = cache.fetch(&input).await?;
-                                let output = OutputFile::try_from(&input)?;
+                        // This happens when the input resolver cannot establish an input
+                        // source, language or query file.
+                        let input = input?;
+                        let language = cache.fetch(&input).await?;
+                        let output = OutputFile::try_from(&input)?;
 
-                                log::info!(
-                                    "Formatting {}, as {} using {}, to {}",
-                                    input.source(),
-                                    input.language().name,
-                                    input.query(),
-                                    output
-                                );
+                        log::info!(
+                            "Formatting {}, as {} using {}, to {}",
+                            input.source(),
+                            input.language().name,
+                            input.query(),
+                            output
+                        );
 
-                                let mut buf_output = BufWriter::new(output);
+                        let mut buf_output = BufWriter::new(output);
 
-                                {
-                                    // NOTE This newly opened scope is important! `buf_input` takes
-                                    // ownership of `input`, which -- upon reading -- contains an
-                                    // open file handle. We need to close this file, by dropping
-                                    // `buf_input`, before we attempt to persist our output.
-                                    // Otherwise, we get an exclusive lock problem on Windows.
-                                    let mut buf_input = BufReader::new(input);
+                        {
+                            // NOTE This newly opened scope is important! `buf_input` takes
+                            // ownership of `input`, which -- upon reading -- contains an
+                            // open file handle. We need to close this file, by dropping
+                            // `buf_input`, before we attempt to persist our output.
+                            // Otherwise, we get an exclusive lock problem on Windows.
+                            let mut buf_input = BufReader::new(input);
 
-                                    formatter(
-                                        &mut buf_input,
-                                        &mut buf_output,
-                                        &language,
-                                        Operation::Format {
-                                            skip_idempotence,
-                                            tolerate_parsing_errors,
-                                        },
-                                    )
-                                    .map_err(|e| {
-                                        e.with_location(format!("{}", buf_input.get_ref().source()))
-                                    })?;
-                                }
-
-                                buf_output.into_inner()?.persist()?;
-
-                                Ok(())
-                            }
-
-                            // This happens when the input resolver cannot establish an input
-                            // source, language or query file.
-                            Err(error) => Err(error),
-                        };
-
-                        if let Err(error) = &result {
-                            // By this point, we've lost any reference to the original
-                            // input; we trust that it is embedded into `error`.
-                            log::warn!("Skipping: {error}");
+                            formatter(
+                                &mut buf_input,
+                                &mut buf_output,
+                                &language,
+                                Operation::Format {
+                                    skip_idempotence,
+                                    tolerate_parsing_errors,
+                                },
+                            )
+                            .map_err(|e| {
+                                e.with_location(format!("{}", buf_input.get_ref().source()))
+                            })?;
                         }
 
-                        result
+                        buf_output.into_inner()?.persist()?;
+
+                        CLIResult::Ok(())
                     });
                 }
             });
@@ -120,6 +107,15 @@ async fn run() -> CLIResult<()> {
                 results.remove(0)??
             } else if results
                 .iter()
+                .inspect(|r| match r {
+                    Err(e) => print_error(&e),
+                    Ok(Err(e)) => {
+                        if !e.benign() {
+                            print_error(&e)
+                        }
+                    }
+                    _ => {}
+                })
                 .any(|result| matches!(result, Err(_) | Ok(Err(_))))
             {
                 // For multiple inputs, bail out if any failed with a "multiple errors" failure


### PR DESCRIPTION
# log early returns during formatting

## Description
Certain errors would not get logged during an early return because they exited the async block rather than the let scope:
https://github.com/tweag/topiary/blob/5f336358fe2ccc9a0a9c2b52b38d60df67f41cf8/topiary-cli/src/main.rs#L62-L63

This resulted in only the match arm below being logged:
https://github.com/tweag/topiary/blob/5f336358fe2ccc9a0a9c2b52b38d60df67f41cf8/topiary-cli/src/main.rs#L102-L104

This PR changes the scoped future to log all errors emitted.

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] Updated regression tests
