### PR TITLE
Topiary Book: Clarify configuration sources on macOS

### DIFF
--- a/docs/book/src/cli/configuration.md
+++ b/docs/book/src/cli/configuration.md
@@ -9,9 +9,10 @@ such a file.
 
 At build time the
 [`languages.ncl`](https://github.com/tweag/topiary/blob/main/topiary-config/languages.ncl)
-in the root of the Topiary repository is embedded into Topiary. This file is
-parsed at runtime. The purpose of this `languages.ncl` file is to provide sane
-defaults for users of Topiary (both the library and the CLI binary).
+in the root of the Topiary repository is embedded into Topiary. This
+file is parsed at runtime. The purpose of this `languages.ncl` file is
+to provide sane defaults for users of Topiary (both the library and the
+CLI binary).
 
 The next two are read by the Topiary binary at runtime and allow the
 user to configure Topiary to their needs. The first is intended to be
@@ -48,8 +49,9 @@ following order (highest to lowest):
 3. The user configuration file in the OS's configuration directory.
 4. The built-in configuration file.
 
-One can call `topiary config show-sources` to display configuration sources
-along with any detected `language.ncl` files or `queries` directories therein:
+One can call `topiary config show-sources` to display configuration
+sources along with any detected `language.ncl` files or `queries`
+directories therein:
 
 ```
 $ topiary config show-sources
@@ -72,10 +74,10 @@ $ topiary config show-sources
 
 ### Configuration merging
 
-By default, Topiary only considers the configuration file with the highest
-priority and merges it with the built-in configuration. However, if the
-`-M`/`--merge-configuration` option is provided to the CLI, then all available
-configurations are merged together, as per the [Nickel
+By default, Topiary only considers the configuration file with the
+highest priority and merges it with the built-in configuration. However,
+if the `-M`/`--merge-configuration` option is provided to the CLI, then
+all available configurations are merged together, as per the [Nickel
 specification](https://nickel-lang.org/user-manual/merging).
 
 In which case, if one of the sources listed above attempts to define a
@@ -185,10 +187,11 @@ nickel = {
 > by Topiary itself, those look like `~/.cache/topiary/<LANGUAGE>/<GIT_HASH>.so`
 > (or the equivalent for your platform).
 
-For usage in Nix, a `prefetchLanguages.nix` file provides utilities allowing to
-transform a Topiary configuration into one where languages have been pre-fetched
-and pre-compiled in Nix derivations. The only caveat is that, for each Git
-source, the configuration must contain a `nixHash` for that source. For instance:
+For usage in Nix, a `prefetchLanguages.nix` file provides utilities
+allowing to transform a Topiary configuration into one where languages
+have been pre-fetched and pre-compiled in Nix derivations. The only
+caveat is that, for each Git source, the configuration must contain a
+`nixHash` for that source. For instance:
 
 ```nickel
 nickel = {
@@ -201,13 +204,15 @@ nickel = {
 },
 ```
 
-The simplest way to obtain the hash is to use `nix-prefetch-git` (and look for
-the `hash` field in its output):
+The simplest way to obtain the hash is to use `nix-prefetch-git` (and
+look for the `hash` field in its output):
+
 ```sh
 nix run nixpkgs#nix-prefetch-git -- https://github.com/bytecodealliance/tree-sitter-wit 230984dfaf803a0ff8f77da5034361a62c326577
 ```
 
 The second simplest way is to compile, which will show something like:
+
 ```
 evaluation warning: Language `nickel`: no nixHash provided - using dummy value
 error: hash mismatch in fixed-output derivation '/nix/store/jgny7ll7plh7rfdnvdpgcb82kd51aiyx-tree-sitter-nickel-43433d8.drv':


### PR DESCRIPTION
# Topiary Book: Clarify configuration sources on macOS

<!----------------------------------------------------------------------
If this PR is related to, or resolves an issue, please reference it
here.

- For issues that are fixed by this PR, use GitHub's automatic closing
  feature by writing "Resolves #XXX", for example.

- If multiple issues are implicated, please list them out, with an
  appropriate byline for each issue, with one issue per line.

- You may also use this section to reference other PRs and discussion
  items, following the same pattern outlined here for issues.

Below is an example; please update as appropriate. If no issue, etc. is
implicated in this PR, please remove this section.
----------------------------------------------------------------------->
Resolves #1135
References #1077

## Description

Clarify configuration sources on macOS

## Checklist

<!----------------------------------------------------------------------
See MAINTAINERS.md for more details.
This is particularly important if this PR is preparing a release.
----------------------------------------------------------------------->

Checklist before merging, wherever relevant:

- [ ] ~`CHANGELOG.md` updated~
- [x] Documentation (The Topiary Book, `README.md`, etc.) up-to-date
<!----------------------------------------------------------------------
If the PR solves a formatting issue for a supported language,
or generally improves formatting, please make sure to include a
regression test showcasing the fix/improvement to:
`topiary-cli/tests/samples/{input,expected}/mylanguage.lang`
----------------------------------------------------------------------->
- [ ] ~Updated regression tests~
