### PR TITLE
Bump topiary-web-tree-sitter-sys to fix wasm-bindgen conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "topiary-web-tree-sitter-sys"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5069,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ wasm-bindgen-futures = "0.4"
 wasm-bindgen-test = "0.3"
 web-sys = "0.3"
 
-topiary-web-tree-sitter-sys = { version = "0.6.1", path = "./topiary-web-tree-sitter-sys" }
+topiary-web-tree-sitter-sys = { version = "0.6.2", path = "./topiary-web-tree-sitter-sys" }
 topiary-tree-sitter-facade = { version = "0.6.2", path = "./topiary-tree-sitter-facade" }
 topiary-core = { version = "0.6.1", path = "./topiary-core" }
 topiary-config = { version = "0.6.3", path = "./topiary-config" }

--- a/topiary-web-tree-sitter-sys/Cargo.toml
+++ b/topiary-web-tree-sitter-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "topiary-web-tree-sitter-sys"
 authors = ["<silvanshade@users.noreply.github.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
-version.workspace = true
+version = "0.6.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Basically the same as #1097, but for `topiry-web-tree-sitter-sys`. I guess that's all of them now :sweat_smile: 