### PR TITLE
chore: Update to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 version = "0.6.1"
-edition = "2021"
+edition = "2024"
 authors = ["Tweag"]
 homepage = "https://topiary.tweag.io"
 repository = "https://github.com/tweag/topiary"

--- a/topiary-cli/src/cli.rs
+++ b/topiary-cli/src/cli.rs
@@ -244,7 +244,10 @@ pub fn get_args() -> CLIResult<Cli> {
             // Make sure our FILE is not a directory
             if file.is_dir() {
                 return Err(TopiaryError::Bin(
-                    format!("Cannot visualise directory \"{}\"; please provide a single file from disk or stdin.", file.to_string_lossy()),
+                    format!(
+                        "Cannot visualise directory \"{}\"; please provide a single file from disk or stdin.",
+                        file.to_string_lossy()
+                    ),
                     None,
                 ));
             }

--- a/topiary-cli/src/io.rs
+++ b/topiary-cli/src/io.rs
@@ -9,7 +9,7 @@ use std::{
 use nickel_lang_core::term::RichTerm;
 use tempfile::tempfile;
 use topiary_config::Configuration;
-use topiary_core::{formatter, Language, Operation, TopiaryQuery};
+use topiary_core::{Language, Operation, TopiaryQuery, formatter};
 
 use crate::{
     cli::{AtLeastOneInput, ExactlyOneInput, FromStdin},
@@ -257,7 +257,9 @@ fn to_query_from_language(language: &topiary_config::language::Language) -> CLIR
         // builtin ones. Store the error, return that if we
         // fail to find anything, because the builtin error might be unexpected.
         Err(e) => {
-            log::warn!("No query files found in any of the expected locations. Falling back to compile-time included files.");
+            log::warn!(
+                "No query files found in any of the expected locations. Falling back to compile-time included files."
+            );
             to_query(&language.name).map_err(|_| e)?
         }
     };

--- a/topiary-cli/src/language.rs
+++ b/topiary-cli/src/language.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{
-        hash_map::{DefaultHasher, Entry},
         HashMap,
+        hash_map::{DefaultHasher, Entry},
     },
     hash::{Hash, Hasher},
     sync::Arc,

--- a/topiary-cli/src/main.rs
+++ b/topiary-cli/src/main.rs
@@ -12,14 +12,14 @@ use std::{
 };
 
 use error::Benign;
-use tabled::{settings::Style, Table};
+use tabled::{Table, settings::Style};
 use topiary_config::source::Source;
-use topiary_core::{check_query_coverage, formatter, Operation};
+use topiary_core::{Operation, check_query_coverage, formatter};
 
 use crate::{
     cli::Commands,
     error::{CLIError, CLIResult, TopiaryError},
-    io::{read_input, Inputs, OutputFile},
+    io::{Inputs, OutputFile, read_input},
     language::LanguageDefinitionCache,
 };
 
@@ -194,7 +194,7 @@ async fn run() -> CLIResult<()> {
                 .await
                 .inspect_err(|e| {
                     // nickel may not be present in user config so log as info
-                    log::info!("Config formatting error: {}", e);
+                    log::info!("Config formatting error: {e}");
                 })
                 .is_ok()
             {

--- a/topiary-config/src/error.rs
+++ b/topiary-config/src/error.rs
@@ -36,16 +36,42 @@ pub enum TopiaryConfigFetchingError {
 impl fmt::Display for TopiaryConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TopiaryConfigError::FileNotFound(path) => write!(f, "We tried to find your configuration file at {}, but failed to do so. Make sure the file exists.", path.to_string_lossy()),
-            TopiaryConfigError::UnknownLanguage(lang) => write!(f, "You were looking for language \"{lang}\", but we do not know that language."),
-            TopiaryConfigError::UnknownExtension(ext) => write!(f, "You tried to format a file with extension: \"{ext}\", but we do not know that extension. Make sure the extension is in your configuration file!"),
-            TopiaryConfigError::NoExtension(path) => write!(f, "You tried to format {} without specifying a language, but we cannot automatically detect the language because we can't find the filetype extension.", path.to_string_lossy()),
+            TopiaryConfigError::FileNotFound(path) => write!(
+                f,
+                "We tried to find your configuration file at {}, but failed to do so. Make sure the file exists.",
+                path.to_string_lossy()
+            ),
+            TopiaryConfigError::UnknownLanguage(lang) => write!(
+                f,
+                "You were looking for language \"{lang}\", but we do not know that language."
+            ),
+            TopiaryConfigError::UnknownExtension(ext) => write!(
+                f,
+                "You tried to format a file with extension: \"{ext}\", but we do not know that extension. Make sure the extension is in your configuration file!"
+            ),
+            TopiaryConfigError::NoExtension(path) => write!(
+                f,
+                "You tried to format {} without specifying a language, but we cannot automatically detect the language because we can't find the filetype extension.",
+                path.to_string_lossy()
+            ),
             #[cfg(not(target_arch = "wasm32"))]
-            TopiaryConfigError::QueryFileNotFound(path) => write!(f, "We could not find the query file: \"{}\" anywhere. If you use the TOPIARY_LANGUAGE_DIR environment variable, make sure it set set correctly.", path.to_string_lossy()),
+            TopiaryConfigError::QueryFileNotFound(path) => write!(
+                f,
+                "We could not find the query file: \"{}\" anywhere. If you use the TOPIARY_LANGUAGE_DIR environment variable, make sure it set set correctly.",
+                path.to_string_lossy()
+            ),
             TopiaryConfigError::Io(error) => write!(f, "We encountered an io error: {error}"),
-            TopiaryConfigError::Missing => write!(f, "A configuration file is missing. If you passed a configuration file, make sure it exists."),
-            TopiaryConfigError::TreeSitterFacade(_) => write!(f, "We could not load the grammar for the given language"),
-            TopiaryConfigError::Nickel(e) => write!(f, "Nickel error: {e:#?}\n\nDid you forget to add a \"priority\" annotation in your config file?"),
+            TopiaryConfigError::Missing => write!(
+                f,
+                "A configuration file is missing. If you passed a configuration file, make sure it exists."
+            ),
+            TopiaryConfigError::TreeSitterFacade(_) => {
+                write!(f, "We could not load the grammar for the given language")
+            }
+            TopiaryConfigError::Nickel(e) => write!(
+                f,
+                "Nickel error: {e:#?}\n\nDid you forget to add a \"priority\" annotation in your config file?"
+            ),
             TopiaryConfigError::NickelDeserialization(e) => write!(f, "Nickel error: {e:#?}"),
             #[cfg(not(target_arch = "wasm32"))]
             TopiaryConfigError::Fetching(e) => write!(f, "Error Fetching Language: {e}"),

--- a/topiary-config/src/language.rs
+++ b/topiary-config/src/language.rs
@@ -5,11 +5,11 @@
 use anyhow::anyhow;
 #[cfg(not(target_arch = "wasm32"))]
 use gix::{
+    ObjectId,
     interrupt::IS_INTERRUPTED,
     progress::Discard,
-    remote::{self, fetch, fetch::refmap, Direction},
+    remote::{self, Direction, fetch, fetch::refmap},
     worktree::state::checkout,
-    ObjectId,
 };
 use std::collections::HashSet;
 #[cfg(not(target_arch = "wasm32"))]
@@ -151,7 +151,7 @@ impl Language {
                 GrammarSource::Path(_) => {
                     return Err(TopiaryConfigFetchingError::GrammarFileNotFound(
                         library_path,
-                    ))
+                    ));
                 }
             }
         }

--- a/topiary-config/src/lib.rs
+++ b/topiary-config/src/lib.rs
@@ -55,10 +55,10 @@ impl Configuration {
     #[allow(clippy::result_large_err)]
     pub fn fetch(merge: bool, file: &Option<PathBuf>) -> TopiaryConfigResult<(Self, RichTerm)> {
         // If we have an explicit file, fail if it doesn't exist
-        if let Some(path) = file {
-            if !path.exists() {
-                return Err(TopiaryConfigError::FileNotFound(path.to_path_buf()));
-            }
+        if let Some(path) = file
+            && !path.exists()
+        {
+            return Err(TopiaryConfigError::FileNotFound(path.to_path_buf()));
         }
 
         if merge {

--- a/topiary-core/benches/benchmark.rs
+++ b/topiary-core/benches/benchmark.rs
@@ -1,8 +1,8 @@
 use criterion::async_executor::FuturesExecutor;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::fs;
 use std::io;
-use topiary_core::{formatter, Language, Operation, TopiaryQuery};
+use topiary_core::{Language, Operation, TopiaryQuery, formatter};
 
 async fn format() {
     let input = fs::read_to_string("../topiary-cli/tests/samples/input/nickel.ncl").unwrap();

--- a/topiary-core/src/atom_collection.rs
+++ b/topiary-core/src/atom_collection.rs
@@ -8,8 +8,8 @@ use std::{
 use topiary_tree_sitter_facade::Node;
 
 use crate::{
-    tree_sitter::NodeExt, Atom, Capitalisation, FormatterError, FormatterResult, ScopeCondition,
-    ScopeInformation,
+    Atom, Capitalisation, FormatterError, FormatterResult, ScopeCondition, ScopeInformation,
+    tree_sitter::NodeExt,
 };
 
 /// A struct that holds sets of node IDs that have line breaks before or after them.
@@ -206,14 +206,14 @@ impl AtomCollection {
             log::debug!("Skipping because context is single-line and #multi_line_only! is set");
             return Ok(());
         }
-        if let Some(parent_id) = self.parent_leaf_nodes.get(&node.id()) {
-            if *parent_id != node.id() {
-                log::debug!(
-                    "Skipping because the match occurred below a leaf node: {}",
-                    node.display_one_based()
-                );
-                return Ok(());
-            }
+        if let Some(parent_id) = self.parent_leaf_nodes.get(&node.id())
+            && *parent_id != node.id()
+        {
+            log::debug!(
+                "Skipping because the match occurred below a leaf node: {}",
+                node.display_one_based()
+            );
+            return Ok(());
         }
 
         match name {
@@ -404,10 +404,9 @@ impl AtomCollection {
                         single_line_no_indent,
                         ..
                     } = a
+                        && *id == node.id()
                     {
-                        if *id == node.id() {
-                            *single_line_no_indent = true;
-                        }
+                        *single_line_no_indent = true;
                     }
                 }
 
@@ -421,10 +420,9 @@ impl AtomCollection {
                         multi_line_indent_all,
                         ..
                     } = a
+                        && *id == node.id()
                     {
-                        if *id == node.id() {
-                            *multi_line_indent_all = true;
-                        }
+                        *multi_line_indent_all = true;
                     }
                 }
             }
@@ -433,7 +431,7 @@ impl AtomCollection {
                 return Err(FormatterError::Query(
                     format!("@{unknown} is not a valid capture name"),
                     None,
-                ))
+                ));
             }
         }
 
@@ -778,7 +776,9 @@ impl AtomCollection {
                                 Some(multi_line),
                             ));
                         } else {
-                            log::warn!("Found several measuring scopes in a single regular scope {scope_id:?}");
+                            log::warn!(
+                                "Found several measuring scopes in a single regular scope {scope_id:?}"
+                            );
                             force_apply_modifications = true;
                         }
                     } else {
@@ -974,7 +974,10 @@ impl AtomCollection {
                 // If two whitespace atoms follow each other, remove the non-dominant one.
                 (
                     moved_prev @ (Atom::Space | Atom::Hardline | Atom::Blankline),
-                    [head @ (Atom::Space | Atom::Hardline | Atom::Blankline), tail @ ..],
+                    [
+                        head @ (Atom::Space | Atom::Hardline | Atom::Blankline),
+                        tail @ ..,
+                    ],
                 ) => {
                     if head.dominates(moved_prev) {
                         *moved_prev = Atom::Empty;
@@ -1248,7 +1251,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{atom_collection::AtomCollection, Atom};
+    use crate::{Atom, atom_collection::AtomCollection};
     use test_log::test;
 
     #[test]

--- a/topiary-core/src/graphviz.rs
+++ b/topiary-core/src/graphviz.rs
@@ -2,7 +2,7 @@
 //! Named syntax nodes are elliptical; anonymous are rectangular.
 use std::{borrow::Cow, fmt, io};
 
-use crate::{tree_sitter::SyntaxNode, FormatterResult};
+use crate::{FormatterResult, tree_sitter::SyntaxNode};
 
 /// Doubly escapes whitespace (\n and \t) so it is
 /// rendered as the escaped value in the GraphViz output

--- a/topiary-core/src/lib.rs
+++ b/topiary-core/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::{
     error::{FormatterError, IoError},
     language::Language,
     tree_sitter::{
-        apply_query, check_query_coverage, CoverageData, SyntaxNode, TopiaryQuery, Visualisation,
+        CoverageData, SyntaxNode, TopiaryQuery, Visualisation, apply_query, check_query_coverage,
     },
 };
 
@@ -383,8 +383,8 @@ mod tests {
     use test_log::test;
 
     use crate::{
-        error::FormatterError, formatter, test_utils::pretty_assert_eq, Language, Operation,
-        TopiaryQuery,
+        Language, Operation, TopiaryQuery, error::FormatterError, formatter,
+        test_utils::pretty_assert_eq,
     };
 
     /// Attempt to parse invalid json, expecting a failure

--- a/topiary-core/src/pretty.rs
+++ b/topiary-core/src/pretty.rs
@@ -92,7 +92,7 @@ pub fn render(atoms: &[Atom], indent: &str) -> FormatterResult<String> {
                 return Err(FormatterError::Internal(
                     format!("Found atom that should have been removed before rendering: {other:?}",),
                     None,
-                ))
+                ));
             }
         };
     }

--- a/topiary-core/src/test_utils.rs
+++ b/topiary-core/src/test_utils.rs
@@ -1,4 +1,4 @@
-use prettydiff::text::{diff_lines, ContextConfig};
+use prettydiff::text::{ContextConfig, diff_lines};
 
 pub fn pretty_assert_eq(v1: &str, v2: &str) {
     if v1 != v2 {

--- a/topiary-core/src/tree_sitter.rs
+++ b/topiary-core/src/tree_sitter.rs
@@ -14,9 +14,9 @@ use topiary_tree_sitter_facade::{
 use streaming_iterator::StreamingIterator;
 
 use crate::{
+    FormatterResult,
     atom_collection::{AtomCollection, QueryPredicates},
     error::FormatterError,
-    FormatterResult,
 };
 
 /// Supported visualisation formats

--- a/topiary-playground/src/lib.rs
+++ b/topiary-playground/src/lib.rs
@@ -8,7 +8,7 @@ pub use wasm_mod::*;
 mod wasm_mod {
     use std::sync::Mutex;
     use topiary_config::Configuration;
-    use topiary_core::{formatter, FormatterResult, Language, Operation, TopiaryQuery};
+    use topiary_core::{FormatterResult, Language, Operation, TopiaryQuery, formatter};
     use topiary_tree_sitter_facade::TreeSitter;
     use wasm_bindgen::prelude::*;
 

--- a/topiary-tree-sitter-facade/src/node.rs
+++ b/topiary-tree-sitter-facade/src/node.rs
@@ -290,7 +290,7 @@ mod wasm {
     use crate::{input_edit::InputEdit, point::Point, range::Range, tree_cursor::TreeCursor};
     use std::borrow::Cow;
     use topiary_web_tree_sitter_sys::SyntaxNode;
-    use wasm_bindgen::{prelude::*, JsCast};
+    use wasm_bindgen::{JsCast, prelude::*};
 
     #[derive(Clone, Eq, Hash, PartialEq)]
     pub struct Node<'tree> {

--- a/topiary-tree-sitter-facade/src/parser.rs
+++ b/topiary-tree-sitter-facade/src/parser.rs
@@ -28,8 +28,10 @@ mod native {
         #[inline]
         #[warn(deprecated)]
         pub unsafe fn cancellation_flag(&self) -> Option<&AtomicUsize> {
-            #[allow(deprecated)]
-            self.inner.cancellation_flag()
+            unsafe {
+                #[allow(deprecated)]
+                self.inner.cancellation_flag()
+            }
         }
 
         #[inline]
@@ -113,8 +115,10 @@ mod native {
         #[inline]
         #[warn(deprecated)]
         pub unsafe fn set_cancellation_flag(&mut self, flag: Option<&AtomicUsize>) {
-            #[allow(deprecated)]
-            self.inner.set_cancellation_flag(flag);
+            unsafe {
+                #[allow(deprecated)]
+                self.inner.set_cancellation_flag(flag);
+            }
         }
 
         #[inline]
@@ -184,7 +188,7 @@ mod wasm {
         tree::Tree,
     };
     use js_sys::{Function, JsString};
-    use wasm_bindgen::{prelude::*, JsCast};
+    use wasm_bindgen::{JsCast, prelude::*};
 
     pub struct Parser {
         inner: topiary_web_tree_sitter_sys::Parser,

--- a/topiary-web-tree-sitter-sys/src/lib.rs
+++ b/topiary-web-tree-sitter-sys/src/lib.rs
@@ -2,7 +2,7 @@
 
 use core::cell::RefCell;
 use js_sys::{Array, Error, Function, JsString, Object, Promise, Reflect, Uint8Array};
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::{JsCast, prelude::*};
 use wasm_bindgen_futures::JsFuture;
 
 trait JsValueExt {
@@ -803,7 +803,7 @@ extern "C" {
 
     #[wasm_bindgen(method, js_name = namedDescendantForPosition)]
     pub fn named_descendant_for_position(this: &SyntaxNode, position: &Point)
-        -> Option<SyntaxNode>;
+    -> Option<SyntaxNode>;
 
     #[wasm_bindgen(method, js_name = namedDescendantForPosition)]
     pub fn named_descendant_for_position_range(


### PR DESCRIPTION
# Update to Rust 2024 edition

References https://github.com/tweag/topiary/pull/1094

## Description
https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/

Handle clippy lints arising from the edition change

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [x] `CHANGELOG.md` updated
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] Updated regression tests
