### PR TITLE
Bump topiary-tree-sitter-facade to fix wasm-bindgen conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,7 +4153,7 @@ version = "0.6.4"
 
 [[package]]
 name = "topiary-tree-sitter-facade"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "js-sys",
  "streaming-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ wasm-bindgen-test = "0.3"
 web-sys = "0.3"
 
 topiary-web-tree-sitter-sys = { version = "0.6.1", path = "./topiary-web-tree-sitter-sys" }
-topiary-tree-sitter-facade = { version = "0.6.1", path = "./topiary-tree-sitter-facade" }
+topiary-tree-sitter-facade = { version = "0.6.2", path = "./topiary-tree-sitter-facade" }
 topiary-core = { version = "0.6.1", path = "./topiary-core" }
 topiary-config = { version = "0.6.3", path = "./topiary-config" }
 topiary-queries = { version = "0.6.4", path = "./topiary-queries" }

--- a/topiary-tree-sitter-facade/Cargo.toml
+++ b/topiary-tree-sitter-facade/Cargo.toml
@@ -2,7 +2,7 @@
 name = "topiary-tree-sitter-facade"
 authors = ["<herringtondarkholme@users.noreply.github.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
-version.workspace = true
+version = "0.6.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Just trying to get all our ducks in a row to push the updates Topiary queries and config from #1085 